### PR TITLE
Add Modal as recommended cloud GPU provider

### DIFF
--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -1,0 +1,518 @@
+---
+description: First-time toolkit setup - cloud GPU, file transfer, voice, and prerequisites
+---
+
+# Setup
+
+Interactive setup wizard for new users. Checks prerequisites, guides cloud GPU and storage configuration, deploys AI tools, and verifies everything works. Idempotent — safe to run again to add features or verify configuration.
+
+## Key Principles
+
+- **Progressive disclosure** — one phase at a time, explain before asking
+- **Cost transparency** — always state what's free and what costs money before any action
+- **Idempotent** — check what's already configured, skip completed steps
+- **Test after each step** — don't just save keys, verify they work
+- **Skippable** — every phase can be skipped, user can return later
+- **Claude Code native** — use bash tools to check, configure, and verify. This IS the setup wizard.
+
+## Entry Point
+
+On invocation, assess current state and adapt:
+
+### Step 1: Detect Current State
+
+```
+1. Check .env exists — if not, create from .env.example
+2. Read current .env values (which keys are set vs placeholder)
+3. Check prerequisites: node --version, python3 --version, ffmpeg -version
+4. Check pip packages: python3 -c "import dotenv; import requests"
+5. Check Modal CLI: modal --version (if installed)
+6. Check for existing Modal apps: modal app list (if authenticated)
+7. Summarize what's ready vs what needs setup
+```
+
+### Step 2: Present Current State
+
+Show a clear status overview before asking anything:
+
+```
+Toolkit Setup
+
+Prerequisites:
+  [check] Node.js 20.x
+  [check] Python 3.12
+  [check] FFmpeg 7.1
+  [check] pip packages installed
+
+Cloud GPU:      Not configured
+File transfer:  Not configured (using free fallback services)
+Voice:          Not configured
+ElevenLabs:     Not configured (optional, paid)
+
+Let's get you set up! We'll go through each feature one at a time.
+You can skip any step and come back later with /setup.
+```
+
+**If everything is already configured**, show status and offer to verify/test:
+
+```
+Toolkit Setup — All Configured
+
+Cloud GPU:      Modal (7 tools deployed)
+File transfer:  Cloudflare R2 (bucket: video-toolkit)
+Voice:          Qwen3-TTS (speaker: Ryan)
+ElevenLabs:     Configured
+
+Everything looks good! Want me to run a quick verification test?
+```
+
+---
+
+## Phase 1: Prerequisites
+
+Check and report. Don't install anything automatically — just tell the user what's needed and how to get it.
+
+### Required
+
+- **Node.js 18+**: `node --version`. If missing: "Install from https://nodejs.org/ — needed to render videos"
+- **Claude Code**: Already running if they're seeing this command
+
+### Recommended
+
+- **Python 3.9+**: `python3 --version`. If missing: "Install from https://python.org/ — needed for AI voiceover, image editing, and all cloud GPU tools"
+- **pip packages**: `python3 -c "import dotenv; import requests"`. If missing: guide through `pip install -r tools/requirements.txt` (or venv setup)
+- **FFmpeg**: `ffmpeg -version`. If missing: "Install with `brew install ffmpeg` (macOS) or see https://ffmpeg.org/ — needed for media conversion"
+
+### Output
+
+```
+Prerequisites: 4/4 ready
+
+Moving on to cloud GPU setup...
+```
+
+If anything critical is missing, explain what features require it and ask if user wants to continue or fix first.
+
+---
+
+## Phase 2: Cloud GPU Provider
+
+This is the biggest unlock. Frame it properly.
+
+### Explanation (deliver conversationally, not as a wall of text)
+
+Explain what cloud GPU enables:
+- AI voiceovers (Qwen3-TTS) — free, self-hosted text-to-speech
+- AI image generation (FLUX.2) — title backgrounds, thumbnails
+- AI image editing (Qwen-Edit) — transform photos, add effects
+- AI upscaling (RealESRGAN) — enhance image quality
+- AI music generation (ACE-Step) — background music, jingles
+- Talking heads (SadTalker) — animated presenters from a photo
+- Watermark removal (ProPainter) — clean up stock footage
+
+Then present the choice:
+
+### Option A: Modal (Recommended)
+
+Frame the pitch:
+- **$30/month free compute** on the Starter plan — just requires adding a payment method
+- All 7 toolkit tools typically cost $0.50-2.00/month with normal use
+- Faster cold starts than RunPod
+- Scale to zero — no charges when idle
+- Simple deployment: `modal deploy docker/modal-xxx/app.py`
+
+Setup flow:
+```
+1. pip install modal
+2. python3 -m modal setup
+   → Opens browser for authentication
+   → Creates ~/.modal.toml with credentials
+3. Verify: modal app list
+```
+
+### Option B: RunPod
+
+Frame honestly:
+- Pay-as-you-go, typically $0.44/hr for GPU time
+- Each job usually costs $0.01-0.50 depending on the tool
+- More GPU variety available
+- `--setup` flag automates endpoint creation
+- **Availability can be spotty** — GPUs may not be available in some regions
+
+Setup flow:
+```
+1. Create account at https://runpod.io/
+2. Get API key from https://runpod.io/console/user/settings
+3. Add to .env: RUNPOD_API_KEY=your_key_here
+4. Each tool has --setup to create its endpoint automatically
+```
+
+### Option C: Both
+
+Explain dual-provider benefits:
+- Switch between providers with `--cloud modal` or `--cloud runpod`
+- If one provider is down, use the other
+- Modal for daily use (free tier), RunPod as fallback
+
+### Option D: Skip
+
+"No problem — you can still create and render videos with just Node.js. Run /setup anytime to add cloud features later."
+
+---
+
+## Phase 3: Cloudflare R2 (File Transfer)
+
+**Only show this phase if user chose a cloud GPU provider.**
+
+### Explanation
+
+"When you run a cloud GPU tool (like generating a voiceover or editing an image), the tool needs to send your file to the remote GPU and get the result back. Cloudflare R2 is the bridge.
+
+**R2 is free** — 10GB storage, 10 million operations/month, and zero egress fees. That's more than enough for this toolkit. Without R2, tools fall back to free file hosting services (litterbox, 0x0.st) which are slower and less reliable."
+
+### Setup Flow
+
+Guide the user step by step. They'll need to do some of this in their browser:
+
+```
+1. Go to https://dash.cloudflare.com/
+   → Create a free account if you don't have one
+
+2. In the sidebar, click "R2 Object Storage"
+   → Click "Create bucket"
+   → Name it: video-toolkit (or whatever you prefer)
+   → Choose automatic region
+   → Click "Create bucket"
+
+3. Go to R2 > Overview > "Manage R2 API Tokens"
+   → Click "Create API Token"
+   → Name: "video-toolkit"
+   → Permissions: "Object Read & Write"
+   → Scope: Apply to specific bucket → select your bucket
+   → Click "Create API Token"
+   → COPY the Access Key ID and Secret Access Key (shown only once!)
+
+4. Your Account ID is in the URL: dash.cloudflare.com/{account_id}/r2
+   Or find it in the R2 overview sidebar
+```
+
+After user provides the values, write them to .env:
+```
+R2_ACCOUNT_ID=xxx
+R2_ACCESS_KEY_ID=xxx
+R2_SECRET_ACCESS_KEY=xxx
+R2_BUCKET_NAME=video-toolkit
+```
+
+### Verify
+
+Test R2 connectivity:
+```bash
+python3 -c "
+import sys; sys.path.insert(0, 'tools')
+from file_transfer import upload_to_r2, delete_from_r2
+import tempfile, os
+# Create tiny test file
+tmp = tempfile.NamedTemporaryFile(suffix='.txt', delete=False)
+tmp.write(b'R2 connectivity test')
+tmp.close()
+url, key = upload_to_r2(tmp.name, 'setup-test')
+os.unlink(tmp.name)
+if url:
+    print(f'R2 working! Test upload succeeded.')
+    delete_from_r2(key)  # Clean up
+else:
+    print('R2 upload failed — check credentials')
+"
+```
+
+---
+
+## Phase 4: Deploy Cloud GPU Tools
+
+**Only show this phase if user chose a cloud GPU provider in Phase 2.**
+
+### Tool Selection
+
+Present all 7 tools with descriptions and let user choose:
+
+```
+Which AI tools would you like to set up?
+
+  1. [recommended] Speech (Qwen3-TTS)
+     Free AI voiceovers — 9 speakers, voice cloning, tone presets
+     This is the most-used tool in the toolkit.
+
+  2. [recommended] Images (FLUX.2 Klein)
+     Generate title backgrounds, scene illustrations, thumbnails
+     Fast: ~3s per image on warm GPU
+
+  3. Image Editing (Qwen-Image-Edit)
+     Transform photos — add/remove objects, change style, backgrounds
+     Note: Large model, ~8 min cold start on first use
+
+  4. Upscaling (RealESRGAN)
+     Enhance image quality 2x or 4x with AI
+     Fast: ~5s per image
+
+  5. Music (ACE-Step 1.5)
+     Generate background music, jingles, vocals
+     8 scene presets: corporate, ambient, dramatic, tension, cta...
+
+  6. Talking Heads (SadTalker)
+     Animate a portrait photo with lip-sync from audio
+     Great for narrator Picture-in-Picture
+
+  7. Watermark Removal (ProPainter)
+     Remove watermarks from video using AI inpainting
+
+  a. All of the above (recommended)
+  s. Skip for now
+```
+
+Recommend "all" — with Modal's free tier, there's no cost to having them deployed (they scale to zero).
+
+### Modal Deployment Flow
+
+For each selected tool, run `modal deploy` and capture the endpoint URL:
+
+```bash
+# Deploy each app and capture the URL from output
+modal deploy docker/modal-qwen3-tts/app.py
+modal deploy docker/modal-flux2/app.py
+modal deploy docker/modal-image-edit/app.py
+modal deploy docker/modal-upscale/app.py
+modal deploy docker/modal-music-gen/app.py
+modal deploy docker/modal-sadtalker/app.py
+modal deploy docker/modal-propainter/app.py
+```
+
+After each deploy, Modal prints the endpoint URL. Parse it and save to .env:
+```
+MODAL_QWEN3_TTS_ENDPOINT_URL=https://username--video-toolkit-qwen3-tts-...modal.run
+MODAL_FLUX2_ENDPOINT_URL=https://username--video-toolkit-flux2-...modal.run
+```
+
+**Important**: The deploy output contains the URL. Look for lines containing `.modal.run` in the output. The URL format is typically:
+`https://{username}--{app-name}-{class}-{method}.modal.run`
+
+### RunPod Deployment Flow
+
+For each selected tool, run the `--setup` command:
+
+```bash
+python3 tools/qwen3_tts.py --setup
+python3 tools/flux2.py --setup
+python3 tools/image_edit.py --setup
+python3 tools/upscale.py --setup
+python3 tools/music_gen.py --setup
+python3 tools/sadtalker.py --setup
+python3 tools/dewatermark.py --setup
+```
+
+Each `--setup` command creates a RunPod template + endpoint and saves the endpoint ID to .env automatically.
+
+### Smoke Test
+
+After deployment, run a quick test for at least one tool to verify the pipeline works:
+
+**If Qwen3-TTS was deployed (most common):**
+```bash
+python3 tools/qwen3_tts.py --text "Setup complete! Your video toolkit is ready." \
+  --speaker Ryan --tone warm --output /tmp/setup-test.mp3 \
+  --cloud modal
+```
+
+Check that it produces an audio file. If it does, the full pipeline (upload → cloud GPU → download) is working.
+
+**If FLUX.2 was deployed:**
+```bash
+python3 tools/flux2.py --prompt "A minimal geometric logo on dark background" \
+  --output /tmp/setup-test.png --cloud modal
+```
+
+---
+
+## Phase 5: Voice Setup
+
+### Explanation
+
+"For voiceovers in your videos, you have two options:
+
+**Qwen3-TTS (recommended, free)**
+Self-hosted on your cloud GPU. 9 built-in speakers, tone presets (warm, professional, excited...), and voice cloning. This is what most toolkit users use.
+
+**ElevenLabs (optional, paid)**
+Premium cloud TTS with a large voice library. Pay-per-character. Better for some specific voice styles, but Qwen3-TTS is comparable quality for most use cases."
+
+### Qwen3-TTS Setup
+
+If Qwen3-TTS was deployed in Phase 4, it's already ready. Just confirm the default speaker:
+
+```
+Qwen3-TTS is ready! Available speakers:
+  Ryan, Aiden, Vivian, Luna, Aurora, Aria, Nova, Stella, Orion
+
+Default speaker: Ryan (warm male voice)
+
+You can change the speaker per-video or set a default in your brand's voice.json.
+To preview voices: python3 tools/qwen3_tts.py --list-voices
+```
+
+### ElevenLabs Setup (Optional)
+
+```
+1. Sign up at https://elevenlabs.io/
+2. Go to Profile → API Keys
+3. Copy your API key
+```
+
+After user provides the key, write to .env:
+```
+ELEVENLABS_API_KEY=xxx
+```
+
+Optionally set a default voice ID:
+```
+ELEVENLABS_VOICE_ID=xxx
+```
+
+Mention: "You can also use /voice-clone later to clone your own voice for a personal touch."
+
+---
+
+## Phase 6: Verify & Summary
+
+### Run Final Checks
+
+```python
+# Check .env has the expected values
+1. Read .env
+2. For each configured service, verify connectivity:
+   - R2: test upload/download
+   - Modal: modal app list (check apps are deployed)
+   - RunPod: check API key works
+   - ElevenLabs: test API key
+3. Report results
+```
+
+### Present Summary
+
+```
+Setup Complete!
+
+Prerequisites:
+  [check] Node.js 20.x
+  [check] Python 3.12
+  [check] FFmpeg 7.1
+  [check] pip packages
+
+Cloud GPU: Modal
+  [check] Speech (Qwen3-TTS) — deployed
+  [check] Images (FLUX.2) — deployed
+  [check] Image Editing (Qwen-Edit) — deployed
+  [check] Upscaling (RealESRGAN) — deployed
+  [check] Music (ACE-Step) — deployed
+  [check] Talking Heads (SadTalker) — deployed
+  [check] Watermark Removal (ProPainter) — deployed
+
+File Transfer: Cloudflare R2
+  [check] Bucket: video-toolkit
+  [check] Upload/download verified
+
+Voice: Qwen3-TTS (Ryan)
+  [check] Test generation successful
+
+ElevenLabs: Not configured (optional)
+
+Cost summary:
+  - Modal: $30/mo free compute (you'll use ~$1-2/mo typical)
+  - R2: Free (10GB storage, zero egress)
+  - Qwen3-TTS: Free (runs on Modal compute)
+  - ElevenLabs: Not configured
+
+You're ready! Run /video to create your first video.
+```
+
+---
+
+## Re-run Behavior
+
+When `/setup` is run again on an already-configured toolkit:
+
+1. Show current state (Phase 6 summary style)
+2. Offer options:
+   - "Verify everything works" → run smoke tests
+   - "Add a new tool" → jump to Phase 4 tool selection
+   - "Change cloud provider" → jump to Phase 2
+   - "Set up ElevenLabs" → jump to Phase 5
+   - "Everything looks good" → exit
+
+---
+
+## Writing to .env
+
+When adding or updating values in `.env`:
+
+1. Read the current .env file
+2. For each new value:
+   - If the key exists (even commented out), uncomment and update it
+   - If the key doesn't exist, append it in the appropriate section
+3. Never remove existing values
+4. Preserve comments and formatting
+5. Show the user what was written
+
+Example approach:
+```python
+# Read .env, update/add the key, write back
+lines = Path('.env').read_text().splitlines()
+# ... find and update or append
+```
+
+---
+
+## Error Handling
+
+- If `modal deploy` fails: show the error, suggest checking `modal app logs`, offer to retry
+- If R2 test fails: re-check credentials, common issue is wrong bucket name or region
+- If RunPod setup fails: check API key, check account has billing enabled
+- If any step fails, don't block subsequent steps — mark as failed and continue
+- Always show what succeeded even if something failed
+
+---
+
+## Verification Script
+
+Use `tools/verify_setup.py` throughout and at the end of setup:
+
+```bash
+# Quick check (no cloud calls) — use at start to detect current state
+python3 tools/verify_setup.py
+
+# With smoke tests (makes cloud GPU calls, ~$0.01) — use at end to verify
+python3 tools/verify_setup.py --test
+
+# Machine-readable — use to programmatically check what's configured
+python3 tools/verify_setup.py --json
+```
+
+Run `verify_setup.py --json` at the start of `/setup` to detect current state and skip already-configured phases. Run it with `--test` at the end for the Phase 6 verification.
+
+## Integration with Other Commands
+
+- `/video` should check for cloud GPU configuration and mention `/setup` if not configured
+- `/generate-voiceover` should suggest `/setup` if no TTS provider is configured
+- `/versions` could include a setup status check
+
+---
+
+## Evolution
+
+### Local improvements (no upstream contribution needed)
+- Add `--quick` flag to skip explanations and just deploy everything with defaults
+- Add `--verify` flag to only run smoke tests on existing configuration
+- Add `--reset` flag to clear all configuration and start fresh
+
+### Upstream contribution candidates
+- The command pattern itself could be useful for other Claude Code toolkits
+- R2 setup flow is generic enough to extract as a reusable guide

--- a/.claude/commands/video.md
+++ b/.claude/commands/video.md
@@ -10,6 +10,18 @@ Unified command for video projects. Scans for existing projects and offers to re
 
 On invocation, scan for projects and adapt:
 
+### Step 0: Check Setup (first-time only)
+
+If `.env` does not exist or no cloud GPU provider is configured (no `MODAL_*_ENDPOINT_URL` or `RUNPOD_*_ENDPOINT_ID` values set):
+
+```
+Tip: Run /setup to configure AI voiceovers, image generation, and music.
+It takes ~5 minutes and most features are free. You can skip this and
+create videos with just Node.js — run /setup anytime later.
+```
+
+This is a one-line hint, not a blocker. Proceed to Step 1 immediately.
+
 ### Step 1: Scan Projects
 
 ```

--- a/.env.example
+++ b/.env.example
@@ -3,28 +3,52 @@
 # ============================================================
 # All keys are OPTIONAL. The toolkit works without any of them.
 # You only need keys for the specific features you want to use.
+#
+# Quick setup: Run /setup in Claude Code for a guided walkthrough.
 # ============================================================
 
-# --- AI Voiceover (choose one or both) ---
-# ElevenLabs: Premium cloud TTS (pay-per-use)
-# Get yours at https://elevenlabs.io/
-# ELEVENLABS_API_KEY=your_api_key_here
-# ELEVENLABS_VOICE_ID=your_voice_id_here
 
-# --- Cloud GPU Processing (RunPod) ---
-# Required for: Qwen3-TTS, image editing, upscaling, watermark removal, talking heads
-# Get yours at https://runpod.io/console/user/settings
-# RUNPOD_API_KEY=your_api_key_here
-
-# RunPod serverless endpoint IDs (auto-created by each tool's --setup command)
-# RUNPOD_ENDPOINT_ID=your_endpoint_id_here
-# RUNPOD_QWEN3_TTS_ENDPOINT_ID=your_endpoint_id_here
-
-# --- Cloudflare R2 (reliable file transfer for RunPod jobs) ---
+# --- Cloudflare R2 (file transfer for cloud GPU tools) ---
 # Free tier: 10GB storage, 10M ops/month, zero egress fees
 # Setup: https://dash.cloudflare.com → R2 Object Storage → Create bucket
-# If not configured, falls back to free file hosting services (less reliable)
+# This makes cloud GPU tools faster and more reliable.
+# Without it, tools fall back to free file hosting services.
 # R2_ACCOUNT_ID=your_account_id_here
 # R2_ACCESS_KEY_ID=your_access_key_id_here
 # R2_SECRET_ACCESS_KEY=your_secret_access_key_here
 # R2_BUCKET_NAME=video-toolkit
+
+
+# --- Cloud GPU: Modal (recommended) ---
+# $30/month free compute on Starter plan (just add a payment method)
+# Setup: pip install modal && python3 -m modal setup
+# Deploy: modal deploy docker/modal-{tool}/app.py
+# Endpoint URLs are printed after each deploy — paste them here.
+# MODAL_QWEN3_TTS_ENDPOINT_URL=https://yourname--video-toolkit-qwen3-tts-....modal.run
+# MODAL_FLUX2_ENDPOINT_URL=https://yourname--video-toolkit-flux2-....modal.run
+# MODAL_IMAGE_EDIT_ENDPOINT_URL=https://yourname--video-toolkit-image-edit-....modal.run
+# MODAL_UPSCALE_ENDPOINT_URL=https://yourname--video-toolkit-upscale-....modal.run
+# MODAL_MUSIC_GEN_ENDPOINT_URL=https://yourname--video-toolkit-music-gen-....modal.run
+# MODAL_SADTALKER_ENDPOINT_URL=https://yourname--video-toolkit-sadtalker-....modal.run
+# MODAL_DEWATERMARK_ENDPOINT_URL=https://yourname--video-toolkit-dewatermark-....modal.run
+
+
+# --- Cloud GPU: RunPod (alternative) ---
+# Pay-as-you-go, ~$0.44/hr GPU time
+# Setup: https://runpod.io/console/user/settings → API Keys
+# Endpoint IDs are auto-created by each tool's --setup command.
+# RUNPOD_API_KEY=your_api_key_here
+# RUNPOD_QWEN3_TTS_ENDPOINT_ID=
+# RUNPOD_FLUX2_ENDPOINT_ID=
+# RUNPOD_QWEN_EDIT_ENDPOINT_ID=
+# RUNPOD_UPSCALE_ENDPOINT_ID=
+# RUNPOD_SADTALKER_ENDPOINT_ID=
+# RUNPOD_ACESTEP_ENDPOINT_ID=
+# RUNPOD_ENDPOINT_ID=
+
+
+# --- AI Voiceover ---
+# Qwen3-TTS: Free (runs on your cloud GPU above). No key needed.
+# ElevenLabs: Premium cloud TTS (pay-per-character, optional)
+# ELEVENLABS_API_KEY=your_api_key_here
+# ELEVENLABS_VOICE_ID=your_voice_id_here

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,12 @@ Audio, video, and image tools in `tools/`. See registry `tools` section for the 
 pip install -r tools/requirements.txt
 ```
 
+**Important: always invoke tools from the toolkit root directory.** When working inside a project (`projects/my-video/`), tool paths like `python3 tools/upscale.py` will fail because `tools/` is relative. Always use:
+```bash
+cd /path/to/claude-code-video-toolkit && python3 tools/upscale.py ...
+```
+This is especially critical for background commands where the working directory may not be obvious.
+
 ### Tool Categories
 
 | Type | Tools | When to Use |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ pip install -r tools/requirements.txt
 |------|-------|-------------|
 | **Project tools** | voiceover, music, music_gen, sfx, sync_timing | During video creation workflow |
 | **Utility tools** | redub, addmusic, notebooklm_brand, locate_watermark | Quick transformations on existing videos |
-| **Cloud GPU** | image_edit, upscale, dewatermark, sadtalker, qwen3_tts, music_gen | AI processing via RunPod |
+| **Cloud GPU** | image_edit, upscale, dewatermark, sadtalker, qwen3_tts, music_gen, flux2 | AI processing via RunPod or Modal (`--cloud runpod\|modal`) |
 
 Utility tools work on any video file without requiring a project structure.
 
@@ -152,7 +152,7 @@ Temperature controls expressiveness: `--temperature 1.2` (more expressive) or `-
 
 ### AI Image Editing (Cloud GPU)
 
-All Cloud GPU tools require a RunPod account. Use `--setup` to create endpoints automatically. See registry `cloudProviders.runpod.endpoints` for Docker images and env vars.
+All Cloud GPU tools support `--cloud runpod` (default) or `--cloud modal`. RunPod requires a RunPod account — use `--setup` to create endpoints automatically. See registry `cloudProviders` for Docker images and env vars.
 
 ```bash
 # RunPod setup (one-time per tool)
@@ -164,13 +164,14 @@ python tools/music_gen.py --setup
 
 # Image editing (Qwen-Image-Edit)
 python tools/image_edit.py --input photo.jpg --prompt "Add sunglasses"
+python tools/image_edit.py --input photo.jpg --prompt "Add sunglasses" --cloud modal
 python tools/image_edit.py --input photo.jpg --style cyberpunk
 python tools/image_edit.py --input photo.jpg --background office
 python tools/image_edit.py --list-presets  # Full preset list
 
 # Upscaling (RealESRGAN)
-python tools/upscale.py --input photo.jpg --output photo_4x.png --runpod
-python tools/upscale.py --input photo.jpg --scale 2 --model anime --face-enhance --runpod
+python tools/upscale.py --input photo.jpg --output photo_4x.png --cloud runpod
+python tools/upscale.py --input photo.jpg --scale 2 --model anime --face-enhance --cloud runpod
 ```
 
 See `docs/qwen-edit-patterns.md` and `.claude/skills/qwen-edit/` for prompting guidance.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -434,6 +434,9 @@ const opacity = interpolate(frame, [0, 20], [0, 1], { extrapolateRight: 'clamp' 
 ```
 
 ### Media
+
+**Always use `<OffthreadVideo>`, never `<video>`** — Remotion requires its own video component for frame-accurate rendering. Using a raw `<video>` tag will not render correctly.
+
 ```tsx
 <OffthreadVideo src={staticFile('demo.mp4')} />
 <Audio src={staticFile('voiceover.mp3')} volume={1} />

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,17 +150,28 @@ python tools/qwen3_tts.py --list-tones    # neutral, warm, professional, excited
 
 Temperature controls expressiveness: `--temperature 1.2` (more expressive) or `--temperature 0.4` (more consistent).
 
-### AI Image Editing (Cloud GPU)
+### Cloud GPU Providers
 
-All Cloud GPU tools support `--cloud runpod` (default) or `--cloud modal`. RunPod requires a RunPod account — use `--setup` to create endpoints automatically. See registry `cloudProviders` for Docker images and env vars.
+All cloud GPU tools support two providers via `--cloud runpod|modal`. RunPod is the default. Modal was added as a reliability fallback after RunPod outages, and offers faster cold starts.
 
 ```bash
-# RunPod setup (one-time per tool)
+# --- RunPod setup (automated, one-time per tool) ---
 echo "RUNPOD_API_KEY=your_key_here" >> .env
 python tools/image_edit.py --setup
 python tools/upscale.py --setup
 python tools/qwen3_tts.py --setup
 python tools/music_gen.py --setup
+
+# --- Modal setup (deploy each app you need) ---
+pip install modal && python3 -m modal setup
+modal deploy docker/modal-upscale/app.py        # Then save URL to .env
+modal deploy docker/modal-image-edit/app.py
+# See docs/modal-setup.md for full guide
+```
+
+### AI Image Editing
+
+```bash
 
 # Image editing (Qwen-Image-Edit)
 python tools/image_edit.py --input photo.jpg --prompt "Add sunglasses"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,13 @@ claude-code-video-toolkit/
 
 ## Quick Start
 
+**First-time setup (optional, ~5 minutes):**
+```
+/setup
+```
+
+Walks through cloud GPU, file transfer (R2), and voice configuration. Most features are free. Skip this if you just want to render videos with Node.js.
+
 **Work on a video project:**
 ```
 /video

--- a/README.md
+++ b/README.md
@@ -22,10 +22,7 @@ Then in Claude Code:
 
 **That's it.** `/setup` walks you through everything interactively — cloud GPU provider, file transfer, voice config. `/video` creates a project from a template and guides you through the whole workflow.
 
-**What's free:**
-- Cloudflare R2 — free file transfer (10GB storage, zero egress)
-- Modal — $30/month free compute on Starter plan (just add a card)
-- Qwen3-TTS — free AI voiceovers (runs on your Modal compute)
+**What's free:** The toolkit leans heavily on open-source AI models — voiceovers (Qwen3-TTS), image generation (FLUX.2), music (ACE-Step), and more. You deploy them to your own cloud GPU account and run them at cost. Cloudflare R2 has a generous free tier (10GB, zero egress), and Modal gives $30/month free compute on the Starter plan — more than enough for normal use.
 
 **Requirements:** [Node.js](https://nodejs.org/) 18+ and [Claude Code](https://docs.anthropic.com/en/docs/claude-code). Python 3.9+ recommended for AI tools. FFmpeg optional.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Then in Claude Code:
 
 **That's it.** `/setup` walks you through everything interactively — cloud GPU provider, file transfer, voice config. `/video` creates a project from a template and guides you through the whole workflow.
 
-**What's free:** The toolkit leans heavily on open-source AI models — voiceovers (Qwen3-TTS), image generation (FLUX.2), music (ACE-Step), and more. You deploy them to your own cloud GPU account and run them at cost. Cloudflare R2 has a generous free tier (10GB, zero egress), and Modal gives $30/month free compute on the Starter plan — more than enough for normal use.
+**What's free:** The toolkit leans heavily on open-source AI models — voiceovers (Qwen3-TTS), image generation (FLUX.2), music (ACE-Step), and more. You deploy them to your own cloud GPU account and run them at cost. Cloudflare R2 has a generous free tier (10GB, zero egress), and Modal gives $30/month free compute on the Starter plan — more than enough for a few 5-minute videos a month.
 
 **Requirements:** [Node.js](https://nodejs.org/) 18+ and [Claude Code](https://docs.anthropic.com/en/docs/claude-code). Python 3.9+ recommended for AI tools. FFmpeg optional.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Then in Claude Code:
 >
 > **If you're getting started**, run `/setup` then `/video` and let Claude Code guide you. Or start with `/template` to create a template for your own use case.
 >
-> **Cloud GPU** — I recommend [Modal](https://modal.com/) for running the toolkit's AI tools. The Starter plan gives you $30/month free compute, which is more than enough. [RunPod](https://runpod.io/) is also supported as an alternative. All 7 Docker images are public — `/setup` will deploy them for you.
+> **Cloud GPU** — I recommend [Modal](https://modal.com/) for running the toolkit's AI tools. The Starter plan gives you $30/month free compute, which is more than enough. [RunPod](https://runpod.io/) is also supported as an alternative. Run `/setup` to deploy the tools you need.
 >
 > My motto: **Be brave. Experiment.** And please share any videos you create or ideas you have back with the project — it helps me keep improving this toolkit for everyone.
 
@@ -226,21 +226,21 @@ python tools/flux2.py --list-presets
 
 ### Cloud GPU (Modal + RunPod)
 
-Cloud GPU tools support two providers. Use `--cloud modal` or `--cloud runpod` on any tool.
+7 AI tools run on cloud GPUs. Use `--cloud modal` (recommended) or `--cloud runpod` on any tool.
 
-| Tool | Docker Image | What It Does |
-|------|--------------|--------------|
-| qwen3_tts | `ghcr.io/conalmullan/video-toolkit-qwen3-tts` | AI text-to-speech |
-| flux2 | `ghcr.io/conalmullan/video-toolkit-flux2` | AI image generation & editing |
-| image_edit | `ghcr.io/conalmullan/video-toolkit-qwen-edit` | AI image editing & style transfer |
-| upscale | `ghcr.io/conalmullan/video-toolkit-realesrgan` | AI image upscaling (2x/4x) |
-| music_gen | `ghcr.io/conalmullan/video-toolkit-acestep` | AI music generation |
-| sadtalker | `ghcr.io/conalmullan/video-toolkit-sadtalker` | Talking head video |
-| dewatermark | `ghcr.io/conalmullan/video-toolkit-propainter` | Video watermark removal |
+| Tool | What It Does | Est. Cost |
+|------|--------------|-----------|
+| `qwen3_tts` | AI text-to-speech (9 speakers, voice cloning) | ~$0.01 |
+| `flux2` | AI image generation & editing | ~$0.02 |
+| `image_edit` | AI image editing & style transfer | ~$0.03 |
+| `upscale` | AI image upscaling (2x/4x) | ~$0.01 |
+| `music_gen` | AI music generation (8 scene presets) | ~$0.05 |
+| `sadtalker` | Talking head video from portrait + audio | ~$0.10 |
+| `dewatermark` | Video watermark removal | ~$0.10 |
 
-All images are public. `/setup` deploys them to your cloud account automatically.
+**Modal (recommended):** Each tool deploys from `docker/modal-*/app.py` — Modal builds and hosts the containers. $30/month free compute on the Starter plan, typical usage is $1-2/month. Run `/setup` to deploy all tools automatically.
 
-**Cost:** Modal Starter plan includes $30/month free compute. Typical toolkit usage is $1-2/month. RunPod is pay-per-second with no minimums (~$0.01-0.15 per job).
+**RunPod (alternative):** Uses pre-built Docker images from `ghcr.io/conalmullan/video-toolkit-*`. Pay-per-second, no minimums. Run `python3 tools/<tool>.py --setup` to create endpoints.
 
 See [docs/modal-setup.md](docs/modal-setup.md) and [docs/runpod-setup.md](docs/runpod-setup.md) for details.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,40 @@
 
 [![GitHub release](https://img.shields.io/github/v/release/digitalsamba/claude-code-video-toolkit)](https://github.com/digitalsamba/claude-code-video-toolkit/releases)
 
-An AI-native video production workspace for [Claude Code](https://claude.ai/code). Create professional videos with AI assistance — from concept to final render.
+An AI-native video production workspace for [Claude Code](https://claude.ai/code). Skills, commands, templates, and tools that give Claude Code everything it needs to help you create professional videos — from concept to final render.
+
+## Quick Start
+
+```bash
+git clone https://github.com/digitalsamba/claude-code-video-toolkit.git
+cd claude-code-video-toolkit
+pip install -r tools/requirements.txt   # Optional: for AI voiceover, image gen, music
+claude                                   # Open Claude Code in the toolkit
+```
+
+Then in Claude Code:
+
+```
+/setup                    # Configure cloud GPU, storage, voice (~5 min, mostly free)
+/video                    # Create your first video
+```
+
+**That's it.** `/setup` walks you through everything interactively — cloud GPU provider, file transfer, voice config. `/video` creates a project from a template and guides you through the whole workflow.
+
+**What's free:**
+- Cloudflare R2 — free file transfer (10GB storage, zero egress)
+- Modal — $30/month free compute on Starter plan (just add a card)
+- Qwen3-TTS — free AI voiceovers (runs on your Modal compute)
+
+**Requirements:** [Node.js](https://nodejs.org/) 18+ and [Claude Code](https://docs.anthropic.com/en/docs/claude-code). Python 3.9+ recommended for AI tools. FFmpeg optional.
+
+> **Want to skip setup and just render something?**
+> ```bash
+> cd examples/hello-world && npm install && npm run render
+> ```
+> No API keys needed — outputs an MP4 immediately.
+
+---
 
 ## A Note from the Author *(not AI-generated)*
 
@@ -12,99 +45,11 @@ An AI-native video production workspace for [Claude Code](https://claude.ai/code
 >
 > What makes this work is that Claude Code is fantastically resourceful and flexible — give it the framing and tooling that this toolkit provides and it will adapt it to create templates and videos based on your prompting. The skills, templates, and tools here are building blocks. Claude Code is the builder. You are the director, editor, and designer.
 >
-> **If you're getting started**, I'd suggest beginning with the `/template` command and working through creating a template for your own use case.
+> **If you're getting started**, run `/setup` then `/video` and let Claude Code guide you. Or start with `/template` to create a template for your own use case.
 >
-> **I highly recommend a [RunPod](https://runpod.io/) account** for running open-source models with GPU resources. It's cheap — typically pennies per job, and rarely more than $10/month even with heavy use. I will likely make Qwen3-TTS the default for voiceovers as it arguably produces better results with significantly less effort and cost than ElevenLabs.
->
-> **Free Docker images** — I've made all the RunPod images I use in this project available publicly:
-> - `ghcr.io/conalmullan/video-toolkit-qwen-edit` — AI image editing (Qwen-Image-Edit)
-> - `ghcr.io/conalmullan/video-toolkit-realesrgan` — AI image upscaling (Real-ESRGAN)
-> - `ghcr.io/conalmullan/video-toolkit-propainter` — Video watermark removal (ProPainter)
-> - `ghcr.io/conalmullan/video-toolkit-sadtalker` — Talking head generation (SadTalker)
-> - `ghcr.io/conalmullan/video-toolkit-qwen3-tts` — Text-to-speech (Qwen3-TTS)
-> - `ghcr.io/conalmullan/video-toolkit-flux2` — Text-to-image & editing (FLUX.2 Klein 4B)
-> - `ghcr.io/conalmullan/video-toolkit-acestep` — AI music generation (ACE-Step 1.5)
+> **Cloud GPU** — I recommend [Modal](https://modal.com/) for running the toolkit's AI tools. The Starter plan gives you $30/month free compute, which is more than enough. [RunPod](https://runpod.io/) is also supported as an alternative. All 7 Docker images are public — `/setup` will deploy them for you.
 >
 > My motto: **Be brave. Experiment.** And please share any videos you create or ideas you have back with the project — it helps me keep improving this toolkit for everyone.
-
-## What is this?
-
-This toolkit gives Claude Code the knowledge and tools to help you create videos:
-
-- **Skills** — Domain expertise in Remotion, ElevenLabs, FFmpeg, Playwright
-- **Commands** — Guided workflows like `/video`, `/record-demo`, `/contribute`
-- **Templates** — Ready-to-customize video structures
-- **Brands** — Visual identity profiles (colors, fonts, voice settings)
-- **Tools** — Python CLI for audio generation
-
-Clone this repo, open it in Claude Code, and start creating videos.
-
-## Quick Start
-
-### Prerequisites
-
-| Requirement | Status | Purpose |
-|-------------|--------|---------|
-| [Node.js](https://nodejs.org/) 18+ | **Required** | Renders videos with Remotion |
-| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | **Required** | AI assistant for video creation |
-| [Python](https://python.org/) 3.9+ | Optional | AI voiceover, audio tools |
-| [FFmpeg](https://ffmpeg.org/) | Optional | Media conversion |
-| [RunPod account](https://runpod.io/) | Optional | Cloud GPU (TTS, image editing, music gen) |
-| [ElevenLabs API key](https://elevenlabs.io/) | Optional | Premium AI voices |
-
-### Try It Now
-
-```bash
-git clone https://github.com/digitalsamba/claude-code-video-toolkit.git
-cd claude-code-video-toolkit/examples/hello-world
-npm install
-npm run render    # Outputs MP4 — no API keys needed
-```
-
-### Full Setup
-
-```bash
-# Clone the toolkit
-git clone https://github.com/digitalsamba/claude-code-video-toolkit.git
-cd claude-code-video-toolkit
-
-# Install Python dependencies (optional — only needed for AI tools)
-python -m venv .venv
-source .venv/bin/activate
-pip install -r tools/requirements.txt
-
-# Start Claude Code and run the setup wizard
-claude
-```
-
-### Set Up AI Tools (optional, ~5 minutes)
-
-In Claude Code, run:
-
-```
-/setup
-```
-
-This walks you through configuring cloud GPU, file transfer, and voice. Most features are free (Cloudflare R2 free tier, Modal $30/mo free compute, Qwen3-TTS free voiceovers).
-
-### Create Your First Video
-
-In Claude Code, run:
-
-```
-/video
-```
-
-This will:
-1. Scan for existing projects (resume or create new)
-2. Choose template (sprint-review, product-demo)
-3. Choose brand (or create one with `/brand`)
-4. Plan scenes interactively
-5. Create project with VOICEOVER-SCRIPT.md
-
-**Multi-session support:** Projects span multiple sessions. Run `/video` to resume where you left off.
-
-Then iterate with Claude Code to record demos, refine content, and render.
 
 ## Features
 
@@ -127,6 +72,7 @@ Claude Code has deep knowledge in:
 
 | Command | Description |
 |---------|-------------|
+| `/setup` | First-time setup — cloud GPU, file transfer, voice, prerequisites |
 | `/video` | Video projects — list, resume, or create new |
 | `/scene-review` | Scene-by-scene review in Remotion Studio |
 | `/design` | Focused design refinement session for a scene |
@@ -249,27 +195,24 @@ python tools/addmusic.py --input video.mp4 --prompt "Subtle ambient" --output ou
 python tools/notebooklm_brand.py --input video.mp4 --logo logo.png --url "mysite.com" --output branded.mp4
 
 # AI image editing (style transfer, backgrounds, custom prompts)
-python tools/image_edit.py --input photo.jpg --style cyberpunk
-python tools/image_edit.py --input photo.jpg --prompt "Add sunglasses"
+python tools/image_edit.py --input photo.jpg --style cyberpunk --cloud modal
+python tools/image_edit.py --input photo.jpg --prompt "Add sunglasses" --cloud modal
 
 # AI image upscaling (2x/4x)
-python tools/upscale.py --input photo.jpg --output photo_4x.png --runpod
+python tools/upscale.py --input photo.jpg --output photo_4x.png --cloud modal
 
-# Remove watermarks (requires RunPod or NVIDIA GPU)
-python tools/dewatermark.py --input video.mp4 --preset sora --output clean.mp4 --runpod
+# Remove watermarks (requires cloud GPU)
+python tools/dewatermark.py --input video.mp4 --preset sora --output clean.mp4 --cloud modal
 
 # Locate watermark coordinates
 python tools/locate_watermark.py --input video.mp4 --grid --output-dir ./review/
 
 # Generate talking head video from image + audio (SadTalker)
-# Creates animated presenter/narrator from a static portrait + voiceover audio
-# Use with NarratorPiP component for picture-in-picture presenter overlays
-python tools/sadtalker.py --image portrait.png --audio voiceover.mp3 --output talking.mp4
+python tools/sadtalker.py --image portrait.png --audio voiceover.mp3 --output talking.mp4 --cloud modal
 
 # AI image generation (FLUX.2 Klein 4B — text-to-image + editing)
-python tools/flux2.py --prompt "A sunset over mountains"
-python tools/flux2.py --preset title-bg --brand digital-samba
-python tools/flux2.py --input photo.jpg --prompt "Add sunglasses"
+python tools/flux2.py --prompt "A sunset over mountains" --cloud modal
+python tools/flux2.py --preset title-bg --brand digital-samba --cloud modal
 python tools/flux2.py --list-presets
 ```
 
@@ -279,27 +222,27 @@ python tools/flux2.py --list-presets
 |------|-------|---------|
 | **Project** | voiceover, music, music_gen, sfx | Used during video creation workflow |
 | **Utility** | redub, addmusic, notebooklm_brand, locate_watermark | Quick transformations, no project needed |
-| **Cloud GPU** | image_edit, upscale, dewatermark, sadtalker, qwen3_tts, flux2, music_gen | AI processing via RunPod (see below) |
+| **Cloud GPU** | image_edit, upscale, dewatermark, sadtalker, qwen3_tts, flux2, music_gen | AI processing via Modal or RunPod |
 
-See [docs/runpod-setup.md](docs/runpod-setup.md) for Cloud GPU tool setup.
+### Cloud GPU (Modal + RunPod)
 
-### Pre-built Docker Images
+Cloud GPU tools support two providers. Use `--cloud modal` or `--cloud runpod` on any tool.
 
-Cloud GPU tools use pre-built Docker images deployed to RunPod serverless:
+| Tool | Docker Image | What It Does |
+|------|--------------|--------------|
+| qwen3_tts | `ghcr.io/conalmullan/video-toolkit-qwen3-tts` | AI text-to-speech |
+| flux2 | `ghcr.io/conalmullan/video-toolkit-flux2` | AI image generation & editing |
+| image_edit | `ghcr.io/conalmullan/video-toolkit-qwen-edit` | AI image editing & style transfer |
+| upscale | `ghcr.io/conalmullan/video-toolkit-realesrgan` | AI image upscaling (2x/4x) |
+| music_gen | `ghcr.io/conalmullan/video-toolkit-acestep` | AI music generation |
+| sadtalker | `ghcr.io/conalmullan/video-toolkit-sadtalker` | Talking head video |
+| dewatermark | `ghcr.io/conalmullan/video-toolkit-propainter` | Video watermark removal |
 
-| Tool | Docker Image | GPU |
-|------|--------------|-----|
-| image_edit | `ghcr.io/conalmullan/video-toolkit-qwen-edit:latest` | 48GB+ (A6000, L40S) |
-| upscale | `ghcr.io/conalmullan/video-toolkit-realesrgan:latest` | 24GB (RTX 3090/4090) |
-| dewatermark | `ghcr.io/conalmullan/video-toolkit-propainter:latest` | 24GB (RTX 3090/4090) |
-| sadtalker | `ghcr.io/conalmullan/video-toolkit-sadtalker:latest` | 24GB (RTX 4090) |
-| qwen3_tts | `ghcr.io/conalmullan/video-toolkit-qwen3-tts:latest` | 24GB (ADA) |
-| flux2 | `ghcr.io/conalmullan/video-toolkit-flux2:latest` | 24GB (ADA) |
-| music_gen | `ghcr.io/conalmullan/video-toolkit-acestep:latest` | 24GB+ (AMPERE/ADA) |
+All images are public. `/setup` deploys them to your cloud account automatically.
 
-Dockerfiles and handlers are in `docker/`. Run `python tools/<tool>.py --setup` to auto-deploy.
+**Cost:** Modal Starter plan includes $30/month free compute. Typical toolkit usage is $1-2/month. RunPod is pay-per-second with no minimums (~$0.01-0.15 per job).
 
-**Cost:** RunPod is pay-per-second with no minimums. Typical usage is ~$0.01-0.15 per job. Even with heavy experimenting, expect to spend less than $10/month.
+See [docs/modal-setup.md](docs/modal-setup.md) and [docs/runpod-setup.md](docs/runpod-setup.md) for details.
 
 ## Project Structure
 
@@ -327,12 +270,13 @@ claude-code-video-toolkit/
 ## Documentation
 
 - [Getting Started](docs/getting-started.md)
+- [Modal Setup](docs/modal-setup.md) — Cloud GPU with Modal (recommended)
+- [RunPod Setup](docs/runpod-setup.md) — Cloud GPU with RunPod (alternative)
 - [Creating Templates](docs/creating-templates.md)
 - [Creating Brands](docs/creating-brands.md)
 - [Project System](lib/project/README.md) — Multi-session lifecycle, schema, reconciliation
-- [Optional Components](docs/optional-components.md) — GPU tools setup (dewatermark)
-- [RunPod Setup](docs/runpod-setup.md) — Cloud GPU configuration
-- [Toolkit Development](_internal/ROADMAP.md) — Roadmap, backlog, changelog for the toolkit itself
+- [Optional Components](docs/optional-components.md) — Local GPU tools setup
+- [Toolkit Development](_internal/ROADMAP.md) — Roadmap, backlog, changelog
 
 ## Video Workflow
 

--- a/README.md
+++ b/README.md
@@ -68,17 +68,24 @@ npm run render    # Outputs MP4 — no API keys needed
 git clone https://github.com/digitalsamba/claude-code-video-toolkit.git
 cd claude-code-video-toolkit
 
-# Set up environment (all keys are optional)
-cp .env.example .env
-
 # Install Python dependencies (optional — only needed for AI tools)
 python -m venv .venv
 source .venv/bin/activate
 pip install -r tools/requirements.txt
 
-# Start Claude Code
+# Start Claude Code and run the setup wizard
 claude
 ```
+
+### Set Up AI Tools (optional, ~5 minutes)
+
+In Claude Code, run:
+
+```
+/setup
+```
+
+This walks you through configuring cloud GPU, file transfer, and voice. Most features are free (Cloudflare R2 free tier, Modal $30/mo free compute, Qwen3-TTS free voiceovers).
 
 ### Create Your First Video
 

--- a/_internal/ROADMAP.md
+++ b/_internal/ROADMAP.md
@@ -118,6 +118,21 @@ An open-source, AI-native video production workspace for Claude Code, featuring:
 - [x] Temperature/top_p generation params for expressiveness control
 - [ ] Make Qwen3-TTS the default provider (replacing ElevenLabs)
 
+**Modal Cloud GPU Provider:**
+- [x] `tools/cloud_gpu.py` — shared provider abstraction (RunPod + Modal)
+- [x] `tools/file_transfer.py` — shared R2/fallback upload/download
+- [x] `--cloud runpod|modal` flag on all cloud GPU tools
+- [x] `docker/modal-qwen3-tts/app.py` — deployed, tested
+- [x] `docker/modal-flux2/app.py` — deployed, tested
+- [x] `docker/modal-upscale/app.py` — deployed, tested
+- [x] `docker/modal-image-edit/app.py` — deployed, tested
+- [x] `docker/modal-music-gen/app.py` — deployed, tested
+- [x] `docker/modal-sadtalker/app.py` — deployed, tested
+- [x] `--runpod` deprecated in upscale.py (alias for `--cloud runpod`)
+- [x] `voiceover.py` passes `--cloud` through to Qwen3-TTS
+- [ ] `docs/modal-setup.md` — setup guide for Modal deployment
+- [ ] Add `--setup --cloud modal` to tools (currently manual `modal deploy`)
+
 **Sprint Review v2:**
 - [x] `sprint-review-v2` template — composable scene-based architecture
 - [x] Modular scene components
@@ -177,6 +192,7 @@ An open-source, AI-native video production workspace for Claude Code, featuring:
 | frontend-design | stable | Visual design refinement |
 | qwen-edit | stable | AI image editing prompting patterns |
 | runpod | stable | Cloud GPU setup, Docker images, endpoint management |
+| modal | beta | Alternative cloud GPU provider — faster cold starts, all 6 tools deployed |
 
 ---
 

--- a/_internal/ROADMAP.md
+++ b/_internal/ROADMAP.md
@@ -128,8 +128,9 @@ An open-source, AI-native video production workspace for Claude Code, featuring:
 - [x] `docker/modal-image-edit/app.py` — deployed, tested
 - [x] `docker/modal-music-gen/app.py` — deployed, tested
 - [x] `docker/modal-sadtalker/app.py` — deployed, tested
-- [x] `--runpod` deprecated in upscale.py (alias for `--cloud runpod`)
+- [x] `--runpod` deprecated in upscale.py and dewatermark.py (alias for `--cloud runpod`)
 - [x] `voiceover.py` passes `--cloud` through to Qwen3-TTS
+- [x] `dewatermark.py` migrated to `cloud_gpu.py` (removed ~393 lines of inline RunPod code)
 - [ ] `docs/modal-setup.md` — setup guide for Modal deployment
 - [ ] Add `--setup --cloud modal` to tools (currently manual `modal deploy`)
 
@@ -220,7 +221,7 @@ An open-source, AI-native video production workspace for Claude Code, featuring:
 | Brands | 2 | default, digital-samba |
 | Skills | 8 | 6 stable, 2 beta |
 | Tools | 12 | voiceover, music, sfx, redub, addmusic, dewatermark, locate_watermark, notebooklm_brand, image_edit, upscale, sadtalker, qwen3_tts |
-| Commands | 12 | video, brand, template, skills, contribute, record-demo, generate-voiceover, scene-review, design, versions, redub, voice-clone |
+| Commands | 13 | setup, video, brand, template, skills, contribute, record-demo, generate-voiceover, scene-review, design, versions, redub, voice-clone |
 | Components | 11 | AnimatedBackground, SlideTransition, Label, Vignette, FilmGrain, LogoWatermark, SplitScreen, NarratorPiP, Envelope, PointingHand, MazeDecoration |
 | Transitions | 7 | glitch, rgbSplit, zoomBlur, lightLeak, clockWipe, pixelate, checkerboard |
 | Examples | 3 | hello-world, digital-samba-skill-demo, sprint-review-cho-oyu |

--- a/_internal/toolkit-registry.json
+++ b/_internal/toolkit-registry.json
@@ -444,6 +444,30 @@
       },
       "created": "2025-12-30",
       "updated": "2026-03-22"
+    },
+    "modal": {
+      "name": "Modal",
+      "description": "Serverless GPU cloud with Python-native deployment and fast cold starts",
+      "documentation": "docs/modal-setup.md",
+      "envVars": ["MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET"],
+      "endpoints": {
+        "qwen3-tts": {
+          "appFile": "docker/modal-qwen3-tts/app.py",
+          "envVar": "MODAL_QWEN3_TTS_ENDPOINT_URL",
+          "operations": ["qwen3_tts"],
+          "gpu": "A10G",
+          "estimatedCost": "$0.005-0.10 per generation"
+        },
+        "flux2": {
+          "appFile": "docker/modal-flux2/app.py",
+          "envVar": "MODAL_FLUX2_ENDPOINT_URL",
+          "operations": ["flux2"],
+          "gpu": "A10G",
+          "estimatedCost": "$0.01-0.03 per image"
+        }
+      },
+      "created": "2026-03-23",
+      "updated": "2026-03-23"
     }
   },
 

--- a/_internal/toolkit-registry.json
+++ b/_internal/toolkit-registry.json
@@ -464,6 +464,34 @@
           "operations": ["flux2"],
           "gpu": "A10G",
           "estimatedCost": "$0.01-0.03 per image"
+        },
+        "upscale": {
+          "appFile": "docker/modal-upscale/app.py",
+          "envVar": "MODAL_UPSCALE_ENDPOINT_URL",
+          "operations": ["upscale"],
+          "gpu": "A10G",
+          "estimatedCost": "$0.005-0.02 per image"
+        },
+        "image-edit": {
+          "appFile": "docker/modal-image-edit/app.py",
+          "envVar": "MODAL_IMAGE_EDIT_ENDPOINT_URL",
+          "operations": ["image_edit"],
+          "gpu": "A100",
+          "estimatedCost": "$0.02-0.05 per image"
+        },
+        "music-gen": {
+          "appFile": "docker/modal-music-gen/app.py",
+          "envVar": "MODAL_MUSIC_GEN_ENDPOINT_URL",
+          "operations": ["music_gen"],
+          "gpu": "A10G",
+          "estimatedCost": "$0.02-0.10 per generation"
+        },
+        "sadtalker": {
+          "appFile": "docker/modal-sadtalker/app.py",
+          "envVar": "MODAL_SADTALKER_ENDPOINT_URL",
+          "operations": ["sadtalker"],
+          "gpu": "A10G",
+          "estimatedCost": "$0.05-0.30 per video"
         }
       },
       "created": "2026-03-23",

--- a/_internal/toolkit-registry.json
+++ b/_internal/toolkit-registry.json
@@ -492,6 +492,13 @@
           "operations": ["sadtalker"],
           "gpu": "A10G",
           "estimatedCost": "$0.05-0.30 per video"
+        },
+        "dewatermark": {
+          "appFile": "docker/modal-propainter/app.py",
+          "envVar": "MODAL_DEWATERMARK_ENDPOINT_URL",
+          "operations": ["dewatermark"],
+          "gpu": "A10G",
+          "estimatedCost": "$0.05-0.50 per video"
         }
       },
       "created": "2026-03-23",

--- a/_internal/toolkit-registry.json
+++ b/_internal/toolkit-registry.json
@@ -157,6 +157,13 @@
       "status": "beta",
       "created": "2026-02-19",
       "updated": "2026-02-19"
+    },
+    "setup": {
+      "path": ".claude/commands/setup.md",
+      "description": "First-time toolkit setup - cloud GPU, file transfer, voice, and prerequisites",
+      "status": "beta",
+      "created": "2026-03-23",
+      "updated": "2026-03-23"
     }
   },
 
@@ -245,6 +252,14 @@
       "presets": ["notebooklm", "tiktok", "sora", "stock-br", "stock-bl", "stock-center"],
       "created": "2025-12-29",
       "updated": "2025-12-30"
+    },
+    "verify_setup": {
+      "path": "tools/verify_setup.py",
+      "description": "Verify toolkit setup - check prerequisites, cloud GPU, R2, and voice configuration",
+      "usage": "python tools/verify_setup.py [--test] [--json]",
+      "status": "beta",
+      "created": "2026-03-23",
+      "updated": "2026-03-23"
     },
     "notebooklm_brand": {
       "path": "tools/notebooklm_brand.py",

--- a/docker/modal-flux2/app.py
+++ b/docker/modal-flux2/app.py
@@ -1,0 +1,224 @@
+"""
+Modal deployment for FLUX.2 Klein 4B.
+
+Text-to-image generation and image editing.
+Equivalent to docker/runpod-flux2/handler.py but deployed on Modal.
+
+Deploy:
+    modal deploy docker/modal-flux2/app.py
+
+Input format (POST JSON to web endpoint):
+{
+    "operation": "generate" | "edit",
+    "prompt": str,
+    "image_base64": str,           # Required for edit
+    "images_base64": [str],        # Optional additional reference images
+    "width": int,                  # Default: 1024
+    "height": int,                 # Default: 1024
+    "num_inference_steps": int,    # Default: 4 (generate), 50 (edit)
+    "guidance_scale": float,       # Default: 1.0 (generate), 4.0 (edit)
+    "seed": int,
+    "r2": dict                     # Optional R2 upload config
+}
+"""
+
+import modal
+
+app = modal.App("video-toolkit-flux2")
+
+MODEL_ID = "black-forest-labs/FLUX.2-klein-4B"
+
+# Container image — mirrors docker/runpod-flux2/Dockerfile
+image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .apt_install("git")
+    .pip_install(
+        "torch==2.5.1",
+        "torchvision==0.20.1",
+        "transformers>=4.45.0",
+        "accelerate>=0.30.0",
+        "sentencepiece",
+        "protobuf",
+        "Pillow",
+        "boto3",
+        "requests",
+        "fastapi[standard]",
+        "huggingface_hub>=0.25.0",
+    )
+    # Flux2KleinPipeline requires diffusers from git (not PyPI release)
+    .run_commands("pip install --no-cache-dir git+https://github.com/huggingface/diffusers")
+    # Bake model weights into the image
+    .run_commands(
+        'python -c "'
+        "from huggingface_hub import snapshot_download; "
+        f"snapshot_download('{MODEL_ID}')"
+        '"'
+    )
+)
+
+
+@app.cls(
+    image=image,
+    gpu="A10G",
+    timeout=600,
+    scaledown_window=60,
+)
+@modal.concurrent(max_inputs=1)
+class Flux2:
+    """FLUX.2 Klein inference class."""
+
+    @modal.enter()
+    def load_pipeline(self):
+        """Load the Flux2 Klein pipeline when the container starts."""
+        import time
+        import torch
+
+        print(f"CUDA available: {torch.cuda.is_available()}")
+        if torch.cuda.is_available():
+            props = torch.cuda.get_device_properties(0)
+            print(f"GPU: {props.name}, VRAM: {props.total_memory // (1024**3)}GB")
+
+        print(f"Loading Flux2 Klein pipeline from {MODEL_ID}...")
+        start = time.time()
+
+        from diffusers import Flux2KleinPipeline
+
+        self.pipeline = Flux2KleinPipeline.from_pretrained(
+            MODEL_ID,
+            torch_dtype=torch.bfloat16,
+        )
+        self.pipeline.to("cuda")
+
+        print(f"Pipeline loaded in {time.time() - start:.1f}s")
+
+    @modal.fastapi_endpoint(method="POST")
+    def generate(self, request: dict) -> dict:
+        """Web endpoint — accepts same payload format as RunPod handler."""
+        import base64
+        import io
+        import random
+        import time
+        import uuid
+
+        import torch
+        from PIL import Image
+
+        operation = request.get("operation", "generate")
+        prompt = request.get("prompt")
+
+        if not prompt:
+            return {"error": "Missing required 'prompt' in input"}
+
+        seed = request.get("seed")
+        if seed is None:
+            seed = random.randint(0, 2**32 - 1)
+
+        r2_config = request.get("r2")
+        start_time = time.time()
+
+        try:
+            generator = torch.Generator(device="cuda").manual_seed(seed)
+
+            if operation == "edit":
+                # Image editing
+                image_base64 = request.get("image_base64")
+                if not image_base64:
+                    return {"error": "Missing required 'image_base64' for edit operation"}
+
+                # Decode images
+                def decode_b64_image(b64: str) -> Image.Image:
+                    if "," in b64:
+                        b64 = b64.split(",", 1)[1]
+                    return Image.open(io.BytesIO(base64.b64decode(b64))).convert("RGB")
+
+                all_images = [decode_b64_image(image_base64)]
+                for ref_b64 in request.get("images_base64", [])[:2]:
+                    all_images.append(decode_b64_image(ref_b64))
+
+                image_input = all_images if len(all_images) > 1 else all_images[0]
+
+                num_inference_steps = request.get("num_inference_steps", 50)
+                guidance_scale = request.get("guidance_scale", 4.0)
+
+                output = self.pipeline(
+                    prompt=prompt,
+                    image=image_input,
+                    num_inference_steps=num_inference_steps,
+                    guidance_scale=guidance_scale,
+                    generator=generator,
+                )
+            else:
+                # Text-to-image generation
+                width = request.get("width", 1024)
+                height = request.get("height", 1024)
+                num_inference_steps = request.get("num_inference_steps", 4)
+                guidance_scale = request.get("guidance_scale", 1.0)
+
+                output = self.pipeline(
+                    prompt=prompt,
+                    width=width,
+                    height=height,
+                    num_inference_steps=num_inference_steps,
+                    guidance_scale=guidance_scale,
+                    generator=generator,
+                )
+
+            output_image = output.images[0]
+
+            # Encode to base64
+            buffer = io.BytesIO()
+            output_image.save(buffer, format="PNG")
+            output_base64 = base64.b64encode(buffer.getvalue()).decode("utf-8")
+
+            elapsed_ms = int((time.time() - start_time) * 1000)
+
+            result = {
+                "success": True,
+                "image_base64": output_base64,
+                "seed": seed,
+                "inference_time_ms": elapsed_ms,
+                "image_size": list(output_image.size),
+                "num_inference_steps": num_inference_steps,
+                "guidance_scale": guidance_scale,
+            }
+
+            # Upload to R2 if configured
+            if r2_config:
+                try:
+                    import boto3
+                    from botocore.config import Config
+
+                    client = boto3.client(
+                        "s3",
+                        endpoint_url=r2_config["endpoint_url"],
+                        aws_access_key_id=r2_config["access_key_id"],
+                        aws_secret_access_key=r2_config["secret_access_key"],
+                        config=Config(signature_version="s3v4"),
+                    )
+                    object_key = f"flux2/results/{uuid.uuid4().hex[:12]}.png"
+                    client.put_object(
+                        Bucket=r2_config["bucket_name"],
+                        Key=object_key,
+                        Body=base64.b64decode(output_base64),
+                        ContentType="image/png",
+                    )
+                    presigned_url = client.generate_presigned_url(
+                        "get_object",
+                        Params={"Bucket": r2_config["bucket_name"], "Key": object_key},
+                        ExpiresIn=7200,
+                    )
+                    result["output_url"] = presigned_url
+                    result["r2_key"] = object_key
+                except Exception as e:
+                    print(f"R2 upload error: {e}")
+
+            return result
+
+        except torch.cuda.OutOfMemoryError as e:
+            torch.cuda.empty_cache()
+            return {"error": f"GPU out of memory: {e}. Try smaller dimensions."}
+        except Exception as e:
+            import traceback
+            print(f"Error: {e}")
+            print(traceback.format_exc())
+            return {"error": f"Internal error: {str(e)}"}

--- a/docker/modal-image-edit/app.py
+++ b/docker/modal-image-edit/app.py
@@ -1,0 +1,175 @@
+"""
+Modal deployment for Qwen-Image-Edit (AI image editing).
+
+Deploy:
+    modal deploy docker/modal-image-edit/app.py
+
+Capabilities: background replacement, style transfer, custom edits, multi-image merge.
+"""
+
+import modal
+
+app = modal.App("video-toolkit-image-edit")
+
+MODEL_ID = "Qwen/Qwen-Image-Edit-2511"
+
+image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .apt_install("git", "libgl1", "libglib2.0-0")
+    .pip_install(
+        "torch==2.5.1",
+        "torchvision==0.20.1",
+        "transformers>=4.45.0",
+        "accelerate>=0.30.0",
+        "safetensors>=0.4.0",
+        "einops>=0.7.0",
+        "Pillow>=10.0.0",
+        "numpy>=1.26.0",
+        "opencv-python-headless>=4.9.0",
+        "sentencepiece",
+        "protobuf",
+        "boto3",
+        "requests",
+        "fastapi[standard]",
+        "huggingface_hub>=0.25.0",
+    )
+    .run_commands("pip install --no-cache-dir git+https://github.com/huggingface/diffusers")
+    .run_commands(
+        'python -c "'
+        "from huggingface_hub import snapshot_download; "
+        f"snapshot_download('{MODEL_ID}')"
+        '"'
+    )
+)
+
+
+@app.cls(
+    image=image,
+    gpu="A100",
+    timeout=600,
+    scaledown_window=60,
+)
+@modal.concurrent(max_inputs=1)
+class ImageEditor:
+    @modal.enter()
+    def load_pipeline(self):
+        import torch
+        from diffusers import QwenImageEditPlusPipeline
+
+        print(f"Loading {MODEL_ID}...")
+        self.pipeline = QwenImageEditPlusPipeline.from_pretrained(
+            MODEL_ID,
+            torch_dtype=torch.bfloat16,
+        )
+        self.pipeline.to("cuda")
+        print("Pipeline ready")
+
+    @modal.fastapi_endpoint(method="POST")
+    def edit(self, request: dict) -> dict:
+        import base64
+        import io
+        import random
+        import time
+        import uuid
+
+        import torch
+        from PIL import Image
+
+        image_base64 = request.get("image_base64")
+        prompt = request.get("prompt")
+
+        if not image_base64:
+            return {"error": "Missing required 'image_base64'"}
+        if not prompt:
+            return {"error": "Missing required 'prompt'"}
+
+        num_inference_steps = request.get("num_inference_steps", 4)
+        guidance_scale = request.get("guidance_scale", 1.0)
+        seed = request.get("seed")
+        negative_prompt = request.get("negative_prompt")
+        r2_config = request.get("r2")
+
+        if seed is None:
+            seed = random.randint(0, 2**32 - 1)
+
+        start_time = time.time()
+
+        try:
+            def decode_b64_image(b64: str) -> Image.Image:
+                if "," in b64:
+                    b64 = b64.split(",", 1)[1]
+                return Image.open(io.BytesIO(base64.b64decode(b64))).convert("RGB")
+
+            # Primary image + optional references
+            all_images = [decode_b64_image(image_base64)]
+            for ref_b64 in request.get("images_base64", [])[:2]:
+                all_images.append(decode_b64_image(ref_b64))
+
+            image_input = all_images if len(all_images) > 1 else all_images[0]
+
+            generator = torch.Generator(device="cuda").manual_seed(seed)
+
+            kwargs = {
+                "prompt": prompt,
+                "image": image_input,
+                "num_inference_steps": num_inference_steps,
+                "guidance_scale": guidance_scale,
+                "generator": generator,
+            }
+            if negative_prompt:
+                kwargs["negative_prompt"] = negative_prompt
+
+            output = self.pipeline(**kwargs)
+            output_image = output.images[0]
+
+            buffer = io.BytesIO()
+            output_image.save(buffer, format="PNG")
+            output_base64 = base64.b64encode(buffer.getvalue()).decode("utf-8")
+
+            elapsed_ms = int((time.time() - start_time) * 1000)
+
+            result = {
+                "success": True,
+                "edited_image_base64": output_base64,
+                "seed": seed,
+                "inference_time_ms": elapsed_ms,
+                "image_size": list(output_image.size),
+                "num_inference_steps": num_inference_steps,
+            }
+
+            # R2 upload
+            if r2_config:
+                import boto3
+                from botocore.config import Config
+
+                client = boto3.client(
+                    "s3",
+                    endpoint_url=r2_config["endpoint_url"],
+                    aws_access_key_id=r2_config["access_key_id"],
+                    aws_secret_access_key=r2_config["secret_access_key"],
+                    config=Config(signature_version="s3v4"),
+                )
+                object_key = f"image-edit/results/{uuid.uuid4().hex[:12]}.png"
+                client.put_object(
+                    Bucket=r2_config["bucket_name"],
+                    Key=object_key,
+                    Body=base64.b64decode(output_base64),
+                    ContentType="image/png",
+                )
+                result["output_url"] = client.generate_presigned_url(
+                    "get_object",
+                    Params={"Bucket": r2_config["bucket_name"], "Key": object_key},
+                    ExpiresIn=7200,
+                )
+                result["r2_key"] = object_key
+
+            return result
+
+        except torch.cuda.OutOfMemoryError as e:
+            torch.cuda.empty_cache()
+            return {"error": f"GPU out of memory: {e}. Try smaller image."}
+        except Exception as e:
+            import traceback
+            print(f"Error: {e}")
+            print(traceback.format_exc())
+            return {"error": f"Internal error: {str(e)}"}

--- a/docker/modal-music-gen/app.py
+++ b/docker/modal-music-gen/app.py
@@ -1,0 +1,269 @@
+"""
+Modal deployment for ACE-Step 1.5 music generation.
+
+Deploy:
+    modal deploy docker/modal-music-gen/app.py
+
+Capabilities: text-to-music, vocal music with lyrics, cover/style transfer, stem extraction.
+
+Note: Uses A10G (24GB VRAM). Cold start ~60-90s (models are baked into image).
+"""
+
+import modal
+
+app = modal.App("video-toolkit-music-gen")
+
+# Build image with ACE-Step repo and baked model weights (~10GB)
+image = (
+    modal.Image.from_registry("nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04", add_python="3.11")
+    .apt_install("git", "git-lfs", "ffmpeg", "libsndfile1")
+    .run_commands("git lfs install")
+    .pip_install(
+        "torch==2.5.1",
+        "torchaudio==2.5.1",
+        "torchvision==0.20.1",
+        "transformers>=4.51.0,<4.58.0",
+        "diffusers",
+        "accelerate>=1.12.0",
+        "safetensors>=0.7.0",
+        "soundfile>=0.13.1",
+        "einops>=0.8.1",
+        "scipy>=1.10.1",
+        "vector-quantize-pytorch>=1.27.15",
+        "numba>=0.63.1",
+        "toml",
+        "loguru>=0.7.3",
+        "peft>=0.18.0",
+        "boto3",
+        "requests",
+        "fastapi[standard]",
+        "huggingface_hub>=0.25.0",
+    )
+    # Clone ACE-Step repo and install
+    .run_commands(
+        "git clone --depth 1 https://github.com/ACE-Step/ACE-Step-1.5.git /app/acestep-repo",
+        "cd /app/acestep-repo/acestep/third_parts/nano-vllm && pip install --no-deps -e .",
+        "cd /app/acestep-repo && pip install --no-deps -e .",
+    )
+    # Bake model weights into image
+    .run_commands(
+        'python -c "'
+        "from huggingface_hub import snapshot_download; "
+        "snapshot_download('ACE-Step/Ace-Step1.5', "
+        "allow_patterns=['acestep-v15-turbo/*', 'vae/*', 'config.json'])"
+        '"'
+    )
+    .run_commands(
+        'python -c "'
+        "from huggingface_hub import snapshot_download; "
+        "snapshot_download('ACE-Step/Ace-Step1.5', "
+        "allow_patterns=['acestep-5Hz-lm-1.7B/*'])"
+        '"'
+    )
+    .run_commands(
+        'python -c "'
+        "from huggingface_hub import snapshot_download; "
+        "snapshot_download('ACE-Step/Ace-Step1.5', "
+        "allow_patterns=['Qwen3-Embedding-0.6B/*'])"
+        '"'
+    )
+    .env({"ACESTEP_CONFIG_PATH": "acestep-v15-turbo", "ACESTEP_DEVICE": "cuda"})
+)
+
+
+@app.cls(
+    image=image,
+    gpu="A10G",
+    timeout=600,
+    scaledown_window=60,
+)
+@modal.concurrent(max_inputs=1)
+class MusicGen:
+    @modal.enter()
+    def load_models(self):
+        """Load ACE-Step DiT model on container start."""
+        import os
+        import time
+        import torch
+
+        print(f"PyTorch {torch.__version__}, CUDA: {torch.cuda.is_available()}")
+        if torch.cuda.is_available():
+            print(f"GPU: {torch.cuda.get_device_name(0)}")
+
+        t0 = time.time()
+        from acestep.handler import AceStepHandler
+
+        self.dit_handler = AceStepHandler()
+        self.dit_handler.initialize_service(
+            project_root="/app/acestep-repo",
+            config_path=os.environ.get("ACESTEP_CONFIG_PATH", "acestep-v15-turbo"),
+            device=os.environ.get("ACESTEP_DEVICE", "cuda"),
+        )
+        print(f"DiT model loaded in {time.time() - t0:.1f}s")
+
+    @modal.fastapi_endpoint(method="POST")
+    def generate(self, request: dict) -> dict:
+        import base64
+        import os
+        import random
+        import tempfile
+        import time
+        import uuid
+        from pathlib import Path
+
+        from acestep.inference import GenerationParams, GenerationConfig, generate_music
+
+        task_type = request.get("task_type", "text2music")
+        prompt = request.get("prompt", "")
+        lyrics = request.get("lyrics", "")
+        duration = float(request.get("audio_duration", 30))
+        steps = int(request.get("inference_steps", 8))
+        audio_format = request.get("audio_format", "mp3")
+        seed = request.get("seed")
+        r2_config = request.get("r2")
+
+        if seed is None:
+            seed = random.randint(0, 2**32 - 1)
+
+        start_time = time.time()
+        temp_files = []
+
+        try:
+            params = GenerationParams(
+                task_type=task_type,
+                caption=prompt,
+                lyrics=lyrics,
+                duration=duration,
+                inference_steps=steps,
+                seed=seed,
+                vocal_language=request.get("vocal_language", "unknown"),
+            )
+
+            if request.get("bpm"):
+                params.bpm = int(request["bpm"])
+            if request.get("key_scale"):
+                params.keyscale = request["key_scale"]
+            if request.get("time_signature"):
+                params.timesignature = str(request["time_signature"])
+
+            # Task-specific params
+            if task_type == "cover":
+                ref_audio = request.get("reference_audio_base64")
+                if not ref_audio:
+                    return {"error": "reference_audio_base64 required for cover task"}
+                ref_path = tempfile.NamedTemporaryFile(suffix=".mp3", delete=False).name
+                with open(ref_path, "wb") as f:
+                    f.write(base64.b64decode(ref_audio))
+                temp_files.append(ref_path)
+                params.reference_audio = ref_path
+                params.audio_cover_strength = float(request.get("audio_cover_strength", 0.7))
+
+            elif task_type == "extract":
+                src_audio = request.get("src_audio_base64")
+                if not src_audio:
+                    return {"error": "src_audio_base64 required for extract task"}
+                src_path = tempfile.NamedTemporaryFile(suffix=".mp3", delete=False).name
+                with open(src_path, "wb") as f:
+                    f.write(base64.b64decode(src_audio))
+                temp_files.append(src_path)
+                params.src_audio = src_path
+
+            config = GenerationConfig(
+                batch_size=1,
+                audio_format=audio_format,
+                seeds=[seed],
+                use_random_seed=False,
+            )
+
+            save_dir = tempfile.mkdtemp(prefix="acestep_")
+
+            print(f"Generating: {task_type}, {duration}s, {steps} steps, seed={seed}")
+            result = generate_music(
+                dit_handler=self.dit_handler,
+                llm_handler=None,
+                params=params,
+                config=config,
+                save_dir=save_dir,
+            )
+
+            inference_time_ms = int((time.time() - start_time) * 1000)
+
+            if not result or not result.success or not result.audios:
+                error_msg = result.error if result and result.error else "No audio generated"
+                return {"error": str(error_msg)}
+
+            audio_entry = result.audios[0]
+            output_path = audio_entry.get("path", "")
+            audio_params = audio_entry.get("params", {})
+            metas = {
+                "bpm": audio_params.get("bpm"),
+                "keyscale": audio_params.get("keyscale", audio_params.get("key_scale")),
+                "duration": audio_params.get("duration"),
+                "timesignature": audio_params.get("timesignature"),
+            }
+            seed_value = audio_params.get("seed", seed)
+
+            if not output_path or not Path(output_path).exists():
+                return {"error": "No output audio file produced"}
+
+            # Get actual duration
+            actual_duration = None
+            try:
+                import torchaudio
+                info = torchaudio.info(output_path)
+                actual_duration = round(info.num_frames / info.sample_rate, 2)
+            except Exception:
+                pass
+
+            response = {
+                "success": True,
+                "seed_value": seed_value,
+                "metas": metas,
+                "inference_time_ms": inference_time_ms,
+            }
+            if actual_duration:
+                response["actual_duration_seconds"] = actual_duration
+
+            # Upload to R2 or return base64
+            if r2_config:
+                try:
+                    import boto3
+                    from botocore.config import Config
+
+                    s3 = boto3.client(
+                        "s3",
+                        endpoint_url=r2_config["endpoint_url"],
+                        aws_access_key_id=r2_config["access_key_id"],
+                        aws_secret_access_key=r2_config["secret_access_key"],
+                        config=Config(signature_version="s3v4"),
+                    )
+                    object_key = f"acestep/results/{uuid.uuid4().hex[:12]}.{audio_format}"
+                    s3.upload_file(output_path, r2_config["bucket_name"], object_key)
+                    response["output_url"] = s3.generate_presigned_url(
+                        "get_object",
+                        Params={"Bucket": r2_config["bucket_name"], "Key": object_key},
+                        ExpiresIn=7200,
+                    )
+                    response["r2_key"] = object_key
+                except Exception as e:
+                    print(f"R2 upload failed, falling back to base64: {e}")
+                    with open(output_path, "rb") as f:
+                        response["audio_base64"] = base64.b64encode(f.read()).decode("utf-8")
+            else:
+                with open(output_path, "rb") as f:
+                    response["audio_base64"] = base64.b64encode(f.read()).decode("utf-8")
+
+            print(f"Done: {inference_time_ms}ms, {actual_duration}s audio")
+            return response
+
+        except Exception as e:
+            import traceback
+            print(f"Error: {e}")
+            print(traceback.format_exc())
+            return {"error": f"Internal error: {str(e)}"}
+        finally:
+            for f in temp_files:
+                try:
+                    os.unlink(f)
+                except OSError:
+                    pass

--- a/docker/modal-propainter/app.py
+++ b/docker/modal-propainter/app.py
@@ -1,0 +1,281 @@
+"""
+Modal deployment for ProPainter video inpainting (dewatermark).
+
+Deploy:
+    modal deploy docker/modal-propainter/app.py
+
+Removes watermarks/objects from video using AI inpainting.
+Specify region as x,y,width,height or provide a mask image URL.
+"""
+
+import modal
+
+app = modal.App("video-toolkit-dewatermark")
+
+WEIGHT_URLS = {
+    "ProPainter.pth": "https://github.com/sczhou/ProPainter/releases/download/v0.1.0/ProPainter.pth",
+    "recurrent_flow_completion.pth": "https://github.com/sczhou/ProPainter/releases/download/v0.1.0/recurrent_flow_completion.pth",
+    "raft-things.pth": "https://github.com/sczhou/ProPainter/releases/download/v0.1.0/raft-things.pth",
+    "i3d_rgb_imagenet.pt": "https://github.com/sczhou/ProPainter/releases/download/v0.1.0/i3d_rgb_imagenet.pt",
+}
+
+# Memory profiles based on GPU VRAM
+MEMORY_PROFILES = {
+    8:  {"subvideo_length": 20, "neighbor_length": 3, "ref_stride": 30},
+    15: {"subvideo_length": 30, "neighbor_length": 5, "ref_stride": 20},
+    22: {"subvideo_length": 40, "neighbor_length": 5, "ref_stride": 15},
+    45: {"subvideo_length": 50, "neighbor_length": 5, "ref_stride": 15},
+    75: {"subvideo_length": 60, "neighbor_length": 5, "ref_stride": 15},
+}
+
+image = (
+    modal.Image.from_registry(
+        "nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04",
+        add_python="3.10",
+    )
+    .apt_install("git", "ffmpeg", "curl")
+    .pip_install("numpy<2")
+    .pip_install("torch==2.4.0", "torchvision==0.19.0")
+    # Clone ProPainter and install deps
+    .run_commands(
+        "git clone --depth 1 https://github.com/sczhou/ProPainter.git /app/propainter",
+        "cd /app/propainter && pip install -r requirements.txt",
+    )
+    # Download model weights (~2GB)
+    .run_commands(
+        "mkdir -p /app/propainter/weights",
+        *[f"curl -sL -o /app/propainter/weights/{name} {url}" for name, url in WEIGHT_URLS.items()],
+    )
+    .pip_install("boto3", "requests", "fastapi[standard]")
+)
+
+
+@app.cls(
+    image=image,
+    gpu="A10G",
+    timeout=1800,
+    scaledown_window=60,
+)
+@modal.concurrent(max_inputs=1)
+class Dewatermark:
+    @modal.enter()
+    def verify_setup(self):
+        import torch
+        from pathlib import Path
+
+        print(f"PyTorch {torch.__version__}, CUDA: {torch.cuda.is_available()}")
+        if torch.cuda.is_available():
+            print(f"GPU: {torch.cuda.get_device_name(0)}")
+
+        weights_dir = Path("/app/propainter/weights")
+        print(f"Weights: {[f.name for f in weights_dir.iterdir()]}")
+
+    @modal.fastapi_endpoint(method="POST")
+    def dewatermark(self, request: dict) -> dict:
+        import json
+        import math
+        import os
+        import shutil
+        import subprocess
+        import tempfile
+        import time
+        import uuid
+        from pathlib import Path
+
+        import requests as req
+        import torch
+
+        video_url = request.get("video_url")
+        region = request.get("region")
+        mask_url = request.get("mask_url")
+        fp16 = request.get("fp16", True)
+        requested_resize_ratio = request.get("resize_ratio", "auto")
+        r2_config = request.get("r2")
+
+        if not video_url:
+            return {"error": "Missing required 'video_url'"}
+        if not region and not mask_url:
+            return {"error": "Either 'region' (x,y,w,h) or 'mask_url' is required"}
+
+        work_dir = Path(tempfile.mkdtemp(prefix="modal_dewatermark_"))
+        start_time = time.time()
+
+        try:
+            # Download video
+            print(f"Downloading video from {video_url[:80]}...")
+            video_path = str(work_dir / "input.mp4")
+            resp = req.get(video_url, stream=True, timeout=300)
+            resp.raise_for_status()
+            with open(video_path, "wb") as f:
+                for chunk in resp.iter_content(8192):
+                    f.write(chunk)
+
+            # Get video info
+            probe = subprocess.run(
+                ["ffprobe", "-v", "error", "-select_streams", "v:0",
+                 "-show_entries", "stream=width,height,duration,r_frame_rate,nb_frames",
+                 "-show_entries", "format=duration", "-of", "json", video_path],
+                capture_output=True, text=True, timeout=30,
+            )
+            vinfo = json.loads(probe.stdout) if probe.returncode == 0 else {}
+            stream = vinfo.get("streams", [{}])[0]
+            fmt = vinfo.get("format", {})
+            width = int(stream.get("width", 0))
+            height = int(stream.get("height", 0))
+            duration = float(stream.get("duration") or fmt.get("duration", 0))
+            fps_str = stream.get("r_frame_rate", "30/1")
+            fps = eval(fps_str) if "/" in str(fps_str) else float(fps_str or 30)
+            nb_frames = int(stream.get("nb_frames") or int(duration * fps))
+
+            if not width or not height:
+                return {"error": "Could not read video dimensions"}
+
+            print(f"Video: {width}x{height}, {duration:.1f}s, {nb_frames} frames")
+
+            # GPU memory profile
+            vram_gb = torch.cuda.get_device_properties(0).total_memory // (1024**3) if torch.cuda.is_available() else 16
+            profile = MEMORY_PROFILES[8]
+            for threshold in sorted(MEMORY_PROFILES.keys(), reverse=True):
+                if vram_gb >= threshold:
+                    profile = MEMORY_PROFILES[threshold]
+                    break
+
+            # Auto resize ratio
+            if requested_resize_ratio == "auto":
+                pixels = width * height
+                bytes_per_frame = 6.5 * 1024 * 1024 * (pixels / (1280 * 720))
+                total_needed = bytes_per_frame * nb_frames + 2 * (1024**3)
+                available = vram_gb * (1024**3) * 0.7
+                if total_needed > available:
+                    frame_mem = bytes_per_frame * nb_frames
+                    usable = available - 2 * (1024**3)
+                    resize_ratio = max(0.25, min(1.0, math.sqrt(max(0, usable) / max(1, frame_mem))))
+                    for nice in [1.0, 0.75, 0.5, 0.375, 0.25]:
+                        if resize_ratio >= nice:
+                            resize_ratio = nice
+                            break
+                else:
+                    resize_ratio = 1.0
+            else:
+                resize_ratio = float(requested_resize_ratio)
+
+            print(f"GPU: {vram_gb}GB, profile: {profile}, resize: {resize_ratio}")
+
+            # Create mask
+            mask_path = str(work_dir / "mask.png")
+            if mask_url:
+                resp = req.get(mask_url, timeout=60)
+                resp.raise_for_status()
+                with open(mask_path, "wb") as f:
+                    f.write(resp.content)
+            else:
+                parts = [int(v.strip()) for v in region.split(",")]
+                if len(parts) != 4:
+                    return {"error": f"Region must be x,y,width,height — got: {region}"}
+                x, y, w, h = parts
+                subprocess.run(
+                    ["ffmpeg", "-y", "-f", "lavfi",
+                     "-i", f"color=black:s={width}x{height}:d=1",
+                     "-vf", f"drawbox=x={x}:y={y}:w={w}:h={h}:c=white:t=fill",
+                     "-frames:v", "1", mask_path],
+                    capture_output=True, timeout=30, check=True,
+                )
+
+            # Run ProPainter
+            output_dir = str(work_dir / "results")
+            os.makedirs(output_dir, exist_ok=True)
+
+            cmd = [
+                "python3", "/app/propainter/inference_propainter.py",
+                "-i", video_path, "-m", mask_path, "-o", output_dir,
+                "--neighbor_length", str(profile["neighbor_length"]),
+                "--ref_stride", str(profile["ref_stride"]),
+                "--subvideo_length", str(profile["subvideo_length"]),
+            ]
+            if fp16:
+                cmd.append("--fp16")
+            if resize_ratio != 1.0:
+                cmd.extend(["--resize_ratio", str(resize_ratio)])
+
+            print(f"Running ProPainter...")
+            proc = subprocess.run(
+                cmd, cwd="/app/propainter",
+                capture_output=True, text=True, timeout=3600,
+            )
+
+            if proc.returncode != 0:
+                print(f"ProPainter stderr: {proc.stderr[-500:]}")
+                return {"error": f"ProPainter failed: {proc.stderr[-300:]}"}
+
+            # Find output
+            result_path = None
+            video_stem = Path(video_path).stem
+            expected = Path(output_dir) / video_stem / "inpaint_out.mp4"
+            if expected.exists():
+                result_path = str(expected)
+            else:
+                for mp4 in Path(output_dir).rglob("inpaint_out.mp4"):
+                    result_path = str(mp4)
+                    break
+                if not result_path:
+                    for mp4 in Path(output_dir).rglob("*.mp4"):
+                        if "masked" not in mp4.name:
+                            result_path = str(mp4)
+                            break
+
+            if not result_path:
+                return {"error": "No output file produced"}
+
+            elapsed = time.time() - start_time
+            print(f"Done: {elapsed:.1f}s")
+
+            result = {
+                "success": True,
+                "video_dimensions": f"{width}x{height}",
+                "video_duration_seconds": round(duration, 2),
+                "video_frame_count": nb_frames,
+                "gpu_vram_gb": vram_gb,
+                "profile_used": profile,
+                "resize_ratio": resize_ratio,
+                "processing_time_seconds": round(elapsed, 2),
+            }
+
+            # Upload to R2 or return base64
+            if r2_config:
+                import boto3
+                from botocore.config import Config
+
+                client = boto3.client(
+                    "s3",
+                    endpoint_url=r2_config["endpoint_url"],
+                    aws_access_key_id=r2_config["access_key_id"],
+                    aws_secret_access_key=r2_config["secret_access_key"],
+                    config=Config(signature_version="s3v4"),
+                )
+                object_key = f"dewatermark/results/{uuid.uuid4().hex[:12]}.mp4"
+                client.upload_file(
+                    result_path, r2_config["bucket_name"], object_key,
+                    ExtraArgs={"ContentType": "video/mp4"},
+                )
+                result["output_url"] = client.generate_presigned_url(
+                    "get_object",
+                    Params={"Bucket": r2_config["bucket_name"], "Key": object_key},
+                    ExpiresIn=7200,
+                )
+                result["r2_key"] = object_key
+            else:
+                import base64
+                result["video_base64"] = base64.b64encode(Path(result_path).read_bytes()).decode("utf-8")
+                print("Warning: Returning video as base64 (use R2 for large files)")
+
+            return result
+
+        except subprocess.TimeoutExpired:
+            return {"error": "ProPainter timed out (1h limit)"}
+        except Exception as e:
+            import traceback
+            print(f"Error: {e}")
+            print(traceback.format_exc())
+            return {"error": f"Internal error: {str(e)}"}
+        finally:
+            shutil.rmtree(work_dir, ignore_errors=True)

--- a/docker/modal-qwen3-tts/app.py
+++ b/docker/modal-qwen3-tts/app.py
@@ -1,0 +1,275 @@
+"""
+Modal deployment for Qwen3-TTS.
+
+Generates speech from text with built-in voices, emotion control, and voice cloning.
+Equivalent to docker/runpod-qwen3-tts/handler.py but deployed on Modal.
+
+Deploy:
+    modal deploy docker/modal-qwen3-tts/app.py
+
+Test:
+    modal run docker/modal-qwen3-tts/app.py --text "Hello world"
+
+Input format (POST JSON to web endpoint):
+{
+    "text": str,                    # Required: text to synthesize
+    "mode": "custom_voice",         # "custom_voice" (default) or "clone"
+    "speaker": "Ryan",              # Speaker name (custom_voice mode)
+    "instruct": "",                 # Emotion/style instruction
+    "language": "Auto",
+    "output_format": "mp3",         # "mp3" or "wav"
+    "temperature": 0.7,
+    "top_p": 0.8,
+
+    # Clone mode:
+    "ref_audio_url": str,           # URL to reference audio
+    "ref_audio_base64": str,        # Or base64 encoded reference audio
+    "ref_text": str,                # Transcript of reference audio (required)
+
+    # Optional R2 upload:
+    "r2": { "endpoint_url": ..., "access_key_id": ..., "secret_access_key": ..., "bucket_name": ... }
+}
+
+Output format:
+{
+    "success": true,
+    "audio_base64": str,            # Base64 audio (if no R2)
+    "audio_url": str,               # Presigned R2 URL (if R2 configured)
+    "r2_key": str,
+    "duration_seconds": float,
+    "mode": str,
+    "processing_time_seconds": float
+}
+"""
+
+import modal
+
+app = modal.App("video-toolkit-qwen3-tts")
+
+# Container image — mirrors docker/runpod-qwen3-tts/Dockerfile
+image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .apt_install("ffmpeg")
+    .pip_install(
+        "torch==2.4.0",
+        "torchaudio==2.4.0",
+        "qwen-tts",
+        "soundfile",
+        "boto3",
+        "requests",
+        "fastapi[standard]",
+    )
+    # Bake model weights into the image (avoids cold-start downloads)
+    .run_commands(
+        'python -c "'
+        "from huggingface_hub import snapshot_download; "
+        "snapshot_download('Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice'); "
+        "snapshot_download('Qwen/Qwen3-TTS-12Hz-1.7B-Base')"
+        '"'
+    )
+)
+
+
+@app.cls(
+    image=image,
+    gpu="A10G",
+    timeout=300,
+    scaledown_window=60,
+)
+@modal.concurrent(max_inputs=1)
+class Qwen3TTS:
+    """Qwen3-TTS inference class. Models are loaded once and reused across requests."""
+
+    @modal.enter()
+    def load_models(self):
+        """Load models when the container starts (equivalent to lazy-load globals in RunPod handler)."""
+        import torch
+        from qwen_tts import Qwen3TTSModel
+
+        print(f"CUDA available: {torch.cuda.is_available()}")
+        if torch.cuda.is_available():
+            print(f"GPU: {torch.cuda.get_device_name(0)}")
+
+        print("Loading CustomVoice model...")
+        self.custom_voice_model = Qwen3TTSModel.from_pretrained(
+            "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
+            device_map="cuda:0",
+            dtype=torch.bfloat16,
+            attn_implementation="sdpa",
+        )
+        print("CustomVoice model loaded")
+
+        print("Loading Base model...")
+        self.base_model = Qwen3TTSModel.from_pretrained(
+            "Qwen/Qwen3-TTS-12Hz-1.7B-Base",
+            device_map="cuda:0",
+            dtype=torch.bfloat16,
+            attn_implementation="sdpa",
+        )
+        print("Base model loaded")
+
+    @modal.fastapi_endpoint(method="POST")
+    def generate(self, request: dict) -> dict:
+        """Web endpoint — accepts same payload format as RunPod handler."""
+        import base64
+        import shutil
+        import subprocess
+        import tempfile
+        import time
+        import uuid
+        from pathlib import Path
+
+        import requests as req
+        import soundfile as sf
+
+        start_time = time.time()
+
+        # Validate
+        text = request.get("text")
+        if not text:
+            return {"error": "Missing required field: text"}
+
+        mode = request.get("mode", "custom_voice")
+        language = request.get("language", "Auto")
+        output_format = request.get("output_format", "mp3")
+        r2_config = request.get("r2")
+
+        gen_kwargs = {}
+        if "temperature" in request:
+            gen_kwargs["temperature"] = float(request["temperature"])
+        if "top_p" in request:
+            gen_kwargs["top_p"] = float(request["top_p"])
+
+        job_id = uuid.uuid4().hex[:12]
+        work_dir = Path(tempfile.mkdtemp(prefix=f"qwen3tts_{job_id}_"))
+
+        try:
+            wav_path = work_dir / "output.wav"
+
+            if mode == "clone":
+                ref_audio_path = work_dir / "ref_audio.wav"
+                ref_text = request.get("ref_text")
+
+                if not ref_text:
+                    return {"error": "ref_text is required for clone mode"}
+
+                # Download or decode reference audio
+                if request.get("ref_audio_url"):
+                    resp = req.get(request["ref_audio_url"], timeout=300)
+                    resp.raise_for_status()
+                    ref_audio_path.write_bytes(resp.content)
+                elif request.get("ref_audio_base64"):
+                    data = request["ref_audio_base64"]
+                    if "," in data:
+                        data = data.split(",", 1)[1]
+                    ref_audio_path.write_bytes(base64.b64decode(data))
+                else:
+                    return {"error": "ref_audio_url or ref_audio_base64 required for clone mode"}
+
+                # Generate with voice cloning
+                prompt = self.base_model.create_voice_clone_prompt(
+                    ref_audio=str(ref_audio_path),
+                    ref_text=ref_text,
+                )
+                wavs, sr = self.base_model.generate_voice_clone(
+                    text=text,
+                    language=language,
+                    voice_clone_prompt=prompt,
+                    **gen_kwargs,
+                )
+                audio_data = wavs[0]
+
+            else:
+                # CustomVoice mode
+                speaker = request.get("speaker", "Ryan")
+                instruct = request.get("instruct", "")
+
+                cv_kwargs = {
+                    "text": text,
+                    "language": language,
+                    "speaker": speaker,
+                }
+                if instruct:
+                    cv_kwargs["instruct"] = instruct
+                cv_kwargs.update(gen_kwargs)
+
+                wavs, sr = self.custom_voice_model.generate_custom_voice(**cv_kwargs)
+                audio_data = wavs[0]
+
+            # Write WAV
+            sf.write(str(wav_path), audio_data, sr)
+
+            # Convert to output format
+            if output_format == "mp3":
+                output_path = work_dir / "output.mp3"
+                subprocess.run(
+                    ["ffmpeg", "-y", "-i", str(wav_path),
+                     "-codec:a", "libmp3lame", "-b:a", "192k",
+                     str(output_path)],
+                    capture_output=True, timeout=120, check=True,
+                )
+                content_type = "audio/mpeg"
+            else:
+                output_path = wav_path
+                content_type = "audio/wav"
+
+            # Get duration
+            try:
+                dur_result = subprocess.run(
+                    ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+                     "-of", "default=noprint_wrappers=1:nokey=1", str(output_path)],
+                    capture_output=True, text=True, timeout=30,
+                )
+                duration = float(dur_result.stdout.strip())
+            except Exception:
+                duration = 0.0
+
+            elapsed = time.time() - start_time
+
+            result = {
+                "success": True,
+                "duration_seconds": round(duration, 2),
+                "mode": mode,
+                "processing_time_seconds": round(elapsed, 2),
+            }
+
+            # Upload to R2 or return base64
+            if r2_config:
+                try:
+                    import boto3
+                    from botocore.config import Config
+
+                    client = boto3.client(
+                        "s3",
+                        endpoint_url=r2_config["endpoint_url"],
+                        aws_access_key_id=r2_config["access_key_id"],
+                        aws_secret_access_key=r2_config["secret_access_key"],
+                        config=Config(signature_version="s3v4"),
+                    )
+                    ext = output_path.suffix
+                    object_key = f"qwen3-tts/results/{job_id}_{uuid.uuid4().hex[:8]}{ext}"
+                    client.upload_file(
+                        str(output_path), r2_config["bucket_name"], object_key,
+                        ExtraArgs={"ContentType": content_type},
+                    )
+                    presigned_url = client.generate_presigned_url(
+                        "get_object",
+                        Params={"Bucket": r2_config["bucket_name"], "Key": object_key},
+                        ExpiresIn=7200,
+                    )
+                    result["audio_url"] = presigned_url
+                    result["r2_key"] = object_key
+                except Exception as e:
+                    return {"error": f"R2 upload failed: {e}"}
+            else:
+                result["audio_base64"] = base64.b64encode(output_path.read_bytes()).decode("utf-8")
+
+            return result
+
+        except Exception as e:
+            import traceback
+            print(f"Error: {e}")
+            print(traceback.format_exc())
+            return {"error": f"Internal error: {str(e)}"}
+        finally:
+            shutil.rmtree(work_dir, ignore_errors=True)

--- a/docker/modal-sadtalker/app.py
+++ b/docker/modal-sadtalker/app.py
@@ -34,19 +34,23 @@ image = (
     modal.Image.from_registry(
         "nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04",
         add_python="3.10",
+        force_build=True,
     )
     .apt_install(
         "ffmpeg", "git", "wget", "unzip", "cmake", "build-essential",
         "libgl1-mesa-glx", "libglib2.0-0",
     )
-    .pip_install(
-        "torch==2.1.2+cu118",
-        "torchvision==0.16.2+cu118",
-        "torchaudio==2.1.2+cu118",
-        extra_index_url="https://download.pytorch.org/whl/cu118",
+    # torch 2.4+ handles both numpy 1.x and 2.x correctly.
+    # Earlier torch versions fail with "Numpy is not available" on Modal's runtime.
+    .pip_install("numpy<2")
+    .pip_install("torch==2.4.0", "torchvision==0.19.0", "torchaudio==2.4.0")
+    .pip_install("basicsr>=1.4.2", "facexlib>=0.3.0", "gfpgan", "realesrgan")
+    # Patch basicsr for torchvision 0.19+ (functional_tensor removed)
+    .run_commands(
+        r"find /usr/local/lib -name 'degradations.py' -path '*/basicsr/*' -exec "
+        r"sed -i 's/from torchvision.transforms.functional_tensor import rgb_to_grayscale/"
+        r"from torchvision.transforms.functional import rgb_to_grayscale/g' {} \;"
     )
-    # Install numpy<2 first (basicsr/gfpgan need it at build time)
-    .pip_install("numpy<2", "Cython")
     .pip_install(
         "dlib-bin",
         "face_alignment",
@@ -59,10 +63,10 @@ image = (
         "tqdm",
         "yacs",
         "safetensors",
+        "boto3",
+        "requests",
+        "fastapi[standard]",
     )
-    # Install basicsr/gfpgan separately (C extensions need numpy<2 present)
-    .pip_install("basicsr>=1.4.2", "facexlib>=0.3.0", "gfpgan", "realesrgan")
-    .pip_install("boto3", "requests", "fastapi[standard]")
     # Clone SadTalker
     .run_commands("git clone --depth 1 https://github.com/OpenTalker/SadTalker.git /app/SadTalker")
     # Patch numpy 2.0 compat (belt-and-suspenders even with numpy<2 pin)
@@ -104,12 +108,25 @@ image = (
 class SadTalkerGen:
     @modal.enter()
     def verify_setup(self):
+        import subprocess
         import torch
         from pathlib import Path
 
         print(f"PyTorch {torch.__version__}, CUDA: {torch.cuda.is_available()}")
         if torch.cuda.is_available():
             print(f"GPU: {torch.cuda.get_device_name(0)}")
+
+        # Verify numpy-torch bridge works in this runtime
+        import numpy
+        t = torch.from_numpy(numpy.array([1.0]))
+        print(f"numpy {numpy.__version__}, torch.from_numpy: {t}")
+
+        # Also verify it works from subprocess (since SadTalker runs as subprocess)
+        result = subprocess.run(
+            ["python", "-c", "import torch, numpy; print(f'subprocess: numpy={numpy.__version__}, from_numpy={torch.from_numpy(numpy.array([1.0]))}')"],
+            capture_output=True, text=True,
+        )
+        print(f"Subprocess check: {result.stdout.strip() or result.stderr.strip()}")
 
         ckpt = Path("/app/SadTalker/checkpoints")
         print(f"Checkpoints: {[f.name for f in ckpt.iterdir()][:6]}")

--- a/docker/modal-sadtalker/app.py
+++ b/docker/modal-sadtalker/app.py
@@ -1,0 +1,333 @@
+"""
+Modal deployment for SadTalker talking head generation.
+
+Deploy:
+    modal deploy docker/modal-sadtalker/app.py
+
+Generates talking head videos from a portrait image + audio file.
+Audio >45s is split into chunks to prevent drift.
+
+Note: Uses subprocess to run SadTalker inference.py (not a direct Python API).
+Cold start ~45-60s (models baked into image).
+"""
+
+import modal
+
+app = modal.App("video-toolkit-sadtalker")
+
+CHUNK_DURATION = 45  # seconds — split long audio to prevent drift
+
+# Model weight URLs (baked into image at build time)
+SADTALKER_WEIGHTS = {
+    "mapping_109": "https://github.com/OpenTalker/SadTalker/releases/download/v0.0.2-rc/mapping_00109-model.pth.tar",
+    "mapping_229": "https://github.com/OpenTalker/SadTalker/releases/download/v0.0.2-rc/mapping_00229-model.pth.tar",
+    "model_256": "https://github.com/OpenTalker/SadTalker/releases/download/v0.0.2-rc/SadTalker_V0.0.2_256.safetensors",
+    "model_512": "https://github.com/OpenTalker/SadTalker/releases/download/v0.0.2-rc/SadTalker_V0.0.2_512.safetensors",
+    "bfm": "https://github.com/OpenTalker/SadTalker/releases/download/v0.0.2/BFM_Fitting.zip",
+    "hub": "https://github.com/OpenTalker/SadTalker/releases/download/v0.0.2/hub.zip",
+    "gfpgan": "https://github.com/TencentARC/GFPGAN/releases/download/v1.3.0/GFPGANv1.4.pth",
+    "facexlib_det": "https://github.com/xinntao/facexlib/releases/download/v0.1.0/detection_Resnet50_Final.pth",
+    "facexlib_parse": "https://github.com/xinntao/facexlib/releases/download/v0.2.2/parsing_parsenet.pth",
+}
+
+image = (
+    modal.Image.from_registry(
+        "nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04",
+        add_python="3.10",
+    )
+    .apt_install(
+        "ffmpeg", "git", "wget", "unzip", "cmake", "build-essential",
+        "libgl1-mesa-glx", "libglib2.0-0",
+    )
+    .pip_install(
+        "torch==2.1.2+cu118",
+        "torchvision==0.16.2+cu118",
+        "torchaudio==2.1.2+cu118",
+        extra_index_url="https://download.pytorch.org/whl/cu118",
+    )
+    .pip_install(
+        "numpy<2",
+        "dlib-bin",
+        "face_alignment",
+        "imageio",
+        "imageio-ffmpeg",
+        "kornia",
+        "librosa",
+        "pydub",
+        "scipy",
+        "tqdm",
+        "yacs",
+        "safetensors",
+        "gfpgan",
+        "basicsr",
+        "facexlib",
+        "realesrgan",
+        "boto3",
+        "requests",
+        "fastapi[standard]",
+    )
+    # Clone SadTalker
+    .run_commands("git clone --depth 1 https://github.com/OpenTalker/SadTalker.git /app/SadTalker")
+    # Patch numpy 2.0 compat (belt-and-suspenders even with numpy<2 pin)
+    .run_commands(
+        r"find /app/SadTalker -name '*.py' -exec sed -i 's/np\.float\b/float/g' {} \;",
+        r"find /app/SadTalker -name '*.py' -exec sed -i 's/np\.int\b/int/g' {} \;",
+        r"find /app/SadTalker -name '*.py' -exec sed -i 's/np\.VisibleDeprecationWarning/DeprecationWarning/g' {} \;",
+        # Fix trans_params array element error
+        r"""sed -i 's/trans_params = np\.array(\[w0, h0, s, t\[0\], t\[1\]\])/trans_params = np.array([w0, h0, s, t[0], t[1]], dtype=object)/g' /app/SadTalker/src/face3d/util/preprocess.py""",
+    )
+    # Download model weights
+    .run_commands(
+        "mkdir -p /app/SadTalker/checkpoints",
+        f"wget -q -P /app/SadTalker/checkpoints {SADTALKER_WEIGHTS['mapping_109']}",
+        f"wget -q -P /app/SadTalker/checkpoints {SADTALKER_WEIGHTS['mapping_229']}",
+        f"wget -q -P /app/SadTalker/checkpoints {SADTALKER_WEIGHTS['model_256']}",
+        f"wget -q -P /app/SadTalker/checkpoints {SADTALKER_WEIGHTS['model_512']}",
+        # BFM fitting models
+        f"cd /app/SadTalker/checkpoints && wget -q {SADTALKER_WEIGHTS['bfm']} && unzip -q BFM_Fitting.zip && rm BFM_Fitting.zip",
+        # Face detection hub models
+        f"wget -q {SADTALKER_WEIGHTS['hub']} -O /tmp/hub.zip && unzip -q /tmp/hub.zip -d /root/.cache/torch/ && rm /tmp/hub.zip",
+        # GFPGAN weights
+        f"mkdir -p /app/SadTalker/gfpgan/weights && wget -q -P /app/SadTalker/gfpgan/weights {SADTALKER_WEIGHTS['gfpgan']}",
+        # facexlib detection models
+        f"mkdir -p /root/.cache/facexlib && wget -q -O /root/.cache/facexlib/detection_Resnet50_Final.pth {SADTALKER_WEIGHTS['facexlib_det']}",
+        f"wget -q -O /root/.cache/facexlib/parsing_parsenet.pth {SADTALKER_WEIGHTS['facexlib_parse']}",
+    )
+    .env({"PYTHONPATH": "/app/SadTalker"})
+)
+
+
+@app.cls(
+    image=image,
+    gpu="A10G",
+    timeout=900,
+    scaledown_window=60,
+)
+@modal.concurrent(max_inputs=1)
+class SadTalkerGen:
+    @modal.enter()
+    def verify_setup(self):
+        import torch
+        from pathlib import Path
+
+        print(f"PyTorch {torch.__version__}, CUDA: {torch.cuda.is_available()}")
+        if torch.cuda.is_available():
+            print(f"GPU: {torch.cuda.get_device_name(0)}")
+
+        ckpt = Path("/app/SadTalker/checkpoints")
+        print(f"Checkpoints: {[f.name for f in ckpt.iterdir()][:6]}")
+
+    @modal.fastapi_endpoint(method="POST")
+    def generate(self, request: dict) -> dict:
+        import base64
+        import shutil
+        import subprocess
+        import tempfile
+        import time
+        import uuid
+        from pathlib import Path
+
+        import requests as req
+
+        start_time = time.time()
+
+        # Get inputs
+        image_url = request.get("image_url")
+        image_base64 = request.get("image_base64")
+        audio_url = request.get("audio_url")
+        audio_base64 = request.get("audio_base64")
+
+        if not image_url and not image_base64:
+            return {"error": "Missing image_url or image_base64"}
+        if not audio_url and not audio_base64:
+            return {"error": "Missing audio_url or audio_base64"}
+
+        still_mode = request.get("still_mode", False)
+        enhancer = request.get("enhancer", "gfpgan")
+        preprocess = request.get("preprocess", "crop")
+        size = request.get("size", 256)
+        expression_scale = request.get("expression_scale", 1.0)
+        pose_style = request.get("pose_style", 0)
+        r2_config = request.get("r2")
+
+        work_dir = Path(tempfile.mkdtemp(prefix="modal_sadtalker_"))
+
+        try:
+            # Download/decode image
+            image_path = work_dir / "input_image.png"
+            if image_url:
+                resp = req.get(image_url, stream=True, timeout=300)
+                resp.raise_for_status()
+                with open(image_path, "wb") as f:
+                    for chunk in resp.iter_content(8192):
+                        f.write(chunk)
+            else:
+                data = image_base64
+                if "," in data:
+                    data = data.split(",", 1)[1]
+                image_path.write_bytes(base64.b64decode(data))
+
+            # Download/decode audio
+            audio_path = work_dir / "input_audio.wav"
+            if audio_url:
+                resp = req.get(audio_url, stream=True, timeout=300)
+                resp.raise_for_status()
+                with open(audio_path, "wb") as f:
+                    for chunk in resp.iter_content(8192):
+                        f.write(chunk)
+            else:
+                data = audio_base64
+                if "," in data:
+                    data = data.split(",", 1)[1]
+                audio_path.write_bytes(base64.b64decode(data))
+
+            # Get audio duration
+            total_duration = 0.0
+            try:
+                result = subprocess.run(
+                    ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+                     "-of", "default=noprint_wrappers=1:nokey=1", str(audio_path)],
+                    capture_output=True, text=True, timeout=30,
+                )
+                total_duration = float(result.stdout.strip())
+            except Exception:
+                pass
+
+            print(f"Audio: {total_duration:.1f}s, size={size}, enhancer={enhancer}")
+
+            # Split audio into chunks if needed
+            if total_duration > CHUNK_DURATION:
+                audio_chunks = []
+                start = 0.0
+                idx = 0
+                while start < total_duration:
+                    chunk_path = work_dir / f"chunk_{idx:03d}.wav"
+                    end = min(start + CHUNK_DURATION, total_duration)
+                    subprocess.run(
+                        ["ffmpeg", "-y", "-i", str(audio_path),
+                         "-ss", str(start), "-t", str(end - start),
+                         "-c:a", "pcm_s16le", str(chunk_path)],
+                        capture_output=True, timeout=60,
+                    )
+                    if chunk_path.exists():
+                        audio_chunks.append(chunk_path)
+                    start = end
+                    idx += 1
+                print(f"Split into {len(audio_chunks)} chunks")
+            else:
+                audio_chunks = [audio_path]
+
+            # Process each chunk
+            video_chunks = []
+            for i, chunk in enumerate(audio_chunks):
+                print(f"Processing chunk {i + 1}/{len(audio_chunks)}...")
+                chunk_out = work_dir / f"output_{i:03d}"
+                chunk_out.mkdir()
+
+                cmd = [
+                    "python", "/app/SadTalker/inference.py",
+                    "--driven_audio", str(chunk),
+                    "--source_image", str(image_path),
+                    "--result_dir", str(chunk_out),
+                    "--checkpoint_dir", "/app/SadTalker/checkpoints",
+                    "--size", str(size),
+                    "--expression_scale", str(expression_scale),
+                    "--pose_style", str(pose_style),
+                    "--preprocess", preprocess,
+                ]
+                if still_mode:
+                    cmd.append("--still")
+                if enhancer != "none":
+                    cmd.extend(["--enhancer", enhancer])
+
+                proc = subprocess.run(
+                    cmd, cwd="/app/SadTalker",
+                    capture_output=True, text=True, timeout=600,
+                )
+
+                if proc.returncode != 0:
+                    print(f"SadTalker stderr: {proc.stderr[-500:]}")
+                    return {"error": f"Chunk {i + 1} failed: {proc.stderr[-300:]}"}
+
+                # Find output video
+                video_path = None
+                for f in chunk_out.glob("*.mp4"):
+                    video_path = f
+                    break
+                if not video_path:
+                    for subdir in chunk_out.iterdir():
+                        if subdir.is_dir():
+                            for f in subdir.glob("*.mp4"):
+                                video_path = f
+                                break
+                        if video_path:
+                            break
+
+                if not video_path:
+                    return {"error": f"No video output for chunk {i + 1}"}
+
+                video_chunks.append(video_path)
+
+            # Concatenate chunks
+            final_video = work_dir / "final.mp4"
+            if len(video_chunks) == 1:
+                shutil.copy(video_chunks[0], final_video)
+            else:
+                concat_file = work_dir / "concat.txt"
+                with open(concat_file, "w") as f:
+                    for vp in video_chunks:
+                        f.write(f"file '{vp}'\n")
+                subprocess.run(
+                    ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                     "-i", str(concat_file), "-c", "copy", str(final_video)],
+                    capture_output=True, timeout=120, check=True,
+                )
+
+            elapsed = time.time() - start_time
+            print(f"Done: {elapsed:.1f}s, {len(audio_chunks)} chunks")
+
+            result = {
+                "success": True,
+                "duration_seconds": round(total_duration, 2),
+                "chunks_processed": len(audio_chunks),
+                "processing_time_seconds": round(elapsed, 2),
+            }
+
+            # Upload to R2 or return base64
+            if r2_config:
+                import boto3
+                from botocore.config import Config
+
+                client = boto3.client(
+                    "s3",
+                    endpoint_url=r2_config["endpoint_url"],
+                    aws_access_key_id=r2_config["access_key_id"],
+                    aws_secret_access_key=r2_config["secret_access_key"],
+                    config=Config(signature_version="s3v4"),
+                )
+                object_key = f"sadtalker/results/{uuid.uuid4().hex[:12]}.mp4"
+                client.upload_file(
+                    str(final_video), r2_config["bucket_name"], object_key,
+                    ExtraArgs={"ContentType": "video/mp4"},
+                )
+                result["video_url"] = client.generate_presigned_url(
+                    "get_object",
+                    Params={"Bucket": r2_config["bucket_name"], "Key": object_key},
+                    ExpiresIn=7200,
+                )
+                result["r2_key"] = object_key
+            else:
+                result["video_base64"] = base64.b64encode(final_video.read_bytes()).decode("utf-8")
+                print("Warning: Returning video as base64 (use R2 for large files)")
+
+            return result
+
+        except subprocess.TimeoutExpired:
+            return {"error": "SadTalker timed out"}
+        except Exception as e:
+            import traceback
+            print(f"Error: {e}")
+            print(traceback.format_exc())
+            return {"error": f"Internal error: {str(e)}"}
+        finally:
+            shutil.rmtree(work_dir, ignore_errors=True)

--- a/docker/modal-sadtalker/app.py
+++ b/docker/modal-sadtalker/app.py
@@ -101,7 +101,7 @@ image = (
 @app.cls(
     image=image,
     gpu="A10G",
-    timeout=900,
+    timeout=1800,
     scaledown_window=60,
 )
 @modal.concurrent(max_inputs=1)
@@ -256,7 +256,7 @@ class SadTalkerGen:
 
                 proc = subprocess.run(
                     cmd, cwd="/app/SadTalker",
-                    capture_output=True, text=True, timeout=600,
+                    capture_output=True, text=True, timeout=1800,
                 )
 
                 if proc.returncode != 0:

--- a/docker/modal-sadtalker/app.py
+++ b/docker/modal-sadtalker/app.py
@@ -45,8 +45,9 @@ image = (
         "torchaudio==2.1.2+cu118",
         extra_index_url="https://download.pytorch.org/whl/cu118",
     )
+    # Install numpy<2 first (basicsr/gfpgan need it at build time)
+    .pip_install("numpy<2", "Cython")
     .pip_install(
-        "numpy<2",
         "dlib-bin",
         "face_alignment",
         "imageio",
@@ -58,14 +59,10 @@ image = (
         "tqdm",
         "yacs",
         "safetensors",
-        "gfpgan",
-        "basicsr",
-        "facexlib",
-        "realesrgan",
-        "boto3",
-        "requests",
-        "fastapi[standard]",
     )
+    # Install basicsr/gfpgan separately (C extensions need numpy<2 present)
+    .pip_install("basicsr>=1.4.2", "facexlib>=0.3.0", "gfpgan", "realesrgan")
+    .pip_install("boto3", "requests", "fastapi[standard]")
     # Clone SadTalker
     .run_commands("git clone --depth 1 https://github.com/OpenTalker/SadTalker.git /app/SadTalker")
     # Patch numpy 2.0 compat (belt-and-suspenders even with numpy<2 pin)
@@ -86,7 +83,7 @@ image = (
         # BFM fitting models
         f"cd /app/SadTalker/checkpoints && wget -q {SADTALKER_WEIGHTS['bfm']} && unzip -q BFM_Fitting.zip && rm BFM_Fitting.zip",
         # Face detection hub models
-        f"wget -q {SADTALKER_WEIGHTS['hub']} -O /tmp/hub.zip && unzip -q /tmp/hub.zip -d /root/.cache/torch/ && rm /tmp/hub.zip",
+        f"mkdir -p /root/.cache/torch && wget -q {SADTALKER_WEIGHTS['hub']} -O /tmp/hub.zip && unzip -q /tmp/hub.zip -d /root/.cache/torch/ && rm /tmp/hub.zip",
         # GFPGAN weights
         f"mkdir -p /app/SadTalker/gfpgan/weights && wget -q -P /app/SadTalker/gfpgan/weights {SADTALKER_WEIGHTS['gfpgan']}",
         # facexlib detection models

--- a/docker/modal-upscale/app.py
+++ b/docker/modal-upscale/app.py
@@ -1,0 +1,247 @@
+"""
+Modal deployment for Real-ESRGAN image upscaling.
+
+Deploy:
+    modal deploy docker/modal-upscale/app.py
+
+Models:
+    - general: RealESRGAN_x4plus (default, most images)
+    - anime: RealESRGAN_x4plus_anime_6B (illustrations)
+    - photo: realesr-general-x4v3 (alternative general)
+"""
+
+import modal
+
+app = modal.App("video-toolkit-upscale")
+
+WEIGHT_URLS = {
+    "general": "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.0/RealESRGAN_x4plus.pth",
+    "anime": "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.2.4/RealESRGAN_x4plus_anime_6B.pth",
+    "photo": "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.5.0/realesr-general-x4v3.pth",
+}
+
+GFPGAN_URL = "https://github.com/TencentARC/GFPGAN/releases/download/v1.3.0/GFPGANv1.3.pth"
+
+image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .apt_install("libgl1", "libglib2.0-0")
+    .pip_install(
+        "torch==2.1.2",
+        "torchvision==0.16.2",
+        "realesrgan>=0.3.0",
+        "basicsr>=1.4.2",
+        "facexlib>=0.3.0",
+        "gfpgan>=1.3.8",
+        "opencv-python-headless>=4.8.0",
+        "numpy>=1.24.0,<2.0",
+        "Pillow>=10.0.0",
+        "boto3",
+        "requests",
+        "fastapi[standard]",
+    )
+    .run_commands(
+        "mkdir -p /app/weights",
+        f"python -c \"import requests; "
+        f"[open(f'/app/weights/{{k}}.pth', 'wb').write(requests.get(v).content) "
+        f"for k, v in {WEIGHT_URLS!r}.items()]\"",
+    )
+)
+
+
+@app.cls(
+    image=image,
+    gpu="A10G",
+    timeout=300,
+    scaledown_window=60,
+)
+@modal.concurrent(max_inputs=1)
+class Upscaler:
+    @modal.enter()
+    def load_default_model(self):
+        """Pre-load the default general model on container start."""
+        import torch
+        self._upscalers = {}
+        print(f"CUDA available: {torch.cuda.is_available()}")
+        if torch.cuda.is_available():
+            print(f"GPU: {torch.cuda.get_device_name(0)}")
+        # Pre-load default model
+        self._get_upscaler("general", 4, False)
+
+    def _get_upscaler(self, model: str = "general", scale: int = 4, face_enhance: bool = False):
+        """Get or create cached upscaler instance."""
+        cache_key = f"{model}_{scale}_{face_enhance}"
+        if cache_key in self._upscalers:
+            return self._upscalers[cache_key]
+
+        from basicsr.archs.rrdbnet_arch import RRDBNet
+        from realesrgan import RealESRGANer
+
+        weight_files = {
+            "general": "/app/weights/general.pth",
+            "anime": "/app/weights/anime.pth",
+            "photo": "/app/weights/photo.pth",
+        }
+
+        num_block = 6 if model == "anime" else 23
+        net = RRDBNet(num_in_ch=3, num_out_ch=3, num_feat=64, num_block=num_block, num_grow_ch=32, scale=4)
+
+        print(f"Loading model: {model}")
+        upscaler = RealESRGANer(
+            scale=4,
+            model_path=weight_files[model],
+            dni_weight=None,
+            model=net,
+            tile=0,
+            tile_pad=10,
+            pre_pad=0,
+            half=True,
+            gpu_id=0,
+        )
+
+        if face_enhance:
+            from gfpgan import GFPGANer
+            face_enhancer = GFPGANer(
+                model_path=GFPGAN_URL,
+                upscale=scale,
+                arch="clean",
+                channel_multiplier=2,
+                bg_upsampler=upscaler,
+            )
+            self._upscalers[cache_key] = face_enhancer
+            return face_enhancer
+
+        self._upscalers[cache_key] = upscaler
+        return upscaler
+
+    @modal.fastapi_endpoint(method="POST")
+    def upscale(self, request: dict) -> dict:
+        import shutil
+        import tempfile
+        import time
+        import uuid
+        from pathlib import Path
+
+        import cv2
+        import numpy as np
+        import requests as req
+
+        image_url = request.get("image_url")
+        if not image_url:
+            return {"error": "Missing required 'image_url'"}
+
+        scale = request.get("scale", 4)
+        model = request.get("model", "general")
+        face_enhance = request.get("face_enhance", False)
+        output_format = request.get("output_format", "png").lower()
+        r2_config = request.get("r2")
+
+        if scale not in [2, 4]:
+            return {"error": f"Invalid scale: {scale}. Must be 2 or 4"}
+        if model not in ["general", "anime", "photo"]:
+            return {"error": f"Invalid model: {model}"}
+        if output_format not in ["png", "jpg", "jpeg", "webp"]:
+            return {"error": f"Invalid output_format: {output_format}"}
+
+        work_dir = Path(tempfile.mkdtemp(prefix="modal_upscale_"))
+        start_time = time.time()
+
+        try:
+            # Download image
+            print(f"Downloading image from {image_url[:80]}...")
+            resp = req.get(image_url, stream=True, timeout=300)
+            resp.raise_for_status()
+
+            url_path = image_url.split("?")[0]
+            input_ext = Path(url_path).suffix.lower() or ".png"
+            input_path = str(work_dir / f"input{input_ext}")
+
+            with open(input_path, "wb") as f:
+                for chunk in resp.iter_content(chunk_size=8192):
+                    f.write(chunk)
+
+            # Read image
+            img = cv2.imread(input_path, cv2.IMREAD_UNCHANGED)
+            if img is None:
+                return {"error": "Failed to read image file"}
+
+            input_height, input_width = img.shape[:2]
+            print(f"Input: {input_width}x{input_height}")
+
+            # Upscale
+            upscaler = self._get_upscaler(model=model, scale=scale, face_enhance=face_enhance)
+
+            print("Upscaling...")
+            inference_start = time.time()
+
+            if face_enhance:
+                _, _, output = upscaler.enhance(img, has_aligned=False, only_center_face=False, paste_back=True)
+            else:
+                output, _ = upscaler.enhance(img, outscale=scale)
+
+            inference_time = time.time() - inference_start
+            output_height, output_width = output.shape[:2]
+            print(f"Output: {output_width}x{output_height} ({inference_time:.2f}s)")
+
+            # Save output
+            output_ext = "jpg" if output_format == "jpeg" else output_format
+            output_path = str(work_dir / f"output.{output_ext}")
+
+            if output_format in ["jpg", "jpeg"]:
+                cv2.imwrite(output_path, output, [cv2.IMWRITE_JPEG_QUALITY, 95])
+            elif output_format == "webp":
+                cv2.imwrite(output_path, output, [cv2.IMWRITE_WEBP_QUALITY, 95])
+            else:
+                cv2.imwrite(output_path, output, [cv2.IMWRITE_PNG_COMPRESSION, 6])
+
+            elapsed = time.time() - start_time
+
+            result = {
+                "success": True,
+                "input_dimensions": f"{input_width}x{input_height}",
+                "output_dimensions": f"{output_width}x{output_height}",
+                "scale": scale,
+                "model_used": model,
+                "face_enhance": face_enhance,
+                "output_format": output_format,
+                "inference_time_seconds": round(inference_time, 2),
+                "processing_time_seconds": round(elapsed, 2),
+            }
+
+            # Upload to R2 or return base64
+            if r2_config:
+                import boto3
+                from botocore.config import Config
+
+                client = boto3.client(
+                    "s3",
+                    endpoint_url=r2_config["endpoint_url"],
+                    aws_access_key_id=r2_config["access_key_id"],
+                    aws_secret_access_key=r2_config["secret_access_key"],
+                    config=Config(signature_version="s3v4"),
+                )
+                object_key = f"upscale/results/{uuid.uuid4().hex[:12]}.{output_ext}"
+                content_types = {"png": "image/png", "jpg": "image/jpeg", "jpeg": "image/jpeg", "webp": "image/webp"}
+                client.upload_file(
+                    output_path, r2_config["bucket_name"], object_key,
+                    ExtraArgs={"ContentType": content_types.get(output_ext, "application/octet-stream")},
+                )
+                result["output_url"] = client.generate_presigned_url(
+                    "get_object",
+                    Params={"Bucket": r2_config["bucket_name"], "Key": object_key},
+                    ExpiresIn=7200,
+                )
+                result["r2_key"] = object_key
+            else:
+                import base64
+                with open(output_path, "rb") as f:
+                    result["image_base64"] = base64.b64encode(f.read()).decode("utf-8")
+
+            return result
+
+        except Exception as e:
+            import traceback
+            print(f"Error: {e}")
+            print(traceback.format_exc())
+            return {"error": f"Internal error: {str(e)}"}
+        finally:
+            shutil.rmtree(work_dir, ignore_errors=True)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,23 +43,23 @@ No API keys needed. Edit `src/config/sprint-config.ts` to customize content.
    cd claude-code-video-toolkit
    ```
 
-2. **Create environment file**
-   ```bash
-   cp .env.example .env
-   # Edit .env and add keys for the features you want (all optional)
-   ```
-
-3. **Install Python dependencies**
+2. **Install Python dependencies**
    ```bash
    python -m venv .venv
    source .venv/bin/activate  # On Windows: .venv\Scripts\activate
    pip install -r tools/requirements.txt
    ```
 
-4. **Start Claude Code**
+3. **Start Claude Code and run the setup wizard**
    ```bash
    claude
    ```
+   Then type `/setup` — this walks you through configuring cloud GPU, file transfer, and voice in about 5 minutes. Most features are free:
+   - **Cloudflare R2**: Free (10GB storage, zero egress)
+   - **Modal**: $30/month free compute on Starter plan
+   - **Qwen3-TTS**: Free AI voiceovers (runs on your Modal compute)
+
+   Or configure manually: `cp .env.example .env` and edit with your API keys.
 
 ## Your First Video
 
@@ -108,6 +108,7 @@ If you prefer manual setup:
 
 | Command | Description |
 |---------|-------------|
+| `/setup` | First-time setup - cloud GPU, file transfer, voice, prerequisites |
 | `/video` | Video projects - list, resume, or create new |
 | `/scene-review` | Scene-by-scene review in Remotion Studio |
 | `/design` | Focused design refinement session for a scene |

--- a/docs/modal-setup.md
+++ b/docs/modal-setup.md
@@ -1,0 +1,117 @@
+# Modal Cloud GPU Setup
+
+Modal is an alternative cloud GPU provider for the toolkit's AI tools. All cloud GPU tools support both RunPod (`--cloud runpod`) and Modal (`--cloud modal`).
+
+## Why Dual Cloud GPU Support?
+
+We added Modal alongside RunPod after a weekend of RunPod reliability issues (March 2026). Having two providers means:
+
+- **No single point of failure** — if one provider is down, switch to the other with `--cloud modal` or `--cloud runpod`
+- **Faster cold starts** — Modal typically spins up containers faster than RunPod serverless
+- **Scale to zero** — both providers only charge when actively processing (no idle costs)
+- **Same interface** — all tools use `--cloud runpod|modal`, same payloads, same results
+
+RunPod remains the default (`--cloud runpod`) for backward compatibility.
+
+## Cloud GPU Tools
+
+All 7 cloud GPU tools support both providers:
+
+| Tool | Backend | Use Case | Est. Cost (Modal) |
+|------|---------|----------|-------------------|
+| `qwen3_tts` | Qwen3-TTS | AI speech generation | ~$0.005-0.02 |
+| `flux2` | FLUX.2 Klein | AI image generation | ~$0.01-0.03 |
+| `image_edit` | Qwen-Image-Edit | AI image editing, style transfer | ~$0.02-0.05 |
+| `upscale` | RealESRGAN | AI image upscaling (2x/4x) | ~$0.005-0.02 |
+| `music_gen` | ACE-Step 1.5 | AI music generation | ~$0.02-0.10 |
+| `sadtalker` | SadTalker | Talking head video | ~$0.05-0.30 |
+| `dewatermark` | ProPainter | AI video inpainting | ~$0.05-0.50 |
+
+All Modal apps use A10G GPUs (24GB VRAM) and scale to zero when idle.
+
+## Quick Start
+
+```bash
+# 1. Install Modal CLI
+pip install modal
+python3 -m modal setup    # Authenticates with your Modal account
+
+# 2. Deploy the tools you need
+modal deploy docker/modal-qwen3-tts/app.py      # Speech generation
+modal deploy docker/modal-flux2/app.py           # Image generation
+modal deploy docker/modal-image-edit/app.py      # Image editing
+modal deploy docker/modal-upscale/app.py         # Image upscaling
+modal deploy docker/modal-music-gen/app.py       # Music generation
+modal deploy docker/modal-sadtalker/app.py       # Talking head video
+modal deploy docker/modal-propainter/app.py      # Watermark removal
+
+# 3. Save the endpoint URLs to .env (printed after each deploy)
+#    Each deploy prints a URL like:
+#    https://yourname--video-toolkit-upscale-upscaler-upscale.modal.run
+#
+#    Add them to .env:
+echo "MODAL_QWEN3_TTS_ENDPOINT_URL=https://..." >> .env
+echo "MODAL_FLUX2_ENDPOINT_URL=https://..." >> .env
+echo "MODAL_IMAGE_EDIT_ENDPOINT_URL=https://..." >> .env
+echo "MODAL_UPSCALE_ENDPOINT_URL=https://..." >> .env
+echo "MODAL_MUSIC_GEN_ENDPOINT_URL=https://..." >> .env
+echo "MODAL_SADTALKER_ENDPOINT_URL=https://..." >> .env
+echo "MODAL_DEWATERMARK_ENDPOINT_URL=https://..." >> .env
+
+# 4. Use any tool with --cloud modal
+python3 tools/image_edit.py --input photo.jpg --style cyberpunk --cloud modal
+python3 tools/upscale.py --input photo.jpg --output photo_4x.png --cloud modal
+python3 tools/music_gen.py --preset corporate-bg --duration 30 --output bg.mp3 --cloud modal
+```
+
+## Cold Starts
+
+First request after idle will trigger a cold start while Modal loads the model:
+
+| Tool | Cold Start | Warm Request |
+|------|-----------|--------------|
+| `qwen3_tts` | ~60-90s | ~5-15s |
+| `flux2` | ~25-30s | ~1-3s |
+| `image_edit` | ~5-8min | ~15-20s |
+| `upscale` | ~25-30s | ~3-5s |
+| `music_gen` | ~60-90s | ~10-30s |
+| `sadtalker` | ~45-60s | ~30-60s |
+| `dewatermark` | ~30-45s | varies by video length |
+
+After 60 seconds of no requests, containers scale back to zero. No charges while idle.
+
+## Monitoring & Billing
+
+```bash
+# Check what's running (Tasks column should be 0 when idle)
+modal app list
+
+# Check today's spend
+modal billing report --for today --json
+
+# View container logs
+modal app logs video-toolkit-upscale
+```
+
+## Architecture
+
+Each tool has its own Modal app (`docker/modal-*/app.py`), deployed independently:
+
+- **One app per tool** — independent scaling, GPU assignment, and lifecycle
+- **Web endpoints** — HTTP POST via `@modal.fastapi_endpoint`, no `modal` pip dependency needed on the client
+- **Same payload format** — tools send `{"input": {...}}` to both RunPod and Modal
+- **R2 file transfer** — large results upload to Cloudflare R2 (if configured), otherwise base64
+- **Scale to zero** — `scaledown_window=60` means containers shut down after 1 minute idle
+
+The client-side abstraction lives in `tools/cloud_gpu.py`, which routes `call_cloud_endpoint()` to either `_call_runpod()` (submit + poll) or `_call_modal()` (synchronous POST).
+
+## Differences from RunPod
+
+| Aspect | RunPod | Modal |
+|--------|--------|-------|
+| Setup | `--setup` flag (automated GraphQL) | `modal deploy` (manual) |
+| Invocation | Async submit + poll | Synchronous HTTP POST |
+| Cold start | Slower (Docker pull) | Faster (cached layers) |
+| GPU selection | Per-endpoint config | Per-app in `app.py` |
+| Auth | `RUNPOD_API_KEY` | `MODAL_TOKEN_ID` + `MODAL_TOKEN_SECRET` (optional for web endpoints) |
+| Default | Yes (`--cloud runpod`) | Opt-in (`--cloud modal`) |

--- a/docs/modal-setup.md
+++ b/docs/modal-setup.md
@@ -1,24 +1,115 @@
 # Modal Cloud GPU Setup
 
-Modal is an alternative cloud GPU provider for the toolkit's AI tools. All cloud GPU tools support both RunPod (`--cloud runpod`) and Modal (`--cloud modal`).
+Modal is the recommended cloud GPU provider for the toolkit's AI tools. It offers $30/month free compute on the Starter plan, fast cold starts, and scale-to-zero billing.
 
-## Why Dual Cloud GPU Support?
+> **Fastest path:** Run `/setup` in Claude Code — it handles Modal installation, deployment, and `.env` configuration interactively. This doc is the reference for what `/setup` does under the hood, and for manual setup.
 
-We added Modal alongside RunPod after a weekend of RunPod reliability issues (March 2026). Having two providers means:
+## Create a Modal Account
 
-- **No single point of failure** — if one provider is down, switch to the other with `--cloud modal` or `--cloud runpod`
-- **Faster cold starts** — Modal typically spins up containers faster than RunPod serverless
-- **Scale to zero** — both providers only charge when actively processing (no idle costs)
-- **Same interface** — all tools use `--cloud runpod|modal`, same payloads, same results
+1. Go to [modal.com](https://modal.com/) and sign up
+2. Choose the **Starter plan** — $30/month free compute, just requires a payment method
+3. Typical toolkit usage is $1-2/month, well within the free allowance
+4. All apps scale to zero — no charges when idle
 
-RunPod remains the default (`--cloud runpod`) for backward compatibility.
+## Install & Authenticate
 
-## Cloud GPU Tools
+```bash
+pip install modal
+python3 -m modal setup    # Opens browser to authenticate, saves token to ~/.modal.toml
+modal app list             # Verify it works
+```
 
-All 7 cloud GPU tools support both providers:
+## Deploy Tools
 
-| Tool | Backend | Use Case | Est. Cost (Modal) |
-|------|---------|----------|-------------------|
+Each AI tool has its own Modal app. Deploy only what you need, or deploy all of them — idle apps cost nothing.
+
+```bash
+# Speech generation (most commonly used)
+modal deploy docker/modal-qwen3-tts/app.py
+
+# Image generation & editing
+modal deploy docker/modal-flux2/app.py
+modal deploy docker/modal-image-edit/app.py
+modal deploy docker/modal-upscale/app.py
+
+# Music generation
+modal deploy docker/modal-music-gen/app.py
+
+# Video processing
+modal deploy docker/modal-sadtalker/app.py
+modal deploy docker/modal-propainter/app.py
+```
+
+Each deploy prints an endpoint URL like:
+```
+https://yourname--video-toolkit-qwen3-tts-ttsengine-generate.modal.run
+```
+
+Save each URL to your `.env` file:
+
+```bash
+# Add to .env (replace with your actual URLs from deploy output)
+MODAL_QWEN3_TTS_ENDPOINT_URL=https://yourname--video-toolkit-qwen3-tts-...modal.run
+MODAL_FLUX2_ENDPOINT_URL=https://yourname--video-toolkit-flux2-...modal.run
+MODAL_IMAGE_EDIT_ENDPOINT_URL=https://yourname--video-toolkit-image-edit-...modal.run
+MODAL_UPSCALE_ENDPOINT_URL=https://yourname--video-toolkit-upscale-...modal.run
+MODAL_MUSIC_GEN_ENDPOINT_URL=https://yourname--video-toolkit-music-gen-...modal.run
+MODAL_SADTALKER_ENDPOINT_URL=https://yourname--video-toolkit-sadtalker-...modal.run
+MODAL_DEWATERMARK_ENDPOINT_URL=https://yourname--video-toolkit-dewatermark-...modal.run
+```
+
+> **Tip:** `/setup` automates this — it runs each deploy, parses the URL, and writes it to `.env` for you.
+
+## Cloudflare R2 (Recommended)
+
+R2 is free file storage that bridges your local machine and cloud GPUs. Without it, tools fall back to free upload services (slower, less reliable).
+
+**R2 free tier:** 10GB storage, 10 million operations/month, zero egress fees.
+
+See the R2 section in `/setup`, or configure manually:
+
+1. Sign up at [dash.cloudflare.com](https://dash.cloudflare.com/)
+2. Go to R2 Object Storage → Create bucket (name it `video-toolkit`)
+3. Create an API token: R2 → Manage R2 API Tokens → Object Read & Write
+4. Add to `.env`:
+   ```
+   R2_ACCOUNT_ID=your_account_id
+   R2_ACCESS_KEY_ID=your_access_key_id
+   R2_SECRET_ACCESS_KEY=your_secret_access_key
+   R2_BUCKET_NAME=video-toolkit
+   ```
+
+## Use the Tools
+
+All cloud GPU tools accept `--cloud modal`:
+
+```bash
+# AI voiceover
+python3 tools/qwen3_tts.py --text "Hello world" --speaker Ryan --output hello.mp3 --cloud modal
+
+# AI image generation
+python3 tools/flux2.py --prompt "A sunset over mountains" --output sunset.png --cloud modal
+
+# AI image editing
+python3 tools/image_edit.py --input photo.jpg --style cyberpunk --cloud modal
+
+# AI upscaling
+python3 tools/upscale.py --input photo.jpg --output photo_4x.png --cloud modal
+
+# AI music generation
+python3 tools/music_gen.py --preset corporate-bg --duration 60 --output bg.mp3 --cloud modal
+
+# Talking head from portrait + audio
+python3 tools/sadtalker.py --image portrait.png --audio voiceover.mp3 --output talking.mp4 --cloud modal
+
+# Watermark removal
+python3 tools/dewatermark.py --input video.mp4 --region 1080,660,195,40 --output clean.mp4 --cloud modal
+```
+
+## Tools & Costs
+
+| Tool | Backend | Use Case | Est. Cost |
+|------|---------|----------|-----------|
 | `qwen3_tts` | Qwen3-TTS | AI speech generation | ~$0.005-0.02 |
 | `flux2` | FLUX.2 Klein | AI image generation | ~$0.01-0.03 |
 | `image_edit` | Qwen-Image-Edit | AI image editing, style transfer | ~$0.02-0.05 |
@@ -27,46 +118,11 @@ All 7 cloud GPU tools support both providers:
 | `sadtalker` | SadTalker | Talking head video | ~$0.05-0.30 |
 | `dewatermark` | ProPainter | AI video inpainting | ~$0.05-0.50 |
 
-All Modal apps use A10G GPUs (24GB VRAM) and scale to zero when idle.
-
-## Quick Start
-
-```bash
-# 1. Install Modal CLI
-pip install modal
-python3 -m modal setup    # Authenticates with your Modal account
-
-# 2. Deploy the tools you need
-modal deploy docker/modal-qwen3-tts/app.py      # Speech generation
-modal deploy docker/modal-flux2/app.py           # Image generation
-modal deploy docker/modal-image-edit/app.py      # Image editing
-modal deploy docker/modal-upscale/app.py         # Image upscaling
-modal deploy docker/modal-music-gen/app.py       # Music generation
-modal deploy docker/modal-sadtalker/app.py       # Talking head video
-modal deploy docker/modal-propainter/app.py      # Watermark removal
-
-# 3. Save the endpoint URLs to .env (printed after each deploy)
-#    Each deploy prints a URL like:
-#    https://yourname--video-toolkit-upscale-upscaler-upscale.modal.run
-#
-#    Add them to .env:
-echo "MODAL_QWEN3_TTS_ENDPOINT_URL=https://..." >> .env
-echo "MODAL_FLUX2_ENDPOINT_URL=https://..." >> .env
-echo "MODAL_IMAGE_EDIT_ENDPOINT_URL=https://..." >> .env
-echo "MODAL_UPSCALE_ENDPOINT_URL=https://..." >> .env
-echo "MODAL_MUSIC_GEN_ENDPOINT_URL=https://..." >> .env
-echo "MODAL_SADTALKER_ENDPOINT_URL=https://..." >> .env
-echo "MODAL_DEWATERMARK_ENDPOINT_URL=https://..." >> .env
-
-# 4. Use any tool with --cloud modal
-python3 tools/image_edit.py --input photo.jpg --style cyberpunk --cloud modal
-python3 tools/upscale.py --input photo.jpg --output photo_4x.png --cloud modal
-python3 tools/music_gen.py --preset corporate-bg --duration 30 --output bg.mp3 --cloud modal
-```
+All apps use A10G GPUs (24GB VRAM) except `image_edit` which uses A100 for its 25GB model.
 
 ## Cold Starts
 
-First request after idle will trigger a cold start while Modal loads the model:
+First request after idle triggers a cold start while Modal loads the model:
 
 | Tool | Cold Start | Warm Request |
 |------|-----------|--------------|
@@ -76,7 +132,7 @@ First request after idle will trigger a cold start while Modal loads the model:
 | `upscale` | ~25-30s | ~3-5s |
 | `music_gen` | ~60-90s | ~10-30s |
 | `sadtalker` | ~45-60s | ~30-60s |
-| `dewatermark` | ~30-45s | varies by video length |
+| `dewatermark` | ~60-70s | varies by video length |
 
 After 60 seconds of no requests, containers scale back to zero. No charges while idle.
 
@@ -91,6 +147,9 @@ modal billing report --for today --json
 
 # View container logs
 modal app logs video-toolkit-upscale
+
+# Verify your setup
+python3 tools/verify_setup.py
 ```
 
 ## Architecture
@@ -99,19 +158,21 @@ Each tool has its own Modal app (`docker/modal-*/app.py`), deployed independentl
 
 - **One app per tool** — independent scaling, GPU assignment, and lifecycle
 - **Web endpoints** — HTTP POST via `@modal.fastapi_endpoint`, no `modal` pip dependency needed on the client
-- **Same payload format** — tools send `{"input": {...}}` to both RunPod and Modal
 - **R2 file transfer** — large results upload to Cloudflare R2 (if configured), otherwise base64
 - **Scale to zero** — `scaledown_window=60` means containers shut down after 1 minute idle
 
 The client-side abstraction lives in `tools/cloud_gpu.py`, which routes `call_cloud_endpoint()` to either `_call_runpod()` (submit + poll) or `_call_modal()` (synchronous POST).
 
-## Differences from RunPod
+## RunPod (Alternative)
 
-| Aspect | RunPod | Modal |
-|--------|--------|-------|
-| Setup | `--setup` flag (automated GraphQL) | `modal deploy` (manual) |
-| Invocation | Async submit + poll | Synchronous HTTP POST |
-| Cold start | Slower (Docker pull) | Faster (cached layers) |
-| GPU selection | Per-endpoint config | Per-app in `app.py` |
-| Auth | `RUNPOD_API_KEY` | `MODAL_TOKEN_ID` + `MODAL_TOKEN_SECRET` (optional for web endpoints) |
-| Default | Yes (`--cloud runpod`) | Opt-in (`--cloud modal`) |
+RunPod is also supported as a fallback provider. Use `--cloud runpod` on any tool.
+
+| Aspect | Modal | RunPod |
+|--------|-------|--------|
+| **Free tier** | $30/mo compute | None (pay-as-you-go) |
+| **Setup** | `modal deploy` | `--setup` flag per tool |
+| **Cold start** | Faster (cached layers) | Slower (Docker pull) |
+| **Invocation** | Synchronous POST | Async submit + poll |
+| **Auth** | Token optional for web endpoints | `RUNPOD_API_KEY` required |
+
+See [runpod-setup.md](runpod-setup.md) for RunPod-specific instructions.

--- a/lib/transitions/index.ts
+++ b/lib/transitions/index.ts
@@ -46,15 +46,17 @@ export type { PixelateProps } from './presentations/pixelate';
 export { checkerboard } from './presentations/checkerboard';
 export type { CheckerboardProps, CheckerboardPattern } from './presentations/checkerboard';
 
-// Re-export official transitions for convenience
-export { slide } from '@remotion/transitions/slide';
-export { fade } from '@remotion/transitions/fade';
-export { wipe } from '@remotion/transitions/wipe';
-export { flip } from '@remotion/transitions/flip';
+// Official transitions (slide, fade, wipe, flip) and timing functions
+// (linearTiming, springTiming, TransitionSeries) should be imported directly
+// from '@remotion/transitions' in your project — not re-exported from here.
+// This avoids module resolution issues when lib/ is outside node_modules scope.
+//
+// Example:
+//   import { TransitionSeries, linearTiming } from '@remotion/transitions';
+//   import { fade } from '@remotion/transitions/fade';
+//   import { glitch, lightLeak } from '../../../lib/transitions';
 
-// Re-export timing functions
-export { linearTiming, springTiming, TransitionSeries } from '@remotion/transitions';
-
-// Gallery/showcase components
-export { TransitionGallery, transitionGalleryConfig, SingleTransitionPreview, transitionMap } from './TransitionGallery';
-export type { TransitionName } from './TransitionGallery';
+// Gallery/showcase components — import directly from './TransitionGallery'
+// in the showcase project. Not re-exported here to avoid pulling in
+// @remotion/transitions at barrel import time.
+// Usage: import { TransitionGallery } from '../../../lib/transitions/TransitionGallery';

--- a/skills/openclaw-video-toolkit/SKILL.md
+++ b/skills/openclaw-video-toolkit/SKILL.md
@@ -3,85 +3,85 @@ name: video_toolkit
 description: Create professional videos autonomously using claude-code-video-toolkit — AI voiceovers, image generation, music, talking heads, and Remotion rendering.
 metadata:
   openclaw:
+    emoji: "🎬"
+    skillKey: "video-toolkit"
     os: ["darwin", "linux"]
     requires:
       bins: ["node", "python3", "ffmpeg", "npm"]
 ---
 
-# Video Toolkit — OpenClaw Skill
+# Video Toolkit
 
-> **Status: Alpha.** This skill is designed for [OpenClaw](https://docs.openclaw.ai) and is experimental. It provides autonomous video creation using the [claude-code-video-toolkit](https://github.com/digitalsamba/claude-code-video-toolkit). Expect rough edges — contributions and feedback welcome.
+Create professional explainer videos from a text brief. The toolkit uses open-source AI models on cloud GPUs (Modal or RunPod) for voiceover, image generation, music, and talking head animation. Remotion (React) handles composition and rendering.
 
-Create professional explainer videos from a text brief. The toolkit uses open-source AI models running on cloud GPUs (Modal) for voiceover, image generation, music, and talking head animation. Remotion (React) handles composition and rendering.
+## CRITICAL: Toolkit Path
 
-## Setup (First Run)
-
-Run the verification script to check current state:
+The toolkit lives at a fixed path. **ALWAYS `cd` here before running any tool command.**
 
 ```bash
-python3 tools/verify_setup.py --json
+TOOLKIT=~/.openclaw/workspace/claude-code-video-toolkit
+cd $TOOLKIT
 ```
 
-If `summary.cloud_gpu` is false, you need to set up Modal. This is a one-time process.
+**NEVER run tool commands from inside a project directory.** Tools resolve paths relative to the toolkit root.
 
-### Install Modal CLI
+## Setup
+
+### Step 1: Check Current State
 
 ```bash
-pip3 install modal
+cd ~/.openclaw/workspace/claude-code-video-toolkit
+python3 tools/verify_setup.py
+```
+
+If everything shows `[x]`, skip to "Quick Test" below. Otherwise continue setup.
+
+### Step 2: Install Python Dependencies
+
+```bash
+cd ~/.openclaw/workspace/claude-code-video-toolkit
+pip3 install --break-system-packages -r tools/requirements.txt
+```
+
+Note: `--break-system-packages` is needed on Debian/Ubuntu with managed Python (PEP 668). Safe inside containers.
+
+### Step 3: Configure Cloud GPU Endpoints
+
+The toolkit needs cloud GPU endpoint URLs in `.env`. Check if `.env` exists and has Modal endpoints:
+
+```bash
+cat ~/.openclaw/workspace/claude-code-video-toolkit/.env | grep MODAL
+```
+
+If Modal endpoints are configured, you're ready. If not, **ask the user to provide Modal endpoint URLs** or set up Modal:
+
+```bash
+pip3 install --break-system-packages modal
 python3 -m modal setup   # Opens browser for authentication
+
+# Deploy each tool — capture the endpoint URL from output
+cd ~/.openclaw/workspace/claude-code-video-toolkit
+modal deploy docker/modal-qwen3-tts/app.py
+modal deploy docker/modal-flux2/app.py
+modal deploy docker/modal-music-gen/app.py
+modal deploy docker/modal-sadtalker/app.py
+modal deploy docker/modal-image-edit/app.py
+modal deploy docker/modal-upscale/app.py
+modal deploy docker/modal-propainter/app.py
 ```
 
-### Install Python Dependencies
-
-```bash
-pip3 install -r tools/requirements.txt
+Add each URL to `.env`:
+```
+MODAL_QWEN3_TTS_ENDPOINT_URL=https://...modal.run
+MODAL_FLUX2_ENDPOINT_URL=https://...modal.run
+MODAL_MUSIC_GEN_ENDPOINT_URL=https://...modal.run
+MODAL_SADTALKER_ENDPOINT_URL=https://...modal.run
+MODAL_IMAGE_EDIT_ENDPOINT_URL=https://...modal.run
+MODAL_UPSCALE_ENDPOINT_URL=https://...modal.run
+MODAL_DEWATERMARK_ENDPOINT_URL=https://...modal.run
 ```
 
-### Deploy Tools to Modal
-
-Each tool is a separate Modal app. Deploy them and capture the endpoint URLs:
-
-```bash
-# Deploy each tool — the output contains the endpoint URL
-# Look for the line: "Created web endpoint for ... => https://...modal.run"
-
-modal deploy docker/modal-qwen3-tts/app.py    # Speech (most important)
-modal deploy docker/modal-flux2/app.py         # Image generation
-modal deploy docker/modal-music-gen/app.py     # Background music
-modal deploy docker/modal-sadtalker/app.py     # Talking head narrator
-modal deploy docker/modal-image-edit/app.py    # Image editing
-modal deploy docker/modal-upscale/app.py       # Image upscaling
-modal deploy docker/modal-propainter/app.py    # Watermark removal
-```
-
-After each deploy, Modal prints a URL like:
-```
-https://username--video-toolkit-flux2-flux2-generate.modal.run
-```
-
-### Save Endpoint URLs to .env
-
-Create or update `.env` in the toolkit root with the URLs from each deploy:
-
-```bash
-# Create .env if it doesn't exist
-touch .env
-
-# Add each endpoint URL (replace with actual URLs from deploy output)
-echo 'MODAL_QWEN3_TTS_ENDPOINT_URL=https://username--video-toolkit-qwen3-tts-ttsengine-generate.modal.run' >> .env
-echo 'MODAL_FLUX2_ENDPOINT_URL=https://username--video-toolkit-flux2-flux2-generate.modal.run' >> .env
-echo 'MODAL_MUSIC_GEN_ENDPOINT_URL=https://username--video-toolkit-music-gen-musicgen-generate.modal.run' >> .env
-echo 'MODAL_SADTALKER_ENDPOINT_URL=https://username--video-toolkit-sadtalker-sadtalkergen-generate.modal.run' >> .env
-echo 'MODAL_IMAGE_EDIT_ENDPOINT_URL=https://username--video-toolkit-image-edit-qwenedit-edit.modal.run' >> .env
-echo 'MODAL_UPSCALE_ENDPOINT_URL=https://username--video-toolkit-upscale-upscaler-upscale.modal.run' >> .env
-echo 'MODAL_DEWATERMARK_ENDPOINT_URL=https://username--video-toolkit-dewatermark-dewatermark-dewatermark.modal.run' >> .env
-```
-
-### Optional: Cloudflare R2 (Recommended)
-
-R2 provides reliable file transfer between your machine and cloud GPUs. Free tier: 10GB storage, zero egress. Without it, tools fall back to free upload services (slower, less reliable).
-
-If the user has R2 credentials, add to `.env`:
+Optional but recommended — Cloudflare R2 for reliable file transfer:
 ```
 R2_ACCOUNT_ID=...
 R2_ACCESS_KEY_ID=...
@@ -89,33 +89,44 @@ R2_SECRET_ACCESS_KEY=...
 R2_BUCKET_NAME=video-toolkit
 ```
 
-### Verify Setup
-
-Run verification again to confirm everything is configured:
+### Step 4: Verify and Quick Test
 
 ```bash
+cd ~/.openclaw/workspace/claude-code-video-toolkit
 python3 tools/verify_setup.py
 ```
 
-All tools should show as configured. Modal apps scale to zero when idle — no ongoing cost.
+All tools should show `[x]`. Then run a quick test to confirm the GPU pipeline works:
 
-**Cost:** Modal Starter plan includes $30/month free compute. A typical 60s video costs $1-3 to produce.
+```bash
+cd ~/.openclaw/workspace/claude-code-video-toolkit
+python3 tools/qwen3_tts.py --text "Hello, this is a test." --speaker Ryan --tone warm --output /tmp/video-toolkit-test.mp3 --cloud modal
+```
 
-## End-to-End Workflow
+If you get a valid .mp3 file, setup is complete. If it fails, check:
+- `.env` has the correct `MODAL_QWEN3_TTS_ENDPOINT_URL`
+- Run `python3 tools/verify_setup.py --json` and check `modal_tools` for which endpoints are missing
+
+**Cost:** Modal includes $30/month free compute. A typical 60s video costs $1-3.
+
+---
+
+## Creating a Video
 
 ### Step 1: Create Project
 
 ```bash
-cp -r templates/product-demo projects/{project-name}
-cd projects/{project-name}
+cd ~/.openclaw/workspace/claude-code-video-toolkit
+cp -r templates/product-demo projects/PROJECT_NAME
+cd projects/PROJECT_NAME
 npm install
 ```
 
-Templates available: `product-demo` (marketing/explainer), `sprint-review` (sprint demos), `sprint-review-v2` (composable scenes).
+Templates: `product-demo` (marketing/explainer), `sprint-review`, `sprint-review-v2` (composable scenes).
 
-### Step 2: Write the Config
+### Step 2: Write Config
 
-Edit `src/config/demo-config.ts`. The config drives everything:
+Edit `projects/PROJECT_NAME/src/config/demo-config.ts`:
 
 ```typescript
 export const demoConfig: ProductDemoConfig = {
@@ -126,10 +137,10 @@ export const demoConfig: ProductDemoConfig = {
   },
   scenes: [
     { type: 'title', durationSeconds: 9, content: { headline: '...', subheadline: '...' } },
-    { type: 'problem', durationSeconds: 14, content: { headline: '...', problems: [...] } },
-    { type: 'solution', durationSeconds: 13, content: { headline: '...', highlights: [...] } },
-    { type: 'stats', durationSeconds: 12, content: { stats: [...] } },
-    { type: 'cta', durationSeconds: 10, content: { headline: '...', links: [...] } },
+    { type: 'problem', durationSeconds: 14, content: { headline: '...', problems: ['...', '...'] } },
+    { type: 'solution', durationSeconds: 13, content: { headline: '...', highlights: ['...', '...'] } },
+    { type: 'stats', durationSeconds: 12, content: { stats: [{value: '99%', label: '...'}, ...] } },
+    { type: 'cta', durationSeconds: 10, content: { headline: '...', links: ['...'] } },
   ],
   audio: {
     backgroundMusicFile: 'audio/bg-music.mp3',
@@ -140,183 +151,205 @@ export const demoConfig: ProductDemoConfig = {
 
 Scene types: `title`, `problem`, `solution`, `demo`, `feature`, `stats`, `cta`.
 
-**Duration rule:** Set `durationSeconds` to `ceil(voiceover_duration + 2)`. You won't know the exact voiceover duration until Step 4, so estimate at ~2.5 words/second, then adjust after generating audio.
+**Duration rule:** Estimate `durationSeconds` as `ceil(word_count / 2.5) + 2`. You will adjust this after generating audio in Step 4.
 
-### Step 3: Write the Voiceover Script
+### Step 3: Write Voiceover Script
 
-Create `VOICEOVER-SCRIPT.md` with one section per scene:
+Create `projects/PROJECT_NAME/VOICEOVER-SCRIPT.md`:
 
 ```markdown
-## Scene 1: Title (9s, ~15 words)
-Build videos with AI. This is the product name toolkit.
+## Scene 1: Title (9s, ~17 words)
+Build videos with AI. The product name toolkit makes it easy.
 
 ## Scene 2: Problem (14s, ~30 words)
 The problem statement goes here. Keep it punchy and relatable.
 ```
 
-**Word budget:** `(durationSeconds - 2) * 2.5` words per scene. The -2 accounts for the 1s audio delay and 1s padding.
+**Word budget per scene:** `(durationSeconds - 2) * 2.5` words. The -2 accounts for 1s audio delay + 1s padding.
 
 ### Step 4: Generate Assets
 
-**All tool commands must be run from the toolkit root directory** (not from inside the project). This is critical.
+**CRITICAL: All commands below MUST be run from the toolkit root, not the project directory.**
 
 ```bash
-cd /path/to/claude-code-video-toolkit
+cd ~/.openclaw/workspace/claude-code-video-toolkit
 ```
 
-#### 4a. Background Music (ACE-Step)
+#### 4a. Background Music
 
 ```bash
-python3 tools/music_gen.py --preset corporate-bg --duration 90 --output projects/{name}/public/audio/bg-music.mp3 --cloud modal
+cd ~/.openclaw/workspace/claude-code-video-toolkit
+python3 tools/music_gen.py \
+  --preset corporate-bg \
+  --duration 90 \
+  --output projects/PROJECT_NAME/public/audio/bg-music.mp3 \
+  --cloud modal
 ```
 
 Presets: `corporate-bg`, `upbeat-tech`, `ambient`, `dramatic`, `tension`, `hopeful`, `cta`, `lofi`.
 
-#### 4b. Voiceover (Qwen3-TTS)
+#### 4b. Voiceover (per-scene)
 
-Generate per-scene audio files:
+Generate ONE .mp3 file PER SCENE. Do NOT generate a single voiceover file.
 
 ```bash
-# For each scene:
+cd ~/.openclaw/workspace/claude-code-video-toolkit
+
+# Scene 01
 python3 tools/qwen3_tts.py \
-  --text "The voiceover text for this scene" \
-  --speaker Ryan \
-  --tone warm \
-  --output projects/{name}/public/audio/scenes/01.mp3 \
+  --text "The voiceover text for scene one." \
+  --speaker Ryan --tone warm \
+  --output projects/PROJECT_NAME/public/audio/scenes/01.mp3 \
   --cloud modal
+
+# Scene 02
+python3 tools/qwen3_tts.py \
+  --text "The voiceover text for scene two." \
+  --speaker Ryan --tone warm \
+  --output projects/PROJECT_NAME/public/audio/scenes/02.mp3 \
+  --cloud modal
+
+# ... repeat for each scene
 ```
 
-Speakers: `Ryan`, `Aiden`, `Vivian`, `Luna`, `Aurora`, `Aria`, `Nova`, `Stella`, `Orion`.
-Tones: `neutral`, `warm`, `professional`, `excited`, `calm`, `serious`.
+**Speakers:** `Ryan`, `Aiden`, `Vivian`, `Serena`, `Uncle_Fu`, `Dylan`, `Eric`, `Ono_Anna`, `Sohee`
+**Tones:** `neutral`, `warm`, `professional`, `excited`, `calm`, `serious`, `storyteller`, `tutorial`
 
-For voice cloning (if the user has a reference recording):
+For voice cloning (needs a reference recording):
 ```bash
+cd ~/.openclaw/workspace/claude-code-video-toolkit
 python3 tools/qwen3_tts.py \
-  --text "..." \
+  --text "Text to speak" \
   --ref-audio assets/voices/reference.m4a \
-  --ref-text "Transcript of the reference audio" \
-  --output projects/{name}/public/audio/scenes/01.mp3 \
+  --ref-text "Exact transcript of the reference audio" \
+  --output projects/PROJECT_NAME/public/audio/scenes/01.mp3 \
   --cloud modal
 ```
 
-#### 4c. Scene Images (FLUX.2)
-
-Generate background images for key scenes:
+#### 4c. Scene Images
 
 ```bash
+cd ~/.openclaw/workspace/claude-code-video-toolkit
 python3 tools/flux2.py \
   --prompt "Dark tech background with blue geometric grid, cinematic lighting" \
   --width 1920 --height 1080 \
-  --output projects/{name}/public/images/title-bg.png \
+  --output projects/PROJECT_NAME/public/images/title-bg.png \
   --cloud modal
 ```
 
-#### 4d. Presenter Portrait + Talking Head (FLUX.2 + SadTalker)
-
-Generate a presenter portrait, then animate it with SadTalker for narrator PiP:
+Image presets (use `--preset` instead of `--prompt --width --height`):
+`title-bg`, `problem`, `solution`, `demo-bg`, `stats-bg`, `cta`, `thumbnail`, `portrait-bg`
 
 ```bash
-# Generate portrait
+cd ~/.openclaw/workspace/claude-code-video-toolkit
+python3 tools/flux2.py \
+  --preset title-bg \
+  --output projects/PROJECT_NAME/public/images/title-bg.png \
+  --cloud modal
+```
+
+#### 4d. Talking Head Narrator (optional)
+
+Generate a presenter portrait, then animate per-scene clips:
+
+```bash
+cd ~/.openclaw/workspace/claude-code-video-toolkit
+
+# 1. Generate portrait
 python3 tools/flux2.py \
   --prompt "Professional presenter portrait, clean style, dark background, facing camera, upper body" \
   --width 1024 --height 576 \
-  --output /tmp/presenter.png \
+  --output projects/PROJECT_NAME/public/images/presenter.png \
   --cloud modal
 
-# Generate per-scene narrator clips (NOT one big file — keep them short)
+# 2. Generate per-scene narrator clips (one per scene, NOT one long video)
 python3 tools/sadtalker.py \
-  --image /tmp/presenter.png \
-  --audio projects/{name}/public/audio/scenes/01.mp3 \
+  --image projects/PROJECT_NAME/public/images/presenter.png \
+  --audio projects/PROJECT_NAME/public/audio/scenes/01.mp3 \
   --preprocess full --still --expression-scale 0.8 \
-  --output projects/{name}/public/narrator-01.mp4 \
+  --output projects/PROJECT_NAME/public/narrator-01.mp4 \
   --cloud modal
+
+# Repeat for each scene that needs a narrator
 ```
 
-**Critical SadTalker notes:**
-- Always use `--preprocess full` (preserves dimensions, default `crop` outputs square)
-- Always use `--still` for professional look (reduces head movement)
-- Generate per-scene clips (6-15s each), NOT one long video
-- Processing time is ~3-4 min per 10s of audio on Modal A10G
-- The `--expression-scale 0.8` keeps expressions subtle
+**SadTalker rules — follow these exactly:**
+- **ALWAYS** use `--preprocess full` (default `crop` outputs a square, wrong aspect ratio)
+- **ALWAYS** use `--still` (reduces head movement, looks professional)
+- **ALWAYS** generate per-scene clips (6-15s each), NEVER one long video
+- Processing: ~3-4 min per 10s of audio on Modal A10G
+- `--expression-scale 0.8` keeps expressions subtle (range 0.0-1.5)
 
-#### 4e. Image Editing (Qwen-Edit) — optional
+#### 4e. Image Editing (optional)
 
 Create scene variants from existing images:
 
 ```bash
+cd ~/.openclaw/workspace/claude-code-video-toolkit
 python3 tools/image_edit.py \
-  --input projects/{name}/public/images/title-bg.png \
+  --input projects/PROJECT_NAME/public/images/title-bg.png \
   --prompt "Make it darker with red tones, more ominous" \
-  --output projects/{name}/public/images/problem-bg.png \
+  --output projects/PROJECT_NAME/public/images/problem-bg.png \
   --cloud modal
 ```
 
-#### 4f. Upscaling (RealESRGAN) — optional
-
-Upscale images for HD quality:
+#### 4f. Upscaling (optional)
 
 ```bash
+cd ~/.openclaw/workspace/claude-code-video-toolkit
 python3 tools/upscale.py \
-  --input image.png --output image-4x.png --scale 4 --cloud modal
+  --input projects/PROJECT_NAME/public/images/some-image.png \
+  --output projects/PROJECT_NAME/public/images/some-image-4x.png \
+  --scale 4 --cloud modal
 ```
 
 ### Step 5: Sync Timing
 
-After generating voiceover, check actual durations and update config:
+**ALWAYS do this after generating voiceover.** Audio duration differs from estimates.
 
 ```bash
-# Check each audio file duration
-for f in projects/{name}/public/audio/scenes/*.mp3; do
+cd ~/.openclaw/workspace/claude-code-video-toolkit
+for f in projects/PROJECT_NAME/public/audio/scenes/*.mp3; do
   echo "$(basename $f): $(ffprobe -v error -show_entries format=duration -of csv=p=0 "$f")s"
 done
 ```
 
-Update each scene's `durationSeconds` in `demo-config.ts` to: `ceil(audio_duration + 2)`.
+Update each scene's `durationSeconds` in `demo-config.ts` to: `ceil(actual_audio_duration + 2)`.
 
-### Step 6: Review
+Example: if `01.mp3` is 6.8s, set scene 1 `durationSeconds` to `9` (ceil(6.8 + 2) = 9).
 
-Render still frames at scene midpoints and inspect visually:
+### Step 6: Review Still Frames
 
 ```bash
-cd projects/{name}
-npx remotion still src/index.ts ProductDemo --frame=100 --output=/tmp/review-title.png
-npx remotion still src/index.ts ProductDemo --frame=400 --output=/tmp/review-problem.png
-# ... etc for each scene
+cd ~/.openclaw/workspace/claude-code-video-toolkit/projects/PROJECT_NAME
+npx remotion still src/index.ts ProductDemo --frame=100 --output=/tmp/review-scene1.png
+npx remotion still src/index.ts ProductDemo --frame=400 --output=/tmp/review-scene2.png
 ```
 
-Check for:
-- Text truncation or overflow
-- Animation timing (are all elements visible?)
-- Narrator PiP positioning
-- Background image opacity/contrast
+Check: text truncation, animation timing, narrator PiP positioning, background contrast.
 
-### Step 7: Preview & Render
+### Step 7: Render
 
 ```bash
-cd projects/{name}
-
-# Preview in browser
-npm run studio
-
-# Render final MP4
+cd ~/.openclaw/workspace/claude-code-video-toolkit/projects/PROJECT_NAME
 npm run render
 ```
 
-Output lands in `out/ProductDemo.mp4`.
+**Output:** `out/ProductDemo.mp4`
+
+---
 
 ## Composition Patterns
 
 ### Per-Scene Audio
 
-Don't use a single voiceover file. Use per-scene audio inside `TransitionSeries.Sequence`:
+Use per-scene audio with a 1-second delay (`from={30}` = 30 frames = 1s at 30fps):
 
 ```tsx
 <Sequence from={30}>
   <Audio src={staticFile('audio/scenes/01.mp3')} volume={1} />
 </Sequence>
 ```
-
-The `from={30}` adds a 1-second delay so scenes don't start talking immediately.
 
 ### Per-Scene Narrator PiP
 
@@ -330,11 +363,9 @@ The `from={30}` adds a 1-second delay so scenes don't start talking immediately.
 </Sequence>
 ```
 
-**Always use `<OffthreadVideo>`, never `<video>`.** Remotion requires its own video component for frame-accurate rendering.
+**ALWAYS use `<OffthreadVideo>`, NEVER `<video>`.** Remotion requires its own component for frame-accurate rendering.
 
 ### Transitions
-
-Import custom transitions from `lib/transitions/presentations/` and Remotion's from `@remotion/transitions`:
 
 ```tsx
 import { TransitionSeries, linearTiming } from '@remotion/transitions';
@@ -343,7 +374,23 @@ import { glitch } from '../../../lib/transitions/presentations/glitch';
 import { lightLeak } from '../../../lib/transitions/presentations/light-leak';
 ```
 
-Do NOT import `TransitionSeries` or `fade` from `lib/transitions` — it won't resolve.
+**NEVER import from `lib/transitions` barrel** — import custom transitions from `lib/transitions/presentations/` directly.
+
+---
+
+## Error Recovery
+
+| Problem | Solution |
+|---------|----------|
+| Tool command fails with "No module named..." | Run `pip3 install --break-system-packages -r tools/requirements.txt` from toolkit root |
+| "MODAL_*_ENDPOINT_URL not configured" | Check `.env` has the endpoint URL. Run `python3 tools/verify_setup.py` |
+| SadTalker output is square/cropped | You forgot `--preprocess full`. Re-run with that flag |
+| Audio too short/long for scene | Re-run Step 5 (sync timing) and update config |
+| `npm run render` fails | Make sure you're in the project dir, not toolkit root. Run `npm install` first |
+| "Cannot find module" in Remotion | Check import paths. Custom components use `../../../lib/` relative paths |
+| Cold start timeout on Modal | First call after idle takes 30-120s. Retry once — second call uses warm GPU |
+
+---
 
 ## Cost Estimates (Modal)
 
@@ -356,13 +403,6 @@ Do NOT import `TransitionSeries` or `fade` from `lib/transitions` — it won't r
 | Qwen-Edit | ~$0.03-0.15 | ~8 min cold start (25GB model) |
 | RealESRGAN | ~$0.005/image | Very fast |
 
-**Total for a 60s video:** ~$1-3 depending on number of scenes and narrator clips.
+**Total for a 60s video:** ~$1-3 depending on scenes and narrator clips.
 
-## Common Mistakes
-
-1. **Running tools from project directory** — Always `cd` to toolkit root first
-2. **Using `<video>` instead of `<OffthreadVideo>`** — Will not render correctly
-3. **Importing transitions from `lib/transitions` barrel** — Import custom transitions from `lib/transitions/presentations/` directly
-4. **One big SadTalker video** — Generate per-scene clips (6-15s), not one 60s file
-5. **Not syncing timing after TTS** — Audio duration ≠ estimated duration. Always check and update config
-6. **Missing 1s audio delay in duration math** — If audio starts at `from={30}`, add 1s to your duration calculation
+Modal Starter plan: $30/month free compute. Apps scale to zero when idle.

--- a/skills/openclaw-video-toolkit/SKILL.md
+++ b/skills/openclaw-video-toolkit/SKILL.md
@@ -1,0 +1,297 @@
+---
+name: video_toolkit
+description: Create professional videos autonomously using claude-code-video-toolkit — AI voiceovers, image generation, music, talking heads, and Remotion rendering.
+metadata:
+  openclaw:
+    os: ["darwin", "linux"]
+    requires:
+      bins: ["node", "python3", "ffmpeg", "npm"]
+      env: ["MODAL_QWEN3_TTS_ENDPOINT_URL"]
+---
+
+# Video Toolkit — OpenClaw Skill
+
+> **Status: Alpha.** This skill is designed for [OpenClaw](https://docs.openclaw.ai) and is experimental. It provides autonomous video creation using the [claude-code-video-toolkit](https://github.com/digitalsamba/claude-code-video-toolkit). Expect rough edges — contributions and feedback welcome.
+
+Create professional explainer videos from a text brief. The toolkit uses open-source AI models running on cloud GPUs (Modal) for voiceover, image generation, music, and talking head animation. Remotion (React) handles composition and rendering.
+
+## Prerequisites
+
+Before starting, verify the toolkit is set up:
+
+```bash
+python3 tools/verify_setup.py --json
+```
+
+Check the `summary` field. You need at minimum:
+- `prerequisites: true` — Node.js 18+, Python 3.9+, FFmpeg
+- `cloud_gpu: true` — At least one provider configured (Modal recommended)
+- `voice: true` — Qwen3-TTS endpoint configured
+
+If setup is incomplete, guide the user through `docs/modal-setup.md` or tell them to run `/setup` in Claude Code.
+
+## End-to-End Workflow
+
+### Step 1: Create Project
+
+```bash
+cp -r templates/product-demo projects/{project-name}
+cd projects/{project-name}
+npm install
+```
+
+Templates available: `product-demo` (marketing/explainer), `sprint-review` (sprint demos), `sprint-review-v2` (composable scenes).
+
+### Step 2: Write the Config
+
+Edit `src/config/demo-config.ts`. The config drives everything:
+
+```typescript
+export const demoConfig: ProductDemoConfig = {
+  product: {
+    name: 'My Product',
+    tagline: 'What it does in one line',
+    website: 'example.com',
+  },
+  scenes: [
+    { type: 'title', durationSeconds: 9, content: { headline: '...', subheadline: '...' } },
+    { type: 'problem', durationSeconds: 14, content: { headline: '...', problems: [...] } },
+    { type: 'solution', durationSeconds: 13, content: { headline: '...', highlights: [...] } },
+    { type: 'stats', durationSeconds: 12, content: { stats: [...] } },
+    { type: 'cta', durationSeconds: 10, content: { headline: '...', links: [...] } },
+  ],
+  audio: {
+    backgroundMusicFile: 'audio/bg-music.mp3',
+    backgroundMusicVolume: 0.12,
+  },
+};
+```
+
+Scene types: `title`, `problem`, `solution`, `demo`, `feature`, `stats`, `cta`.
+
+**Duration rule:** Set `durationSeconds` to `ceil(voiceover_duration + 2)`. You won't know the exact voiceover duration until Step 4, so estimate at ~2.5 words/second, then adjust after generating audio.
+
+### Step 3: Write the Voiceover Script
+
+Create `VOICEOVER-SCRIPT.md` with one section per scene:
+
+```markdown
+## Scene 1: Title (9s, ~15 words)
+Build videos with AI. This is the product name toolkit.
+
+## Scene 2: Problem (14s, ~30 words)
+The problem statement goes here. Keep it punchy and relatable.
+```
+
+**Word budget:** `(durationSeconds - 2) * 2.5` words per scene. The -2 accounts for the 1s audio delay and 1s padding.
+
+### Step 4: Generate Assets
+
+**All tool commands must be run from the toolkit root directory** (not from inside the project). This is critical.
+
+```bash
+cd /path/to/claude-code-video-toolkit
+```
+
+#### 4a. Background Music (ACE-Step)
+
+```bash
+python3 tools/music_gen.py --preset corporate-bg --duration 90 --output projects/{name}/public/audio/bg-music.mp3 --cloud modal
+```
+
+Presets: `corporate-bg`, `upbeat-tech`, `ambient`, `dramatic`, `tension`, `hopeful`, `cta`, `lofi`.
+
+#### 4b. Voiceover (Qwen3-TTS)
+
+Generate per-scene audio files:
+
+```bash
+# For each scene:
+python3 tools/qwen3_tts.py \
+  --text "The voiceover text for this scene" \
+  --speaker Ryan \
+  --tone warm \
+  --output projects/{name}/public/audio/scenes/01.mp3 \
+  --cloud modal
+```
+
+Speakers: `Ryan`, `Aiden`, `Vivian`, `Luna`, `Aurora`, `Aria`, `Nova`, `Stella`, `Orion`.
+Tones: `neutral`, `warm`, `professional`, `excited`, `calm`, `serious`.
+
+For voice cloning (if the user has a reference recording):
+```bash
+python3 tools/qwen3_tts.py \
+  --text "..." \
+  --ref-audio assets/voices/reference.m4a \
+  --ref-text "Transcript of the reference audio" \
+  --output projects/{name}/public/audio/scenes/01.mp3 \
+  --cloud modal
+```
+
+#### 4c. Scene Images (FLUX.2)
+
+Generate background images for key scenes:
+
+```bash
+python3 tools/flux2.py \
+  --prompt "Dark tech background with blue geometric grid, cinematic lighting" \
+  --width 1920 --height 1080 \
+  --output projects/{name}/public/images/title-bg.png \
+  --cloud modal
+```
+
+#### 4d. Presenter Portrait + Talking Head (FLUX.2 + SadTalker)
+
+Generate a presenter portrait, then animate it with SadTalker for narrator PiP:
+
+```bash
+# Generate portrait
+python3 tools/flux2.py \
+  --prompt "Professional presenter portrait, clean style, dark background, facing camera, upper body" \
+  --width 1024 --height 576 \
+  --output /tmp/presenter.png \
+  --cloud modal
+
+# Generate per-scene narrator clips (NOT one big file — keep them short)
+python3 tools/sadtalker.py \
+  --image /tmp/presenter.png \
+  --audio projects/{name}/public/audio/scenes/01.mp3 \
+  --preprocess full --still --expression-scale 0.8 \
+  --output projects/{name}/public/narrator-01.mp4 \
+  --cloud modal
+```
+
+**Critical SadTalker notes:**
+- Always use `--preprocess full` (preserves dimensions, default `crop` outputs square)
+- Always use `--still` for professional look (reduces head movement)
+- Generate per-scene clips (6-15s each), NOT one long video
+- Processing time is ~3-4 min per 10s of audio on Modal A10G
+- The `--expression-scale 0.8` keeps expressions subtle
+
+#### 4e. Image Editing (Qwen-Edit) — optional
+
+Create scene variants from existing images:
+
+```bash
+python3 tools/image_edit.py \
+  --input projects/{name}/public/images/title-bg.png \
+  --prompt "Make it darker with red tones, more ominous" \
+  --output projects/{name}/public/images/problem-bg.png \
+  --cloud modal
+```
+
+#### 4f. Upscaling (RealESRGAN) — optional
+
+Upscale images for HD quality:
+
+```bash
+python3 tools/upscale.py \
+  --input image.png --output image-4x.png --scale 4 --cloud modal
+```
+
+### Step 5: Sync Timing
+
+After generating voiceover, check actual durations and update config:
+
+```bash
+# Check each audio file duration
+for f in projects/{name}/public/audio/scenes/*.mp3; do
+  echo "$(basename $f): $(ffprobe -v error -show_entries format=duration -of csv=p=0 "$f")s"
+done
+```
+
+Update each scene's `durationSeconds` in `demo-config.ts` to: `ceil(audio_duration + 2)`.
+
+### Step 6: Review
+
+Render still frames at scene midpoints and inspect visually:
+
+```bash
+cd projects/{name}
+npx remotion still src/index.ts ProductDemo --frame=100 --output=/tmp/review-title.png
+npx remotion still src/index.ts ProductDemo --frame=400 --output=/tmp/review-problem.png
+# ... etc for each scene
+```
+
+Check for:
+- Text truncation or overflow
+- Animation timing (are all elements visible?)
+- Narrator PiP positioning
+- Background image opacity/contrast
+
+### Step 7: Preview & Render
+
+```bash
+cd projects/{name}
+
+# Preview in browser
+npm run studio
+
+# Render final MP4
+npm run render
+```
+
+Output lands in `out/ProductDemo.mp4`.
+
+## Composition Patterns
+
+### Per-Scene Audio
+
+Don't use a single voiceover file. Use per-scene audio inside `TransitionSeries.Sequence`:
+
+```tsx
+<Sequence from={30}>
+  <Audio src={staticFile('audio/scenes/01.mp3')} volume={1} />
+</Sequence>
+```
+
+The `from={30}` adds a 1-second delay so scenes don't start talking immediately.
+
+### Per-Scene Narrator PiP
+
+```tsx
+<Sequence from={30}>
+  <OffthreadVideo
+    src={staticFile('narrator-01.mp4')}
+    style={{ width: 320, height: 180, objectFit: 'cover' }}
+    muted
+  />
+</Sequence>
+```
+
+**Always use `<OffthreadVideo>`, never `<video>`.** Remotion requires its own video component for frame-accurate rendering.
+
+### Transitions
+
+Import custom transitions from `lib/transitions/presentations/` and Remotion's from `@remotion/transitions`:
+
+```tsx
+import { TransitionSeries, linearTiming } from '@remotion/transitions';
+import { fade } from '@remotion/transitions/fade';
+import { glitch } from '../../../lib/transitions/presentations/glitch';
+import { lightLeak } from '../../../lib/transitions/presentations/light-leak';
+```
+
+Do NOT import `TransitionSeries` or `fade` from `lib/transitions` — it won't resolve.
+
+## Cost Estimates (Modal)
+
+| Tool | Typical Cost | Notes |
+|------|-------------|-------|
+| Qwen3-TTS | ~$0.01/scene | ~20s per scene on warm GPU |
+| FLUX.2 | ~$0.01/image | ~3s warm, ~30s cold |
+| ACE-Step | ~$0.02-0.05 | Depends on duration |
+| SadTalker | ~$0.05-0.20/scene | ~3-4 min per 10s audio |
+| Qwen-Edit | ~$0.03-0.15 | ~8 min cold start (25GB model) |
+| RealESRGAN | ~$0.005/image | Very fast |
+
+**Total for a 60s video:** ~$1-3 depending on number of scenes and narrator clips.
+
+## Common Mistakes
+
+1. **Running tools from project directory** — Always `cd` to toolkit root first
+2. **Using `<video>` instead of `<OffthreadVideo>`** — Will not render correctly
+3. **Importing transitions from `lib/transitions` barrel** — Import custom transitions from `lib/transitions/presentations/` directly
+4. **One big SadTalker video** — Generate per-scene clips (6-15s), not one 60s file
+5. **Not syncing timing after TTS** — Audio duration ≠ estimated duration. Always check and update config
+6. **Missing 1s audio delay in duration math** — If audio starts at `from={30}`, add 1s to your duration calculation

--- a/skills/openclaw-video-toolkit/SKILL.md
+++ b/skills/openclaw-video-toolkit/SKILL.md
@@ -6,7 +6,6 @@ metadata:
     os: ["darwin", "linux"]
     requires:
       bins: ["node", "python3", "ffmpeg", "npm"]
-      env: ["MODAL_QWEN3_TTS_ENDPOINT_URL"]
 ---
 
 # Video Toolkit — OpenClaw Skill
@@ -15,20 +14,92 @@ metadata:
 
 Create professional explainer videos from a text brief. The toolkit uses open-source AI models running on cloud GPUs (Modal) for voiceover, image generation, music, and talking head animation. Remotion (React) handles composition and rendering.
 
-## Prerequisites
+## Setup (First Run)
 
-Before starting, verify the toolkit is set up:
+Run the verification script to check current state:
 
 ```bash
 python3 tools/verify_setup.py --json
 ```
 
-Check the `summary` field. You need at minimum:
-- `prerequisites: true` — Node.js 18+, Python 3.9+, FFmpeg
-- `cloud_gpu: true` — At least one provider configured (Modal recommended)
-- `voice: true` — Qwen3-TTS endpoint configured
+If `summary.cloud_gpu` is false, you need to set up Modal. This is a one-time process.
 
-If setup is incomplete, guide the user through `docs/modal-setup.md` or tell them to run `/setup` in Claude Code.
+### Install Modal CLI
+
+```bash
+pip3 install modal
+python3 -m modal setup   # Opens browser for authentication
+```
+
+### Install Python Dependencies
+
+```bash
+pip3 install -r tools/requirements.txt
+```
+
+### Deploy Tools to Modal
+
+Each tool is a separate Modal app. Deploy them and capture the endpoint URLs:
+
+```bash
+# Deploy each tool — the output contains the endpoint URL
+# Look for the line: "Created web endpoint for ... => https://...modal.run"
+
+modal deploy docker/modal-qwen3-tts/app.py    # Speech (most important)
+modal deploy docker/modal-flux2/app.py         # Image generation
+modal deploy docker/modal-music-gen/app.py     # Background music
+modal deploy docker/modal-sadtalker/app.py     # Talking head narrator
+modal deploy docker/modal-image-edit/app.py    # Image editing
+modal deploy docker/modal-upscale/app.py       # Image upscaling
+modal deploy docker/modal-propainter/app.py    # Watermark removal
+```
+
+After each deploy, Modal prints a URL like:
+```
+https://username--video-toolkit-flux2-flux2-generate.modal.run
+```
+
+### Save Endpoint URLs to .env
+
+Create or update `.env` in the toolkit root with the URLs from each deploy:
+
+```bash
+# Create .env if it doesn't exist
+touch .env
+
+# Add each endpoint URL (replace with actual URLs from deploy output)
+echo 'MODAL_QWEN3_TTS_ENDPOINT_URL=https://username--video-toolkit-qwen3-tts-ttsengine-generate.modal.run' >> .env
+echo 'MODAL_FLUX2_ENDPOINT_URL=https://username--video-toolkit-flux2-flux2-generate.modal.run' >> .env
+echo 'MODAL_MUSIC_GEN_ENDPOINT_URL=https://username--video-toolkit-music-gen-musicgen-generate.modal.run' >> .env
+echo 'MODAL_SADTALKER_ENDPOINT_URL=https://username--video-toolkit-sadtalker-sadtalkergen-generate.modal.run' >> .env
+echo 'MODAL_IMAGE_EDIT_ENDPOINT_URL=https://username--video-toolkit-image-edit-qwenedit-edit.modal.run' >> .env
+echo 'MODAL_UPSCALE_ENDPOINT_URL=https://username--video-toolkit-upscale-upscaler-upscale.modal.run' >> .env
+echo 'MODAL_DEWATERMARK_ENDPOINT_URL=https://username--video-toolkit-dewatermark-dewatermark-dewatermark.modal.run' >> .env
+```
+
+### Optional: Cloudflare R2 (Recommended)
+
+R2 provides reliable file transfer between your machine and cloud GPUs. Free tier: 10GB storage, zero egress. Without it, tools fall back to free upload services (slower, less reliable).
+
+If the user has R2 credentials, add to `.env`:
+```
+R2_ACCOUNT_ID=...
+R2_ACCESS_KEY_ID=...
+R2_SECRET_ACCESS_KEY=...
+R2_BUCKET_NAME=video-toolkit
+```
+
+### Verify Setup
+
+Run verification again to confirm everything is configured:
+
+```bash
+python3 tools/verify_setup.py
+```
+
+All tools should show as configured. Modal apps scale to zero when idle — no ongoing cost.
+
+**Cost:** Modal Starter plan includes $30/month free compute. A typical 60s video costs $1-3 to produce.
 
 ## End-to-End Workflow
 

--- a/templates/product-demo/remotion.config.ts
+++ b/templates/product-demo/remotion.config.ts
@@ -1,4 +1,21 @@
 import { Config } from "@remotion/cli/config";
+import path from "path";
 
 Config.setVideoImageFormat("jpeg");
 Config.setOverwriteOutput(true);
+
+// Ensure shared lib/ imports resolve packages from this project's node_modules
+// Without this, imports like `@remotion/transitions` in lib/transitions/ fail
+// because webpack resolves them relative to lib/, not the project root.
+Config.overrideWebpackConfig((config) => {
+  return {
+    ...config,
+    resolve: {
+      ...config.resolve,
+      modules: [
+        path.resolve(__dirname, "node_modules"),
+        ...(config.resolve?.modules || ["node_modules"]),
+      ],
+    },
+  };
+});

--- a/templates/sprint-review-v2/remotion.config.ts
+++ b/templates/sprint-review-v2/remotion.config.ts
@@ -1,4 +1,19 @@
 import { Config } from '@remotion/cli/config';
+import path from 'path';
 
 Config.setVideoImageFormat('jpeg');
 Config.setOverwriteOutput(true);
+
+// Ensure shared lib/ imports resolve packages from this project's node_modules
+Config.overrideWebpackConfig((config) => {
+  return {
+    ...config,
+    resolve: {
+      ...config.resolve,
+      modules: [
+        path.resolve(__dirname, 'node_modules'),
+        ...(config.resolve?.modules || ['node_modules']),
+      ],
+    },
+  };
+});

--- a/templates/sprint-review/remotion.config.ts
+++ b/templates/sprint-review/remotion.config.ts
@@ -1,4 +1,19 @@
 import { Config } from '@remotion/cli/config';
+import path from 'path';
 
 Config.setVideoImageFormat('jpeg');
 Config.setOverwriteOutput(true);
+
+// Ensure shared lib/ imports resolve packages from this project's node_modules
+Config.overrideWebpackConfig((config) => {
+  return {
+    ...config,
+    resolve: {
+      ...config.resolve,
+      modules: [
+        path.resolve(__dirname, 'node_modules'),
+        ...(config.resolve?.modules || ['node_modules']),
+      ],
+    },
+  };
+});

--- a/tools/cloud_gpu.py
+++ b/tools/cloud_gpu.py
@@ -1,0 +1,419 @@
+"""Shared cloud GPU provider abstraction.
+
+Routes job submission to RunPod or Modal endpoints with a unified interface.
+Each tool builds its own payload dict, then calls call_cloud_endpoint() which
+handles submission, polling, timeout, and cancellation for the chosen provider.
+
+Supported providers:
+- runpod: RunPod serverless endpoints (existing)
+- modal: Modal web endpoints (new)
+"""
+
+import os
+import sys
+import time
+
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# ---------------------------------------------------------------------------
+# Provider config: maps tool_name → env var for each provider
+# ---------------------------------------------------------------------------
+
+_RUNPOD_ENV_VARS = {
+    "qwen3_tts": "RUNPOD_QWEN3_TTS_ENDPOINT_ID",
+    "flux2": "RUNPOD_FLUX2_ENDPOINT_ID",
+    "upscale": "RUNPOD_UPSCALE_ENDPOINT_ID",
+    "sadtalker": "RUNPOD_SADTALKER_ENDPOINT_ID",
+    "image_edit": "RUNPOD_QWEN_EDIT_ENDPOINT_ID",
+    "music_gen": "RUNPOD_ACESTEP_ENDPOINT_ID",
+    "dewatermark": "RUNPOD_ENDPOINT_ID",
+}
+
+_MODAL_ENV_VARS = {
+    "qwen3_tts": "MODAL_QWEN3_TTS_ENDPOINT_URL",
+    "flux2": "MODAL_FLUX2_ENDPOINT_URL",
+    "upscale": "MODAL_UPSCALE_ENDPOINT_URL",
+    "sadtalker": "MODAL_SADTALKER_ENDPOINT_URL",
+    "image_edit": "MODAL_IMAGE_EDIT_ENDPOINT_URL",
+    "music_gen": "MODAL_MUSIC_GEN_ENDPOINT_URL",
+}
+
+
+# ---------------------------------------------------------------------------
+# Logging helper
+# ---------------------------------------------------------------------------
+
+def _log(msg: str, level: str = "info"):
+    """Print formatted log message to stderr."""
+    colors = {
+        "info": "\033[94m",
+        "success": "\033[92m",
+        "error": "\033[91m",
+        "warn": "\033[93m",
+        "dim": "\033[90m",
+    }
+    reset = "\033[0m"
+    prefix = {"info": "->", "success": "OK", "error": "!!", "warn": "??", "dim": "  "}
+    color = colors.get(level, "")
+    print(f"{color}{prefix.get(level, '->')} {msg}{reset}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Cost estimation
+# ---------------------------------------------------------------------------
+
+# GPU hourly rates (approximate, as of March 2026)
+_GPU_HOURLY_RATES = {
+    "modal": {
+        "A10G": 1.10,
+        "A100": 3.73,      # 40GB
+        "A100-80GB": 4.68,
+        "T4": 0.59,
+        "L4": 0.80,
+        "H100": 8.10,
+    },
+    "runpod": {
+        "ADA_24": 0.44,    # RTX 4090
+        "AMPERE_24": 0.44, # RTX 3090 / A5000
+        "AMPERE_48": 0.69, # A6000 / RTX A6000
+        "AMPERE_80": 1.64, # A100 80GB
+    },
+}
+
+# Which GPU each tool uses per provider
+_TOOL_GPU = {
+    "modal": {
+        "qwen3_tts": "A10G",
+        "flux2": "A10G",
+        "upscale": "A10G",
+        "sadtalker": "A10G",
+        "image_edit": "A10G",
+        "music_gen": "A10G",
+    },
+    "runpod": {
+        "qwen3_tts": "ADA_24",
+        "flux2": "AMPERE_24",
+        "upscale": "AMPERE_24",
+        "sadtalker": "AMPERE_24",
+        "image_edit": "AMPERE_80",
+        "music_gen": "AMPERE_24",
+    },
+}
+
+
+def _estimate_cost(provider: str, tool_name: str, elapsed_seconds: float) -> float | None:
+    """Estimate cost for a job based on GPU time.
+
+    Returns estimated USD cost, or None if pricing data unavailable.
+    """
+    gpu = _TOOL_GPU.get(provider, {}).get(tool_name)
+    rate = _GPU_HOURLY_RATES.get(provider, {}).get(gpu)
+    if rate is None:
+        return None
+    return (elapsed_seconds / 3600) * rate
+
+
+def get_provider_config(provider: str, tool_name: str) -> dict:
+    """Get configuration for a provider + tool combination.
+
+    Returns dict with provider-specific keys:
+    - RunPod: {"api_key": str, "endpoint_id": str}
+    - Modal: {"endpoint_url": str, "token_id": str, "token_secret": str}
+    """
+    if provider == "runpod":
+        env_var = _RUNPOD_ENV_VARS.get(tool_name)
+        return {
+            "api_key": os.getenv("RUNPOD_API_KEY"),
+            "endpoint_id": os.getenv(env_var) if env_var else None,
+        }
+    elif provider == "modal":
+        env_var = _MODAL_ENV_VARS.get(tool_name)
+        return {
+            "endpoint_url": os.getenv(env_var) if env_var else None,
+            "token_id": os.getenv("MODAL_TOKEN_ID"),
+            "token_secret": os.getenv("MODAL_TOKEN_SECRET"),
+        }
+    else:
+        raise ValueError(f"Unknown provider: {provider}. Use 'runpod' or 'modal'.")
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+def call_cloud_endpoint(
+    provider: str,
+    payload: dict,
+    tool_name: str,
+    timeout: int = 600,
+    poll_interval: int = 5,
+    queue_timeout: int = 300,
+    progress_label: str = "Processing",
+    verbose: bool = True,
+) -> tuple[dict, float]:
+    """Submit a job to a cloud GPU endpoint and wait for the result.
+
+    Args:
+        provider: "runpod" or "modal"
+        payload: The job payload ({"input": {...}} for RunPod, raw dict for Modal)
+        tool_name: Config lookup key (e.g., "qwen3_tts", "flux2")
+        timeout: Overall timeout in seconds
+        poll_interval: Seconds between status checks (RunPod only)
+        queue_timeout: Cancel if stuck in queue longer than this (RunPod only)
+        progress_label: Label for progress messages (e.g., "Generating speech")
+        verbose: Print progress to stderr
+
+    Returns:
+        (result_dict, elapsed_seconds) — result_dict contains the job output
+        or {"error": "..."} on failure.
+    """
+    config = get_provider_config(provider, tool_name)
+
+    if provider == "runpod":
+        result, elapsed = _call_runpod(
+            payload=payload,
+            api_key=config["api_key"],
+            endpoint_id=config["endpoint_id"],
+            timeout=timeout,
+            poll_interval=poll_interval,
+            queue_timeout=queue_timeout,
+            progress_label=progress_label,
+            verbose=verbose,
+        )
+    elif provider == "modal":
+        result, elapsed = _call_modal(
+            payload=payload,
+            endpoint_url=config["endpoint_url"],
+            token_id=config["token_id"],
+            token_secret=config["token_secret"],
+            timeout=timeout,
+            progress_label=progress_label,
+            verbose=verbose,
+        )
+
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+    # Print cost estimate
+    if verbose and elapsed > 0 and not result.get("error"):
+        cost = _estimate_cost(provider, tool_name, elapsed)
+        if cost is not None:
+            _log(f"Est. cost: ${cost:.4f} ({elapsed:.0f}s on {provider})", "dim")
+
+    return result, elapsed
+
+
+# ---------------------------------------------------------------------------
+# RunPod implementation
+# ---------------------------------------------------------------------------
+
+def _call_runpod(
+    payload: dict,
+    api_key: str | None,
+    endpoint_id: str | None,
+    timeout: int = 600,
+    poll_interval: int = 5,
+    queue_timeout: int = 300,
+    progress_label: str = "Processing",
+    verbose: bool = True,
+) -> tuple[dict, float]:
+    """Submit + poll a RunPod serverless endpoint.
+
+    Consolidates the pattern duplicated across flux2.py, music_gen.py,
+    qwen3_tts.py, upscale.py, sadtalker.py, and image_edit.py.
+    """
+    if not api_key:
+        return {"error": "RUNPOD_API_KEY not set in .env"}, 0
+    if not endpoint_id:
+        return {"error": "RunPod endpoint ID not set. Run with --setup first."}, 0
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    start = time.time()
+
+    try:
+        # Submit job
+        run_url = f"https://api.runpod.ai/v2/{endpoint_id}/run"
+        response = requests.post(run_url, json=payload, headers=headers, timeout=30)
+        response.raise_for_status()
+        result = response.json()
+
+        job_id = result.get("id")
+        status = result.get("status")
+
+        if verbose and job_id:
+            _log(f"Job submitted: {job_id}", "dim")
+
+        # Immediate completion (warm worker)
+        if status == "COMPLETED":
+            return result.get("output", result), time.time() - start
+
+        if status == "FAILED":
+            return {"error": result.get("error", "Unknown error")}, time.time() - start
+
+        # Poll for completion
+        if verbose:
+            _log(f"{progress_label}... (cold start may take 3-5 min on first run)", "warn")
+
+        status_url = f"https://api.runpod.ai/v2/{endpoint_id}/status/{job_id}"
+        queue_start = time.time()
+        last_status = None
+
+        while time.time() - start < timeout:
+            time.sleep(poll_interval)
+            elapsed = time.time() - start
+
+            try:
+                status_resp = requests.get(status_url, headers=headers, timeout=30)
+                status_data = status_resp.json()
+                status = status_data.get("status")
+            except Exception as e:
+                if verbose:
+                    _log(f"[{elapsed:.0f}s] Status check error: {e}", "dim")
+                continue
+
+            if status != last_status:
+                if verbose:
+                    if status == "IN_PROGRESS":
+                        _log(f"[{elapsed:.0f}s] {progress_label}...", "dim")
+                    elif status == "IN_QUEUE":
+                        _log(f"[{elapsed:.0f}s] Waiting for GPU...", "dim")
+                last_status = status
+
+            if status == "COMPLETED":
+                return status_data.get("output", status_data), time.time() - start
+
+            if status == "FAILED":
+                error = status_data.get("error", "Unknown error")
+                return {"error": error}, time.time() - start
+
+            if status in ("CANCELLED", "TIMED_OUT"):
+                return {"error": f"Job {status}"}, time.time() - start
+
+            # Cancel jobs stuck in queue too long
+            if status == "IN_QUEUE" and queue_start and (time.time() - queue_start > queue_timeout):
+                if verbose:
+                    _log(f"Job stuck in queue for {queue_timeout}s — cancelling", "warn")
+                _cancel_runpod_job(endpoint_id, api_key, job_id)
+                return {"error": f"Cancelled: no GPU available after {queue_timeout}s in queue"}, time.time() - start
+
+            # Reset queue timer when job starts processing
+            if status == "IN_PROGRESS" and queue_start:
+                queue_start = None
+
+        # Overall timeout — cancel the job
+        if verbose:
+            _log("Polling timeout — cancelling job on RunPod", "warn")
+        _cancel_runpod_job(endpoint_id, api_key, job_id)
+        return {"error": "polling timeout (job cancelled)"}, time.time() - start
+
+    except requests.exceptions.Timeout:
+        return {"error": "HTTP request timeout"}, time.time() - start
+    except requests.exceptions.RequestException as e:
+        return {"error": f"Request failed: {e}"}, time.time() - start
+    except Exception as e:
+        return {"error": f"Unexpected error: {e}"}, time.time() - start
+
+
+def _cancel_runpod_job(endpoint_id: str, api_key: str, job_id: str):
+    """Cancel a RunPod job (best-effort, ignores errors)."""
+    try:
+        cancel_url = f"https://api.runpod.ai/v2/{endpoint_id}/cancel/{job_id}"
+        requests.post(
+            cancel_url,
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=10,
+        )
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Modal implementation
+# ---------------------------------------------------------------------------
+
+def _call_modal(
+    payload: dict,
+    endpoint_url: str | None,
+    token_id: str | None,
+    token_secret: str | None,
+    timeout: int = 600,
+    progress_label: str = "Processing",
+    verbose: bool = True,
+) -> tuple[dict, float]:
+    """Call a Modal web endpoint.
+
+    Modal web endpoints are synchronous — the HTTP request blocks until the
+    function completes and returns the result. No polling needed.
+
+    For endpoints that may take longer than the HTTP timeout, Modal
+    automatically handles keep-alive. We set a generous requests timeout
+    to match the function's server-side timeout.
+    """
+    if not endpoint_url:
+        return {"error": "Modal endpoint URL not set. Run with --setup --cloud modal first."}, 0
+
+    # Modal web endpoints can be public or authenticated.
+    # If token is configured, use it; otherwise call without auth (public endpoint).
+    headers = {"Content-Type": "application/json"}
+    if token_id and token_secret:
+        headers["Authorization"] = f"Bearer {token_id}:{token_secret}"
+
+    # Modal expects the payload directly (not wrapped in {"input": ...}).
+    # Unwrap if the caller used RunPod's format for compatibility.
+    modal_payload = payload.get("input", payload) if isinstance(payload, dict) else payload
+
+    start = time.time()
+
+    if verbose:
+        _log(f"{progress_label} via Modal...", "info")
+
+    try:
+        # Modal web endpoints are synchronous — single POST, wait for result.
+        # Set timeout slightly above the server-side function timeout to avoid
+        # the client giving up before the server does.
+        response = requests.post(
+            endpoint_url,
+            json=modal_payload,
+            headers=headers,
+            timeout=timeout + 30,
+        )
+
+        elapsed = time.time() - start
+
+        if response.status_code == 200:
+            result = response.json()
+            if verbose:
+                _log(f"Completed in {elapsed:.1f}s", "success")
+            return result, elapsed
+
+        # Modal error responses
+        error_body = response.text[:500]
+        if response.status_code == 422:
+            return {"error": f"Modal validation error: {error_body}"}, elapsed
+        elif response.status_code == 408:
+            return {"error": f"Modal function timed out after {timeout}s"}, elapsed
+        elif response.status_code == 503:
+            return {"error": "Modal endpoint is scaling up or unavailable. Try again in a moment."}, elapsed
+        else:
+            return {"error": f"Modal HTTP {response.status_code}: {error_body}"}, elapsed
+
+    except requests.exceptions.Timeout:
+        elapsed = time.time() - start
+        return {"error": f"Modal request timed out after {elapsed:.0f}s"}, elapsed
+    except requests.exceptions.ConnectionError as e:
+        elapsed = time.time() - start
+        return {"error": f"Modal connection failed (is the endpoint deployed?): {e}"}, elapsed
+    except Exception as e:
+        elapsed = time.time() - start
+        return {"error": f"Modal request failed: {e}"}, elapsed

--- a/tools/cloud_gpu.py
+++ b/tools/cloud_gpu.py
@@ -39,6 +39,7 @@ _MODAL_ENV_VARS = {
     "sadtalker": "MODAL_SADTALKER_ENDPOINT_URL",
     "image_edit": "MODAL_IMAGE_EDIT_ENDPOINT_URL",
     "music_gen": "MODAL_MUSIC_GEN_ENDPOINT_URL",
+    "dewatermark": "MODAL_DEWATERMARK_ENDPOINT_URL",
 }
 
 
@@ -96,6 +97,7 @@ _TOOL_GPU = {
         "sadtalker": "A10G",
         "image_edit": "A10G",
         "music_gen": "A10G",
+        "dewatermark": "A10G",
     },
     "runpod": {
         "qwen3_tts": "ADA_24",
@@ -104,6 +106,7 @@ _TOOL_GPU = {
         "sadtalker": "AMPERE_24",
         "image_edit": "AMPERE_80",
         "music_gen": "AMPERE_24",
+        "dewatermark": "AMPERE_24",
     },
 }
 

--- a/tools/config.py
+++ b/tools/config.py
@@ -78,6 +78,30 @@ def get_qwen3_tts_endpoint_id() -> str | None:
     return os.getenv("RUNPOD_QWEN3_TTS_ENDPOINT_ID")
 
 
+def get_modal_token() -> tuple[str | None, str | None]:
+    """Get Modal authentication token from environment.
+
+    Returns (token_id, token_secret) tuple. Both are None if not configured.
+    Modal stores tokens in ~/.modal.toml after `modal setup`, but for
+    web endpoint auth we read from .env.
+    """
+    from dotenv import load_dotenv
+    load_dotenv()
+    return os.getenv("MODAL_TOKEN_ID"), os.getenv("MODAL_TOKEN_SECRET")
+
+
+def get_modal_endpoint_url(tool_name: str) -> str | None:
+    """Get Modal web endpoint URL for a tool.
+
+    Env var convention: MODAL_{TOOL}_ENDPOINT_URL
+    e.g., MODAL_QWEN3_TTS_ENDPOINT_URL, MODAL_FLUX2_ENDPOINT_URL
+    """
+    from dotenv import load_dotenv
+    load_dotenv()
+    env_var = f"MODAL_{tool_name.upper()}_ENDPOINT_URL"
+    return os.getenv(env_var)
+
+
 def get_brand_dir(brand_name: str) -> Path | None:
     """Get the directory for a brand profile."""
     brand_dir = find_workspace_root() / "brands" / brand_name

--- a/tools/dewatermark.py
+++ b/tools/dewatermark.py
@@ -3,14 +3,17 @@
 Remove watermarks from video using AI inpainting (ProPainter).
 
 Supports both local processing (NVIDIA GPU required) and cloud processing
-via RunPod serverless GPUs.
+via RunPod or Modal serverless GPUs.
 
 Usage:
     # Local processing (requires NVIDIA GPU + ProPainter installation)
     python tools/dewatermark.py --input video.mp4 --region 1080,660,195,40 --output clean.mp4
 
-    # Cloud processing via RunPod (works from any machine)
-    python tools/dewatermark.py --input video.mp4 --region 1080,660,195,40 --output clean.mp4 --runpod
+    # Cloud processing via Modal (works from any machine)
+    python tools/dewatermark.py --input video.mp4 --region 1080,660,195,40 --output clean.mp4 --cloud modal
+
+    # Cloud processing via RunPod
+    python tools/dewatermark.py --input video.mp4 --region 1080,660,195,40 --output clean.mp4 --cloud runpod
 
     # Use custom mask image (white = area to remove, black = keep)
     python tools/dewatermark.py --input video.mp4 --mask mask.png --output clean.mp4
@@ -21,21 +24,20 @@ Usage:
     # Check installation status
     python tools/dewatermark.py --status
 
-RunPod Setup:
-    1. Create account at runpod.io
-    2. Deploy the propainter Docker image (see docker/runpod-propainter/)
-    3. Add to .env:
-       RUNPOD_API_KEY=your_key
-       RUNPOD_ENDPOINT_ID=your_endpoint
+Cloud Setup:
+    Modal:  pip install modal && python3 -m modal setup
+            modal deploy docker/modal-propainter/app.py
+    RunPod: See docker/runpod-propainter/ for deployment instructions
 
 Hardware (local mode):
     - NVIDIA GPU: Recommended (uses CUDA)
-    - Apple Silicon: NOT SUPPORTED (too slow, use --runpod instead)
-    - CPU-only: NOT SUPPORTED (too slow, use --runpod instead)
+    - Apple Silicon: NOT SUPPORTED (too slow, use --cloud instead)
+    - CPU-only: NOT SUPPORTED (too slow, use --cloud instead)
 
-Cost (RunPod):
+Cost:
     - ~$0.02-0.25 per video depending on length
-    - Uses RTX 3090 (~$0.34/hr) by default
+    - Modal: A10G GPU, scales to zero when idle
+    - RunPod: RTX 3090 (~$0.34/hr) by default
 """
 
 import argparse
@@ -49,6 +51,12 @@ import time
 from pathlib import Path
 
 import requests
+
+sys.path.insert(0, str(Path(__file__).parent))
+from file_transfer import (
+    upload_to_storage, download_from_r2, delete_from_r2,
+    download_from_url, get_r2_payload_config,
+)
 
 # Default installation path
 PROPAINTER_HOME = Path.home() / ".video-toolkit" / "propainter"
@@ -587,17 +595,25 @@ Examples:
         help="Keep intermediate files (frames, masks)",
     )
 
-    # RunPod cloud processing
+    # Cloud GPU processing
+    parser.add_argument(
+        "--cloud",
+        type=str,
+        default=None,
+        choices=["runpod", "modal"],
+        help="Cloud GPU provider (default: runpod)",
+    )
     parser.add_argument(
         "--runpod",
         action="store_true",
-        help="Process on RunPod serverless GPU instead of locally",
+        help="[Deprecated] Use --cloud runpod instead",
     )
     parser.add_argument(
-        "--runpod-timeout",
+        "--timeout", "--runpod-timeout",
         type=int,
         default=1800,
-        help="RunPod job timeout in seconds (default: 1800 = 30 min)",
+        dest="timeout",
+        help="Job timeout in seconds (default: 1800 = 30 min)",
     )
     parser.add_argument(
         "--setup",
@@ -971,384 +987,8 @@ def run_propainter(
 
 
 # =============================================================================
-# RunPod Cloud Processing
+# Cloud GPU Processing (RunPod + Modal)
 # =============================================================================
-
-def get_runpod_config() -> dict:
-    """Get RunPod configuration from environment."""
-    # Import here to avoid circular dependency and allow graceful failure
-    sys.path.insert(0, str(Path(__file__).parent))
-    try:
-        from config import get_runpod_api_key, get_runpod_endpoint_id
-        return {
-            "api_key": get_runpod_api_key(),
-            "endpoint_id": get_runpod_endpoint_id(),
-        }
-    except ImportError:
-        # Fallback to direct env var access
-        from dotenv import load_dotenv
-        load_dotenv()
-        return {
-            "api_key": os.getenv("RUNPOD_API_KEY"),
-            "endpoint_id": os.getenv("RUNPOD_ENDPOINT_ID"),
-        }
-
-
-def _get_r2_client():
-    """Get boto3 S3 client configured for Cloudflare R2."""
-    sys.path.insert(0, str(Path(__file__).parent))
-    try:
-        from config import get_r2_config
-        r2_config = get_r2_config()
-    except ImportError:
-        r2_config = None
-
-    if not r2_config:
-        return None, None
-
-    try:
-        import boto3
-        from botocore.config import Config
-
-        client = boto3.client(
-            "s3",
-            endpoint_url=r2_config["endpoint_url"],
-            aws_access_key_id=r2_config["access_key_id"],
-            aws_secret_access_key=r2_config["secret_access_key"],
-            config=Config(signature_version="s3v4"),
-        )
-        return client, r2_config
-    except ImportError:
-        print("  boto3 not installed, skipping R2", file=sys.stderr)
-        return None, None
-
-
-def _upload_to_r2(file_path: str, file_name: str) -> tuple[str | None, str | None]:
-    """
-    Upload to Cloudflare R2 and return presigned download URL.
-
-    Returns (url, object_key) tuple. object_key is needed for cleanup.
-    """
-    client, config = _get_r2_client()
-    if not client:
-        return None, None
-
-    import uuid
-    object_key = f"dewatermark/{uuid.uuid4().hex[:8]}_{file_name}"
-
-    try:
-        client.upload_file(file_path, config["bucket_name"], object_key)
-
-        # Generate presigned URL (valid for 2 hours)
-        url = client.generate_presigned_url(
-            "get_object",
-            Params={"Bucket": config["bucket_name"], "Key": object_key},
-            ExpiresIn=7200,
-        )
-        return url, object_key
-    except Exception as e:
-        print(f"  R2 upload error: {e}", file=sys.stderr)
-        return None, None
-
-
-def _delete_from_r2(object_key: str) -> bool:
-    """Delete object from R2 after job completion."""
-    client, config = _get_r2_client()
-    if not client or not object_key:
-        return False
-
-    try:
-        client.delete_object(Bucket=config["bucket_name"], Key=object_key)
-        return True
-    except Exception:
-        return False
-
-
-def _download_from_r2(object_key: str, output_path: str) -> bool:
-    """Download object from R2 to local path."""
-    client, config = _get_r2_client()
-    if not client:
-        return False
-
-    try:
-        client.download_file(config["bucket_name"], object_key, output_path)
-        return True
-    except Exception as e:
-        print(f"  R2 download error: {e}", file=sys.stderr)
-        return False
-
-
-def upload_to_runpod_storage(file_path: str, api_key: str) -> tuple[str | None, str | None]:
-    """
-    Upload a file to temporary storage for job input.
-
-    Returns (url, r2_key) tuple. r2_key is set if R2 was used (for cleanup).
-    Falls back to free file hosting services if R2 not configured.
-    """
-    file_size = Path(file_path).stat().st_size
-    file_name = Path(file_path).name
-
-    print(f"Uploading {file_name} ({file_size // (1024*1024)}MB)...", file=sys.stderr)
-
-    # Try R2 first if configured
-    url, r2_key = _upload_to_r2(file_path, file_name)
-    if url:
-        print(f"  Upload complete (R2): {url[:60]}...", file=sys.stderr)
-        return url, r2_key
-
-    # Fall back to free services
-    upload_services = [
-        ("litterbox", _upload_to_litterbox),
-        ("0x0.st", _upload_to_0x0),
-        ("file.io", _upload_to_fileio),
-        ("transfer.sh", _upload_to_transfersh),
-    ]
-
-    for service_name, upload_func in upload_services:
-        try:
-            url = upload_func(file_path, file_name)
-            if url:
-                print(f"  Upload complete ({service_name}): {url[:60]}...", file=sys.stderr)
-                return url, None  # No R2 key for cleanup
-        except Exception as e:
-            print(f"  {service_name} failed: {e}", file=sys.stderr)
-            continue
-
-    print("All upload services failed", file=sys.stderr)
-    return None, None
-
-
-def _upload_to_litterbox(file_path: str, file_name: str) -> str | None:
-    """Upload to litterbox.catbox.moe (200MB limit, 24h retention) using curl."""
-    result = subprocess.run(
-        [
-            "curl", "-s",
-            "-F", "reqtype=fileupload",
-            "-F", "time=24h",
-            "-F", f"fileToUpload=@{file_path}",
-            "https://litterbox.catbox.moe/resources/internals/api.php",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=600,
-    )
-    if result.returncode == 0:
-        url = result.stdout.strip()
-        if url.startswith("http"):
-            return url
-        else:
-            raise Exception(f"Unexpected response: {url[:100]}")
-    else:
-        raise Exception(f"curl failed: {result.stderr[:100]}")
-
-
-def _upload_to_0x0(file_path: str, file_name: str) -> str | None:
-    """Upload to 0x0.st (512MB limit, 30 day retention) using curl."""
-    result = subprocess.run(
-        ["curl", "-s", "-F", f"file=@{file_path}", "https://0x0.st"],
-        capture_output=True,
-        text=True,
-        timeout=600,
-    )
-    if result.returncode == 0:
-        url = result.stdout.strip()
-        if url.startswith("http"):
-            return url
-        else:
-            raise Exception(f"Unexpected response: {url[:100]}")
-    else:
-        raise Exception(f"curl failed: {result.stderr[:100]}")
-
-
-def _upload_to_fileio(file_path: str, file_name: str) -> str | None:
-    """Upload to file.io (2GB limit, 1 download then deleted)."""
-    with open(file_path, 'rb') as f:
-        response = requests.post(
-            "https://file.io",
-            files={"file": (file_name, f)},
-            timeout=600,
-        )
-    if response.status_code == 200:
-        data = response.json()
-        if data.get("success"):
-            return data.get("link")
-    return None
-
-
-def _upload_to_transfersh(file_path: str, file_name: str) -> str | None:
-    """Upload to transfer.sh (10GB limit, 14 day retention)."""
-    with open(file_path, 'rb') as f:
-        response = requests.put(
-            f"https://transfer.sh/{file_name}",
-            data=f,
-            headers={"Max-Downloads": "5", "Max-Days": "1"},
-            timeout=600,
-        )
-    if response.status_code == 200:
-        return response.text.strip()
-    return None
-
-
-def submit_runpod_job(
-    endpoint_id: str,
-    api_key: str,
-    video_url: str,
-    region: str | None = None,
-    mask_url: str | None = None,
-    r2_config: dict | None = None,
-    resize_ratio: str | float = "auto",
-) -> dict | None:
-    """Submit a dewatermark job to RunPod serverless endpoint."""
-    url = f"https://api.runpod.ai/v2/{endpoint_id}/run"
-
-    # Handle resize_ratio: "auto" or numeric value
-    if resize_ratio == "auto":
-        ratio_value = "auto"
-    else:
-        ratio_value = float(resize_ratio)
-
-    payload = {
-        "input": {
-            "operation": "dewatermark",
-            "video_url": video_url,
-            "resize_ratio": ratio_value,
-        }
-    }
-
-    if region:
-        payload["input"]["region"] = region
-    if mask_url:
-        payload["input"]["mask_url"] = mask_url
-
-    # Pass R2 credentials for result upload (if configured)
-    if r2_config:
-        payload["input"]["r2"] = {
-            "endpoint_url": r2_config["endpoint_url"],
-            "access_key_id": r2_config["access_key_id"],
-            "secret_access_key": r2_config["secret_access_key"],
-            "bucket_name": r2_config["bucket_name"],
-        }
-
-    try:
-        response = requests.post(
-            url,
-            json=payload,
-            headers={"Authorization": f"Bearer {api_key}"},
-            timeout=30,
-        )
-
-        if response.status_code == 200:
-            return response.json()
-        else:
-            print(f"Job submission failed: HTTP {response.status_code}", file=sys.stderr)
-            print(f"  Response: {response.text[:500]}", file=sys.stderr)
-            return None
-
-    except Exception as e:
-        print(f"Job submission error: {e}", file=sys.stderr)
-        return None
-
-
-def poll_runpod_job(
-    endpoint_id: str,
-    api_key: str,
-    job_id: str,
-    timeout: int = 1800,
-    poll_interval: int = 5,
-    verbose: bool = True,
-) -> dict | None:
-    """Poll RunPod job until completion or timeout."""
-    url = f"https://api.runpod.ai/v2/{endpoint_id}/status/{job_id}"
-    headers = {"Authorization": f"Bearer {api_key}"}
-    start_time = time.time()
-    last_status = None
-    queue_timeout = 300  # Cancel job if stuck in queue for 5 min
-    queue_start = time.time()
-
-    while time.time() - start_time < timeout:
-        try:
-            response = requests.get(
-                url,
-                headers=headers,
-                timeout=30,
-            )
-
-            if response.status_code != 200:
-                print(f"Status check failed: HTTP {response.status_code}", file=sys.stderr)
-                time.sleep(poll_interval)
-                continue
-
-            data = response.json()
-            status = data.get("status")
-
-            # Log status changes
-            if verbose and status != last_status:
-                elapsed = int(time.time() - start_time)
-                print(f"  [{elapsed}s] Status: {status}", file=sys.stderr)
-                last_status = status
-
-            if status == "COMPLETED":
-                return data
-            elif status == "FAILED":
-                print(f"Job failed: {data.get('error', 'Unknown error')}", file=sys.stderr)
-                return data
-
-            # Track queue-to-progress transition
-            if status == "IN_PROGRESS" and queue_start is not None:
-                queue_start = None
-
-            # Cancel jobs stuck in queue too long (prevents runaway billing)
-            if status == "IN_QUEUE" and queue_start is not None and (time.time() - queue_start > queue_timeout):
-                print(f"Job stuck in queue for {queue_timeout}s — cancelling to prevent runaway charges", file=sys.stderr)
-                cancel_url = f"https://api.runpod.ai/v2/{endpoint_id}/cancel/{job_id}"
-                try:
-                    requests.post(cancel_url, headers=headers, timeout=10)
-                except Exception:
-                    pass
-                return {"status": "FAILED", "error": f"Cancelled: no GPU available after {queue_timeout}s in queue"}
-
-            time.sleep(poll_interval)
-
-        except Exception as e:
-            print(f"Status check error: {e}", file=sys.stderr)
-            time.sleep(poll_interval)
-
-    # Overall timeout — cancel the job so it doesn't linger in RunPod's queue
-    print(f"Job timed out after {timeout}s — cancelling on RunPod", file=sys.stderr)
-    cancel_url = f"https://api.runpod.ai/v2/{endpoint_id}/cancel/{job_id}"
-    try:
-        requests.post(cancel_url, headers=headers, timeout=10)
-    except Exception:
-        pass
-    return None
-
-
-def download_from_url(url: str, output_path: str, verbose: bool = True) -> bool:
-    """Download file from URL to local path."""
-    try:
-        if verbose:
-            print(f"Downloading result...", file=sys.stderr)
-
-        response = requests.get(url, stream=True, timeout=600)
-        response.raise_for_status()
-
-        total_size = int(response.headers.get('content-length', 0))
-        downloaded = 0
-
-        with open(output_path, 'wb') as f:
-            for chunk in response.iter_content(chunk_size=8192):
-                f.write(chunk)
-                downloaded += len(chunk)
-
-        if verbose:
-            size_mb = Path(output_path).stat().st_size // (1024 * 1024)
-            print(f"  Downloaded: {output_path} ({size_mb}MB)", file=sys.stderr)
-
-        return True
-
-    except Exception as e:
-        print(f"Download error: {e}", file=sys.stderr)
-        return False
 
 
 def resolve_preset_region(preset: str, width: int, height: int) -> str | None:
@@ -1378,20 +1018,11 @@ def suggest_resize_ratio(duration_seconds: float, width: int = 1280, height: int
     """
     Suggest a resize ratio based on video duration and resolution.
 
-    Based on empirical testing with 80GB A100:
-    - < 30s at 720p: 1.0 works (full resolution)
-    - 30-60s at 720p: 0.75 works
-    - 60-180s at 720p: 0.5 recommended
-    - > 180s at 720p: 0.5 + chunking recommended
-
     Returns (ratio, reason) tuple.
     """
-    # Adjust for resolution (720p is baseline)
     pixels = width * height
     pixels_720p = 1280 * 720
     resolution_factor = pixels / pixels_720p
-
-    # Effective duration accounting for resolution
     effective_duration = duration_seconds * resolution_factor
 
     if effective_duration <= 30:
@@ -1450,7 +1081,6 @@ def mux_audio_from_original(
 ) -> bool:
     """Mux audio from original video into processed video (ProPainter strips audio)."""
     try:
-        # Check if original has audio
         probe_cmd = [
             "ffprobe", "-v", "error", "-select_streams", "a",
             "-show_entries", "stream=codec_name", "-of", "json", original_video
@@ -1462,7 +1092,6 @@ def mux_audio_from_original(
         import json as json_module
         probe_data = json_module.loads(result.stdout)
         if not probe_data.get("streams"):
-            # No audio in original, just copy video
             if verbose:
                 print(f"  No audio in original, copying video only", file=sys.stderr)
             shutil.copy2(video_no_audio, output_path)
@@ -1471,7 +1100,6 @@ def mux_audio_from_original(
         if verbose:
             print(f"  Restoring audio from original...", file=sys.stderr)
 
-        # Mux audio from original into processed video
         cmd = [
             "ffmpeg", "-y",
             "-i", video_no_audio,
@@ -1490,7 +1118,7 @@ def mux_audio_from_original(
         return False
 
 
-def process_with_runpod(
+def process_with_cloud(
     input_path: str,
     output_path: str,
     region: str | None = None,
@@ -1502,108 +1130,75 @@ def process_with_runpod(
     upscale: bool = False,
     original_width: int | None = None,
     original_height: int | None = None,
+    cloud: str = "runpod",
 ) -> dict:
-    """
-    Process video using RunPod serverless endpoint.
-
-    Args:
-        upscale: If True and resize_ratio < 1.0, upscale output to original resolution
-        original_width/height: Original video dimensions (for upscaling)
-
-    Returns dict with success/error and metadata.
-    """
-    start_time = time.time()
-    r2_keys_to_cleanup = []  # Track R2 objects for cleanup
-
-    # Get RunPod config
-    config = get_runpod_config()
-    api_key = config.get("api_key")
-    endpoint_id = config.get("endpoint_id")
-
-    if not api_key:
-        return {"error": "RUNPOD_API_KEY not set. Add to .env file."}
-    if not endpoint_id:
-        return {"error": "RUNPOD_ENDPOINT_ID not set. Add to .env file."}
-
-    # Get R2 config (optional, for reliable file transfer)
-    sys.path.insert(0, str(Path(__file__).parent))
-    try:
-        from config import get_r2_config
-        r2_config = get_r2_config()
-    except ImportError:
-        r2_config = None
+    """Process video using cloud GPU endpoint (RunPod or Modal)."""
+    r2_keys_to_cleanup = []
 
     if verbose:
-        print(f"Using RunPod endpoint: {endpoint_id}", file=sys.stderr)
-        if r2_config:
-            print(f"Using Cloudflare R2 for file transfer", file=sys.stderr)
-        else:
-            print(f"R2 not configured, using free file hosting (less reliable)", file=sys.stderr)
+        print(f"Cloud provider: {cloud}", file=sys.stderr)
 
     # Upload video
-    video_url, video_r2_key = upload_to_runpod_storage(input_path, api_key)
+    video_url, video_r2_key = upload_to_storage(input_path, "dewatermark/input")
     if not video_url:
         return {"error": "Failed to upload video"}
     if video_r2_key:
         r2_keys_to_cleanup.append(video_r2_key)
 
-    # Upload mask if provided (instead of region)
+    # Upload mask if provided
     mask_url = None
     if mask_path:
-        mask_url, mask_r2_key = upload_to_runpod_storage(mask_path, api_key)
+        mask_url, mask_r2_key = upload_to_storage(mask_path, "dewatermark/mask")
         if not mask_url:
             return {"error": "Failed to upload mask"}
         if mask_r2_key:
             r2_keys_to_cleanup.append(mask_r2_key)
 
-    # Submit job
-    if verbose:
-        print(f"Submitting job...", file=sys.stderr)
+    # Build payload
+    ratio_value = "auto" if resize_ratio == "auto" else float(resize_ratio)
 
-    job_response = submit_runpod_job(
-        endpoint_id=endpoint_id,
-        api_key=api_key,
-        video_url=video_url,
-        region=region,
-        mask_url=mask_url,
-        r2_config=r2_config,
-        resize_ratio=resize_ratio,
-    )
+    payload = {
+        "input": {
+            "operation": "dewatermark",
+            "video_url": video_url,
+            "resize_ratio": ratio_value,
+        }
+    }
 
-    if not job_response:
-        return {"error": "Failed to submit job"}
+    if region:
+        payload["input"]["region"] = region
+    if mask_url:
+        payload["input"]["mask_url"] = mask_url
 
-    job_id = job_response.get("id")
-    if not job_id:
-        return {"error": f"No job ID in response: {job_response}"}
+    r2_payload = get_r2_payload_config()
+    if r2_payload:
+        payload["input"]["r2"] = r2_payload
 
-    if verbose:
-        print(f"Job submitted: {job_id}", file=sys.stderr)
-        print(f"Waiting for completion (timeout: {timeout}s)...", file=sys.stderr)
+    # For Modal, the endpoint expects the inner payload directly
+    modal_payload = payload["input"] if cloud == "modal" else payload
 
-    # Poll for completion
-    result = poll_runpod_job(
-        endpoint_id=endpoint_id,
-        api_key=api_key,
-        job_id=job_id,
+    # Call cloud GPU endpoint
+    from cloud_gpu import call_cloud_endpoint
+
+    result, elapsed = call_cloud_endpoint(
+        provider=cloud,
+        payload=modal_payload,
+        tool_name="dewatermark",
         timeout=timeout,
+        progress_label="Removing watermark",
         verbose=verbose,
     )
 
-    if not result:
-        return {"error": "Job timed out or failed to get status"}
+    if isinstance(result, dict) and result.get("error"):
+        return {"error": result["error"]}
 
-    status = result.get("status")
-    if status != "COMPLETED":
-        error = result.get("error") or result.get("output", {}).get("error") or "Unknown error"
-        return {"error": f"Job failed: {error}"}
+    # Extract output (RunPod wraps in "output", Modal returns directly)
+    output = result.get("output", result) if cloud == "runpod" else result
 
-    # Get output from result
-    output = result.get("output", {})
     if isinstance(output, dict) and output.get("error"):
         return {"error": output["error"]}
 
-    # Download result - try R2 first if key provided, then URL
+    # Download result
     Path(output_path).parent.mkdir(parents=True, exist_ok=True)
     downloaded = False
 
@@ -1613,18 +1208,27 @@ def process_with_runpod(
     if output_r2_key:
         if verbose:
             print(f"Downloading result from R2...", file=sys.stderr)
-        downloaded = _download_from_r2(output_r2_key, output_path)
+        downloaded = download_from_r2(output_r2_key, output_path)
         if downloaded:
             r2_keys_to_cleanup.append(output_r2_key)
-            if verbose:
-                size_mb = Path(output_path).stat().st_size // (1024 * 1024)
-                print(f"  Downloaded: {output_path} ({size_mb}MB)", file=sys.stderr)
 
     if not downloaded and output_url:
         downloaded = download_from_url(output_url, output_path, verbose=verbose)
 
     if not downloaded:
-        return {"error": f"No output_url or r2_key in result: {output}"}
+        # Try base64 fallback (Modal returns base64 when no R2)
+        video_b64 = output.get("video_base64") if isinstance(output, dict) else None
+        if video_b64:
+            import base64
+            with open(output_path, "wb") as f:
+                f.write(base64.b64decode(video_b64))
+            downloaded = True
+            if verbose:
+                size_mb = Path(output_path).stat().st_size // (1024 * 1024)
+                print(f"  Downloaded: {output_path} ({size_mb}MB)", file=sys.stderr)
+
+    if not downloaded:
+        return {"error": f"No output_url, r2_key, or video_base64 in result"}
 
     # Restore audio from original (ProPainter strips audio)
     if preserve_audio:
@@ -1633,7 +1237,6 @@ def process_with_runpod(
         if mux_audio_from_original(temp_video, input_path, output_path, verbose=verbose):
             Path(temp_video).unlink(missing_ok=True)
         else:
-            # Fallback: keep video without audio
             shutil.move(temp_video, output_path)
             if verbose:
                 print(f"  Warning: Could not restore audio, output has no audio", file=sys.stderr)
@@ -1646,7 +1249,6 @@ def process_with_runpod(
         if upscale_video(temp_video, output_path, original_width, original_height, verbose=verbose):
             Path(temp_video).unlink(missing_ok=True)
         else:
-            # Fallback: keep smaller video
             shutil.move(temp_video, output_path)
             if verbose:
                 print(f"  Warning: Upscale failed, output is at reduced resolution", file=sys.stderr)
@@ -1656,16 +1258,15 @@ def process_with_runpod(
         if verbose:
             print(f"Cleaning up {len(r2_keys_to_cleanup)} R2 objects...", file=sys.stderr)
         for key in r2_keys_to_cleanup:
-            _delete_from_r2(key)
-
-    elapsed = time.time() - start_time
+            delete_from_r2(key)
 
     return {
         "success": True,
         "output": output_path,
-        "job_id": job_id,
         "processing_time_seconds": round(elapsed, 2),
-        "runpod_output": output,
+        "cloud_output": output if not output.get("video_base64") else {
+            k: v for k, v in output.items() if k != "video_base64"
+        },
     }
 
 
@@ -1989,7 +1590,7 @@ def setup_runpod(gpu_id: str = "AMPERE_24", verbose: bool = True) -> dict:
             print(f"Endpoint ID:  {result['endpoint_id']}")
             print()
             print("You can now run:")
-            print("  python tools/dewatermark.py --input video.mp4 --region x,y,w,h --output out.mp4 --runpod")
+            print("  python tools/dewatermark.py --input video.mp4 --region x,y,w,h --output out.mp4 --cloud runpod")
             print()
 
     except Exception as e:
@@ -2064,8 +1665,14 @@ def main():
         print(f"Error: Input file not found: {args.input}", file=sys.stderr)
         sys.exit(1)
 
-    # RunPod cloud processing
+    # Handle deprecated --runpod flag
     if args.runpod:
+        print("Note: --runpod is deprecated, use --cloud runpod instead", file=sys.stderr)
+        if not args.cloud:
+            args.cloud = "runpod"
+
+    # Cloud GPU processing
+    if args.cloud:
         # Get video info for smart resize ratio suggestion
         video_info = get_video_info(args.input)
         video_width = video_info.get("width", 1280)
@@ -2096,10 +1703,11 @@ def main():
                 resize_ratio = 0.5  # Safe default
 
         if args.dry_run:
-            config = get_runpod_config()
+            from cloud_gpu import get_provider_config
+            config = get_provider_config(args.cloud, "dewatermark")
             result = {
                 "dry_run": True,
-                "mode": "runpod",
+                "mode": args.cloud,
                 "input": args.input,
                 "output": args.output,
                 "preset": args.preset,
@@ -2109,32 +1717,31 @@ def main():
                 "video_duration": f"{video_duration:.1f}s",
                 "resize_ratio": resize_ratio,
                 "upscale": args.upscale,
-                "endpoint_configured": bool(config.get("endpoint_id")),
-                "api_key_configured": bool(config.get("api_key")),
-                "timeout": args.runpod_timeout,
+                "timeout": args.timeout,
             }
             if args.json:
                 print(json.dumps(result, indent=2))
             else:
-                print("Would process with RunPod:")
+                print(f"Would process with {args.cloud}:")
                 for k, v in result.items():
                     print(f"  {k}: {v}")
             return
 
         if verbose:
-            print("Processing with RunPod cloud GPU...")
+            print(f"Processing with {args.cloud} cloud GPU...")
 
-        result = process_with_runpod(
+        result = process_with_cloud(
             input_path=args.input,
             output_path=args.output,
             region=region,
             mask_path=args.mask,
-            timeout=args.runpod_timeout,
+            timeout=args.timeout,
             verbose=verbose,
             resize_ratio=resize_ratio,
             upscale=args.upscale,
             original_width=video_width,
             original_height=video_height,
+            cloud=args.cloud,
         )
 
         if result.get("error"):

--- a/tools/file_transfer.py
+++ b/tools/file_transfer.py
@@ -1,0 +1,215 @@
+"""Shared file transfer helpers for cloud GPU tools.
+
+Provides R2 upload/download with fallback to free services (litterbox, 0x0.st).
+Used by all cloud GPU tools to avoid duplicating file transfer logic.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+
+def get_r2_client():
+    """Get boto3 S3 client configured for Cloudflare R2.
+
+    Returns (client, config_dict) or (None, None) if R2 is not configured.
+    """
+    sys.path.insert(0, str(Path(__file__).parent))
+    try:
+        from config import get_r2_config
+        r2_config = get_r2_config()
+    except ImportError:
+        r2_config = None
+
+    if not r2_config:
+        return None, None
+
+    try:
+        import boto3
+        from botocore.config import Config
+
+        client = boto3.client(
+            "s3",
+            endpoint_url=r2_config["endpoint_url"],
+            aws_access_key_id=r2_config["access_key_id"],
+            aws_secret_access_key=r2_config["secret_access_key"],
+            config=Config(signature_version="s3v4"),
+        )
+        return client, r2_config
+    except ImportError:
+        print("  boto3 not installed, skipping R2", file=sys.stderr)
+        return None, None
+
+
+def upload_to_r2(file_path: str, prefix: str) -> tuple[str | None, str | None]:
+    """Upload to Cloudflare R2 and return presigned download URL.
+
+    Returns (presigned_url, object_key) or (None, None) on failure.
+    """
+    client, config = get_r2_client()
+    if not client:
+        return None, None
+
+    import uuid
+    file_name = Path(file_path).name
+    object_key = f"{prefix}/{uuid.uuid4().hex[:8]}_{file_name}"
+
+    try:
+        client.upload_file(file_path, config["bucket_name"], object_key)
+
+        url = client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": config["bucket_name"], "Key": object_key},
+            ExpiresIn=7200,
+        )
+        return url, object_key
+    except Exception as e:
+        print(f"  R2 upload error: {e}", file=sys.stderr)
+        return None, None
+
+
+def download_from_r2(object_key: str, output_path: str) -> bool:
+    """Download object from R2 to local path."""
+    client, config = get_r2_client()
+    if not client:
+        return False
+
+    try:
+        client.download_file(config["bucket_name"], object_key, output_path)
+        return True
+    except Exception as e:
+        print(f"  R2 download error: {e}", file=sys.stderr)
+        return False
+
+
+def delete_from_r2(object_key: str) -> bool:
+    """Delete object from R2 after job completion."""
+    client, config = get_r2_client()
+    if not client or not object_key:
+        return False
+
+    try:
+        client.delete_object(Bucket=config["bucket_name"], Key=object_key)
+        return True
+    except Exception:
+        return False
+
+
+def _upload_to_litterbox(file_path: str, file_name: str) -> str | None:
+    """Upload to litterbox.catbox.moe (200MB limit, 24h retention)."""
+    import subprocess
+    result = subprocess.run(
+        [
+            "curl", "-s",
+            "-F", "reqtype=fileupload",
+            "-F", "time=24h",
+            "-F", f"fileToUpload=@{file_path}",
+            "https://litterbox.catbox.moe/resources/internals/api.php",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    if result.returncode == 0:
+        url = result.stdout.strip()
+        if url.startswith("http"):
+            return url
+    return None
+
+
+def _upload_to_0x0(file_path: str, file_name: str) -> str | None:
+    """Upload to 0x0.st (512MB limit, 30 day retention)."""
+    import subprocess
+    result = subprocess.run(
+        ["curl", "-s", "-F", f"file=@{file_path}", "https://0x0.st"],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    if result.returncode == 0:
+        url = result.stdout.strip()
+        if url.startswith("http"):
+            return url
+    return None
+
+
+def upload_to_storage(file_path: str, prefix: str) -> tuple[str | None, str | None]:
+    """Upload a file to temporary storage for cloud GPU job input.
+
+    Tries R2 first, falls back to litterbox (24h/200MB), then 0x0.st (30d/512MB).
+
+    Returns (url, r2_key) where r2_key is set only for R2 uploads (for cleanup).
+    """
+    file_size = Path(file_path).stat().st_size
+    file_name = Path(file_path).name
+
+    print(f"Uploading {file_name} ({file_size // 1024}KB)...", file=sys.stderr)
+
+    url, r2_key = upload_to_r2(file_path, prefix)
+    if url:
+        print(f"  Upload complete (R2)", file=sys.stderr)
+        return url, r2_key
+
+    # Fall back to free services
+    for service_name, upload_func in [("litterbox", _upload_to_litterbox), ("0x0.st", _upload_to_0x0)]:
+        try:
+            url = upload_func(file_path, file_name)
+            if url:
+                print(f"  Upload complete ({service_name})", file=sys.stderr)
+                return url, None
+        except Exception as e:
+            print(f"  {service_name} failed: {e}", file=sys.stderr)
+            continue
+
+    print("All upload services failed", file=sys.stderr)
+    return None, None
+
+
+def download_from_url(url: str, output_path: str, verbose: bool = True) -> bool:
+    """Download file from URL to local path with streaming."""
+    import requests
+
+    try:
+        if verbose:
+            print(f"Downloading result...", file=sys.stderr)
+
+        response = requests.get(url, stream=True, timeout=300)
+        response.raise_for_status()
+
+        with open(output_path, 'wb') as f:
+            for chunk in response.iter_content(chunk_size=8192):
+                f.write(chunk)
+
+        if verbose:
+            size_kb = Path(output_path).stat().st_size // 1024
+            print(f"  Downloaded: {output_path} ({size_kb}KB)", file=sys.stderr)
+
+        return True
+
+    except Exception as e:
+        print(f"Download error: {e}", file=sys.stderr)
+        return False
+
+
+def get_r2_payload_config() -> dict | None:
+    """Get R2 config dict for embedding in cloud GPU job payloads.
+
+    Returns the dict to include as payload["input"]["r2"], or None if R2
+    is not configured. This is the format expected by RunPod/Modal handlers.
+    """
+    sys.path.insert(0, str(Path(__file__).parent))
+    try:
+        from config import get_r2_config
+        r2_config = get_r2_config()
+    except ImportError:
+        r2_config = None
+
+    if not r2_config:
+        return None
+
+    return {
+        "endpoint_url": r2_config["endpoint_url"],
+        "access_key_id": r2_config["access_key_id"],
+        "secret_access_key": r2_config["secret_access_key"],
+        "bucket_name": r2_config["bucket_name"],
+    }

--- a/tools/file_transfer.py
+++ b/tools/file_transfer.py
@@ -33,6 +33,7 @@ def get_r2_client():
             endpoint_url=r2_config["endpoint_url"],
             aws_access_key_id=r2_config["access_key_id"],
             aws_secret_access_key=r2_config["secret_access_key"],
+            region_name="auto",
             config=Config(signature_version="s3v4"),
         )
         return client, r2_config

--- a/tools/flux2.py
+++ b/tools/flux2.py
@@ -51,22 +51,8 @@ except ImportError as e:
 
 load_dotenv()
 
-def _get_r2_config() -> Optional[dict]:
-    """Get R2 config for result upload. Returns None if not configured."""
-    sys.path.insert(0, str(Path(__file__).parent))
-    try:
-        from config import get_r2_config
-        return get_r2_config()
-    except ImportError:
-        return None
-
-
-def _download_r2_result(url: str, output_path: str):
-    """Download result image from R2 presigned URL."""
-    response = requests.get(url, timeout=60)
-    response.raise_for_status()
-    with open(output_path, "wb") as f:
-        f.write(response.content)
+sys.path.insert(0, str(Path(__file__).parent))
+from file_transfer import download_from_url, get_r2_payload_config
 
 
 RUNPOD_GRAPHQL_URL = "https://api.runpod.io/graphql"
@@ -309,23 +295,6 @@ def log(msg: str, level: str = "info"):
     print(f"{color}{prefix.get(level, '->')} {msg}{reset}")
 
 
-def get_config() -> dict:
-    """Get RunPod configuration from environment."""
-    sys.path.insert(0, str(Path(__file__).parent))
-    try:
-        from config import get_runpod_api_key
-        api_key = get_runpod_api_key()
-    except ImportError:
-        api_key = os.getenv("RUNPOD_API_KEY")
-
-    endpoint_id = os.getenv(ENV_VAR_NAME)
-
-    return {
-        "api_key": api_key,
-        "endpoint_id": endpoint_id,
-    }
-
-
 def encode_image(path: str) -> str:
     """Encode image file to base64."""
     with open(path, "rb") as f:
@@ -336,98 +305,6 @@ def decode_and_save(base64_data: str, output_path: str):
     """Decode base64 and save to file."""
     with open(output_path, "wb") as f:
         f.write(base64.b64decode(base64_data))
-
-
-def call_endpoint(payload: dict, timeout: int = 600) -> tuple[dict, float]:
-    """Call RunPod endpoint and return (result, elapsed_seconds)."""
-    config = get_config()
-    api_key = config.get("api_key")
-    endpoint_id = config.get("endpoint_id")
-
-    if not api_key:
-        return {"error": "RUNPOD_API_KEY not set in .env"}, 0
-    if not endpoint_id:
-        return {"error": f"{ENV_VAR_NAME} not set. Run with --setup first."}, 0
-
-    headers = {
-        "Authorization": f"Bearer {api_key}",
-        "Content-Type": "application/json"
-    }
-
-    start = time.time()
-
-    try:
-        run_url = f"https://api.runpod.ai/v2/{endpoint_id}/run"
-        response = requests.post(run_url, json=payload, headers=headers, timeout=30)
-        response.raise_for_status()
-        result = response.json()
-
-        job_id = result.get("id")
-        status = result.get("status")
-
-        if status == "COMPLETED":
-            return result.get("output", result), time.time() - start
-
-        if status == "FAILED":
-            return {"error": result.get("error", "Unknown error")}, time.time() - start
-
-        # Poll for completion
-        log("Processing... (cold start may take 3-5 min on first run)", "warn")
-        status_url = f"https://api.runpod.ai/v2/{endpoint_id}/status/{job_id}"
-
-        poll_interval = 5
-        queue_timeout = 300  # Cancel job if stuck in queue for 5 min
-        queue_start = time.time()
-        last_status = None
-        while time.time() - start < timeout:
-            time.sleep(poll_interval)
-            elapsed = time.time() - start
-
-            status_resp = requests.get(status_url, headers=headers, timeout=30)
-            status_data = status_resp.json()
-            status = status_data.get("status")
-
-            if status != last_status:
-                if status == "IN_PROGRESS":
-                    log(f"[{elapsed:.0f}s] Generating...", "dim")
-                    queue_start = None  # No longer queued
-                elif status == "IN_QUEUE":
-                    log(f"[{elapsed:.0f}s] Waiting for GPU...", "dim")
-                last_status = status
-
-            if status == "COMPLETED":
-                return status_data.get("output", status_data), time.time() - start
-
-            if status == "FAILED":
-                error = status_data.get("error", "Unknown error")
-                return {"error": error}, time.time() - start
-
-            if status in ("CANCELLED", "TIMED_OUT"):
-                return {"error": f"Job {status}"}, time.time() - start
-
-            # Cancel jobs stuck in queue too long (prevents runaway billing)
-            if status == "IN_QUEUE" and queue_start and (time.time() - queue_start > queue_timeout):
-                log(f"Job stuck in queue for {queue_timeout}s — cancelling to prevent runaway charges", "warn")
-                cancel_url = f"https://api.runpod.ai/v2/{endpoint_id}/cancel/{job_id}"
-                try:
-                    requests.post(cancel_url, headers=headers, timeout=10)
-                except Exception:
-                    pass
-                return {"error": f"Cancelled: no GPU available after {queue_timeout}s in queue"}, time.time() - start
-
-        # Timeout — cancel the job so it doesn't linger in RunPod's queue
-        log("Polling timeout — cancelling job on RunPod", "warn")
-        cancel_url = f"https://api.runpod.ai/v2/{endpoint_id}/cancel/{job_id}"
-        try:
-            requests.post(cancel_url, headers=headers, timeout=10)
-        except Exception:
-            pass
-        return {"error": "polling timeout (job cancelled)"}, time.time() - start
-
-    except requests.exceptions.Timeout:
-        return {"error": "timeout"}, time.time() - start
-    except Exception as e:
-        return {"error": str(e)}, time.time() - start
 
 
 def generate_image(
@@ -472,14 +349,9 @@ def generate_image(
     if guidance is not None:
         payload["input"]["guidance_scale"] = guidance
 
-    r2_config = _get_r2_config()
-    if r2_config:
-        payload["input"]["r2"] = {
-            "endpoint_url": r2_config["endpoint_url"],
-            "access_key_id": r2_config["access_key_id"],
-            "secret_access_key": r2_config["secret_access_key"],
-            "bucket_name": r2_config["bucket_name"],
-        }
+    r2_payload = get_r2_payload_config()
+    if r2_payload:
+        payload["input"]["r2"] = r2_payload
 
     try:
         from cloud_gpu import call_cloud_endpoint
@@ -502,7 +374,7 @@ def generate_image(
 
     if "output_url" in result:
         log("Downloading from R2...", "dim")
-        _download_r2_result(result["output_url"], output_path)
+        download_from_url(result["output_url"], output_path, verbose=False)
     else:
         decode_and_save(result["image_base64"], output_path)
 
@@ -573,14 +445,9 @@ def edit_image(
     if guidance is not None:
         payload["input"]["guidance_scale"] = guidance
 
-    r2_config = _get_r2_config()
-    if r2_config:
-        payload["input"]["r2"] = {
-            "endpoint_url": r2_config["endpoint_url"],
-            "access_key_id": r2_config["access_key_id"],
-            "secret_access_key": r2_config["secret_access_key"],
-            "bucket_name": r2_config["bucket_name"],
-        }
+    r2_payload = get_r2_payload_config()
+    if r2_payload:
+        payload["input"]["r2"] = r2_payload
 
     try:
         from cloud_gpu import call_cloud_endpoint
@@ -603,7 +470,7 @@ def edit_image(
 
     if "output_url" in result:
         log("Downloading from R2...", "dim")
-        _download_r2_result(result["output_url"], output_path)
+        download_from_url(result["output_url"], output_path, verbose=False)
     else:
         decode_and_save(result["image_base64"], output_path)
 
@@ -853,8 +720,7 @@ def setup_runpod(gpu_id: str = "AMPERE_24,ADA_24", verbose: bool = True) -> dict
         "created_endpoint": False,
     }
 
-    config = get_config()
-    api_key = config.get("api_key")
+    api_key = os.getenv("RUNPOD_API_KEY")
 
     if not api_key:
         result["error"] = "RUNPOD_API_KEY not set. Add to .env file first."

--- a/tools/flux2.py
+++ b/tools/flux2.py
@@ -440,6 +440,7 @@ def generate_image(
     guidance: Optional[float] = None,
     open_result: bool = True,
     verbose: bool = False,
+    cloud: str = "runpod",
 ) -> Optional[str]:
     """
     Generate image from text prompt.
@@ -480,7 +481,20 @@ def generate_image(
             "bucket_name": r2_config["bucket_name"],
         }
 
-    result, elapsed = call_endpoint(payload)
+    try:
+        from cloud_gpu import call_cloud_endpoint
+    except ImportError:
+        sys.path.insert(0, str(Path(__file__).parent))
+        from cloud_gpu import call_cloud_endpoint
+
+    result, elapsed = call_cloud_endpoint(
+        provider=cloud,
+        payload=payload,
+        tool_name="flux2",
+        timeout=600,
+        progress_label="Generating image",
+        verbose=True,
+    )
 
     if "error" in result:
         log(f"Generation failed: {result['error']}", "error")
@@ -500,10 +514,6 @@ def generate_image(
     log(f"Output: {output_size[0]}x{output_size[1]}", "dim")
     log(f"Seed: {result.get('seed', 'unknown')}", "dim")
 
-    if verbose:
-        cost = (elapsed / 3600) * 0.34
-        log(f"Est. cost: ${cost:.4f}", "dim")
-
     if open_result and sys.platform == "darwin":
         import subprocess
         subprocess.run(["open", output_path], check=False)
@@ -520,6 +530,7 @@ def edit_image(
     guidance: Optional[float] = None,
     open_result: bool = True,
     verbose: bool = False,
+    cloud: str = "runpod",
 ) -> Optional[str]:
     """
     Edit image(s) with the given prompt.
@@ -571,7 +582,20 @@ def edit_image(
             "bucket_name": r2_config["bucket_name"],
         }
 
-    result, elapsed = call_endpoint(payload)
+    try:
+        from cloud_gpu import call_cloud_endpoint
+    except ImportError:
+        sys.path.insert(0, str(Path(__file__).parent))
+        from cloud_gpu import call_cloud_endpoint
+
+    result, elapsed = call_cloud_endpoint(
+        provider=cloud,
+        payload=payload,
+        tool_name="flux2",
+        timeout=600,
+        progress_label="Editing image",
+        verbose=True,
+    )
 
     if "error" in result:
         log(f"Edit failed: {result['error']}", "error")
@@ -590,10 +614,6 @@ def edit_image(
     log(f"Time: {elapsed:.1f}s total, {inference_ms/1000:.1f}s inference", "dim")
     log(f"Output: {output_size[0]}x{output_size[1]}", "dim")
     log(f"Seed: {result.get('seed', 'unknown')}", "dim")
-
-    if verbose:
-        cost = (elapsed / 3600) * 0.34
-        log(f"Est. cost: ${cost:.4f}", "dim")
 
     if open_result and sys.platform == "darwin":
         import subprocess
@@ -955,11 +975,13 @@ Examples:
     adv_group.add_argument("--guidance", "-g", type=float, help="Guidance scale (default: 1.0 for generate, 4.0 for edit)")
     adv_group.add_argument("--verbose", action="store_true", help="Show detailed output")
 
-    # Setup
-    setup_group = parser.add_argument_group("Setup")
-    setup_group.add_argument("--setup", action="store_true", help="Set up RunPod endpoint")
-    setup_group.add_argument("--setup-gpu", type=str, default="AMPERE_24,ADA_24",
-                             help="GPU type(s) for endpoint, comma-separated for fallback (default: AMPERE_24,ADA_24)")
+    # Cloud GPU
+    cloud_group = parser.add_argument_group("Cloud GPU")
+    cloud_group.add_argument("--cloud", type=str, default="runpod", choices=["runpod", "modal"],
+                             help="Cloud GPU provider (default: runpod)")
+    cloud_group.add_argument("--setup", action="store_true", help="Set up cloud endpoint")
+    cloud_group.add_argument("--setup-gpu", type=str, default="AMPERE_24,ADA_24",
+                             help="GPU type(s) for RunPod endpoint (default: AMPERE_24,ADA_24)")
 
     # Output format
     parser.add_argument("--json", action="store_true", help="Output result as JSON")
@@ -1013,6 +1035,7 @@ Examples:
             guidance=args.guidance,
             open_result=not args.no_open,
             verbose=args.verbose,
+            cloud=args.cloud,
         )
     else:
         # Generate mode
@@ -1026,6 +1049,7 @@ Examples:
             guidance=args.guidance,
             open_result=not args.no_open,
             verbose=args.verbose,
+            cloud=args.cloud,
         )
 
 

--- a/tools/image_edit.py
+++ b/tools/image_edit.py
@@ -2,6 +2,8 @@
 """
 AI-powered image editing using Qwen-Image-Edit-2511.
 
+Cloud providers: RunPod (default), Modal.
+
 Capabilities:
 - Background replacement (--background)
 - Style transfer (--style)
@@ -20,11 +22,8 @@ Examples:
   # Custom prompt (full control)
   python tools/image_edit.py --input photo.jpg --prompt "Add warm sunset lighting"
 
-  # Multi-image merge (group photo)
-  python tools/image_edit.py --input person1.jpg person2.jpg --prompt "Both standing together in a park"
-
-  # Viewpoint change
-  python tools/image_edit.py --input photo.jpg --viewpoint "front facing"
+  # Using Modal instead of RunPod
+  python tools/image_edit.py --input photo.jpg --background "office" --cloud modal
 
   # Batch processing
   python tools/image_edit.py --input-dir ./photos --background "studio backdrop" --output-dir ./edited
@@ -37,43 +36,20 @@ import argparse
 import base64
 import io
 import json
-import os
 import sys
-import time
 from pathlib import Path
 from typing import Optional
 
 try:
     import requests
     from PIL import Image
-    from dotenv import load_dotenv
 except ImportError as e:
     print(f"Missing dependency: {e}")
-    print("Install with: pip install requests Pillow python-dotenv")
+    print("Install with: pip install requests Pillow")
     sys.exit(1)
 
-load_dotenv()
-
-RUNPOD_API_KEY = os.getenv("RUNPOD_API_KEY")
-QWEN_EDIT_ENDPOINT = os.getenv("RUNPOD_QWEN_EDIT_ENDPOINT_ID")
-
-
-def _get_r2_config() -> Optional[dict]:
-    """Get R2 config for result upload. Returns None if not configured."""
-    sys.path.insert(0, str(Path(__file__).parent))
-    try:
-        from config import get_r2_config
-        return get_r2_config()
-    except ImportError:
-        return None
-
-
-def _download_r2_result(url: str, output_path: str):
-    """Download result image from R2 presigned URL."""
-    response = requests.get(url, timeout=60)
-    response.raise_for_status()
-    with open(output_path, "wb") as f:
-        f.write(response.content)
+sys.path.insert(0, str(Path(__file__).parent))
+from file_transfer import download_from_url, get_r2_payload_config
 
 # Background presets
 BACKGROUND_PRESETS = {
@@ -180,99 +156,6 @@ def build_prompt(
     return prompt
 
 
-def call_endpoint(payload: dict, timeout: int = 600) -> tuple[dict, float]:
-    """Call RunPod endpoint and return (result, elapsed_seconds)."""
-    if not RUNPOD_API_KEY:
-        log("RUNPOD_API_KEY not set in .env", "error")
-        sys.exit(1)
-
-    if not QWEN_EDIT_ENDPOINT:
-        log("RUNPOD_QWEN_EDIT_ENDPOINT_ID not set in .env", "error")
-        log("Deploy the endpoint first, then add to .env", "info")
-        sys.exit(1)
-
-    headers = {
-        "Authorization": f"Bearer {RUNPOD_API_KEY}",
-        "Content-Type": "application/json"
-    }
-
-    start = time.time()
-
-    try:
-        # Submit async job
-        run_url = f"https://api.runpod.ai/v2/{QWEN_EDIT_ENDPOINT}/run"
-        response = requests.post(run_url, json=payload, headers=headers, timeout=30)
-        response.raise_for_status()
-        result = response.json()
-
-        job_id = result.get("id")
-        status = result.get("status")
-
-        if status == "COMPLETED":
-            return result.get("output", result), time.time() - start
-
-        if status == "FAILED":
-            return {"error": result.get("error", "Unknown error")}, time.time() - start
-
-        # Poll for completion
-        log(f"Processing... (cold start may take 5-10 min on first run)", "warn")
-        status_url = f"https://api.runpod.ai/v2/{QWEN_EDIT_ENDPOINT}/status/{job_id}"
-
-        poll_interval = 5
-        queue_timeout = 300  # Cancel job if stuck in queue for 5 min
-        queue_start = time.time()
-        last_status = None
-        while time.time() - start < timeout:
-            time.sleep(poll_interval)
-            elapsed = time.time() - start
-
-            status_resp = requests.get(status_url, headers=headers, timeout=30)
-            status_data = status_resp.json()
-            status = status_data.get("status")
-
-            if status != last_status:
-                if status == "IN_PROGRESS":
-                    log(f"[{elapsed:.0f}s] Generating...", "dim")
-                    queue_start = None  # No longer queued
-                elif status == "IN_QUEUE":
-                    log(f"[{elapsed:.0f}s] Waiting for GPU...", "dim")
-                last_status = status
-
-            if status == "COMPLETED":
-                return status_data.get("output", status_data), time.time() - start
-
-            if status == "FAILED":
-                error = status_data.get("error", "Unknown error")
-                return {"error": error}, time.time() - start
-
-            if status in ("CANCELLED", "TIMED_OUT"):
-                return {"error": f"Job {status}"}, time.time() - start
-
-            # Cancel jobs stuck in queue too long (prevents runaway billing)
-            if status == "IN_QUEUE" and queue_start and (time.time() - queue_start > queue_timeout):
-                log(f"Job stuck in queue for {queue_timeout}s — cancelling to prevent runaway charges", "warn")
-                cancel_url = f"https://api.runpod.ai/v2/{QWEN_EDIT_ENDPOINT}/cancel/{job_id}"
-                try:
-                    requests.post(cancel_url, headers=headers, timeout=10)
-                except Exception:
-                    pass
-                return {"error": f"Cancelled: no GPU available after {queue_timeout}s in queue"}, time.time() - start
-
-        # Timeout — cancel the job so it doesn't linger in RunPod's queue
-        log("Polling timeout — cancelling job on RunPod", "warn")
-        cancel_url = f"https://api.runpod.ai/v2/{QWEN_EDIT_ENDPOINT}/cancel/{job_id}"
-        try:
-            requests.post(cancel_url, headers=headers, timeout=10)
-        except Exception:
-            pass
-        return {"error": "polling timeout (job cancelled)"}, time.time() - start
-
-    except requests.exceptions.Timeout:
-        return {"error": "timeout"}, time.time() - start
-    except Exception as e:
-        return {"error": str(e)}, time.time() - start
-
-
 def edit_image(
     input_paths: list[str],
     prompt: str,
@@ -283,6 +166,7 @@ def edit_image(
     negative_prompt: Optional[str] = None,
     open_result: bool = True,
     verbose: bool = False,
+    cloud: str = "runpod",
 ) -> Optional[str]:
     """
     Edit image(s) with the given prompt.
@@ -329,17 +213,21 @@ def edit_image(
         payload["input"]["negative_prompt"] = negative_prompt
         log(f"Negative: {negative_prompt}", "dim")
 
-    r2_config = _get_r2_config()
-    if r2_config:
-        payload["input"]["r2"] = {
-            "endpoint_url": r2_config["endpoint_url"],
-            "access_key_id": r2_config["access_key_id"],
-            "secret_access_key": r2_config["secret_access_key"],
-            "bucket_name": r2_config["bucket_name"],
-        }
+    r2_payload = get_r2_payload_config()
+    if r2_payload:
+        payload["input"]["r2"] = r2_payload
 
-    # Call endpoint
-    result, elapsed = call_endpoint(payload)
+    # Call cloud GPU endpoint
+    from cloud_gpu import call_cloud_endpoint
+
+    result, elapsed = call_cloud_endpoint(
+        provider=cloud,
+        payload=payload,
+        tool_name="image_edit",
+        timeout=600,
+        progress_label="Editing image",
+        verbose=verbose,
+    )
 
     if "error" in result:
         log(f"Edit failed: {result['error']}", "error")
@@ -353,7 +241,7 @@ def edit_image(
     # Save result
     if "output_url" in result:
         log("Downloading from R2...", "dim")
-        _download_r2_result(result["output_url"], output_path)
+        download_from_url(result["output_url"], output_path, verbose=False)
     else:
         decode_and_save(result["edited_image_base64"], output_path)
 
@@ -365,11 +253,6 @@ def edit_image(
     log(f"Time: {elapsed:.1f}s total, {inference_ms/1000:.1f}s inference", "dim")
     log(f"Output: {output_size[0]}x{output_size[1]}", "dim")
     log(f"Seed: {result.get('seed', 'unknown')}", "dim")
-
-    if verbose:
-        # Estimate cost (L4 pricing)
-        cost = (elapsed / 3600) * 0.34
-        log(f"Est. cost: ${cost:.4f}", "dim")
 
     # Open result on macOS
     if open_result and sys.platform == "darwin":
@@ -386,6 +269,7 @@ def batch_edit(
     seed: Optional[int] = None,
     steps: int = 8,
     verbose: bool = False,
+    cloud: str = "runpod",
 ) -> tuple[int, int]:
     """
     Batch edit all images in a directory.
@@ -426,6 +310,7 @@ def batch_edit(
             steps=steps,
             open_result=False,
             verbose=verbose,
+            cloud=cloud,
         )
 
         if result:
@@ -493,6 +378,8 @@ Examples:
     adv_group.add_argument("--guidance", "-g", type=float, default=1.0, help="Guidance scale - higher = follows prompt more strictly (default: 1.0)")
     adv_group.add_argument("--negative", "-n", help="Negative prompt - things to avoid")
     adv_group.add_argument("--verbose", action="store_true", help="Show detailed output")
+    adv_group.add_argument("--cloud", type=str, default="runpod", choices=["runpod", "modal"],
+                           help="Cloud GPU provider (default: runpod)")
 
     # Utility
     parser.add_argument("--list-presets", action="store_true", help="List available presets")
@@ -541,6 +428,7 @@ Examples:
             seed=args.seed,
             steps=args.steps,
             verbose=args.verbose,
+            cloud=args.cloud,
         )
     else:
         edit_image(
@@ -553,6 +441,7 @@ Examples:
             negative_prompt=args.negative,
             open_result=not args.no_open,
             verbose=args.verbose,
+            cloud=args.cloud,
         )
 
 

--- a/tools/music_gen.py
+++ b/tools/music_gen.py
@@ -44,7 +44,6 @@ import base64
 import json
 import os
 import sys
-import time
 from pathlib import Path
 from typing import Optional
 
@@ -57,6 +56,9 @@ except ImportError as e:
     sys.exit(1)
 
 load_dotenv()
+
+sys.path.insert(0, str(Path(__file__).parent))
+from file_transfer import download_from_url, get_r2_payload_config
 
 # --- Constants ---
 
@@ -261,125 +263,6 @@ def encode_audio(path: str) -> str:
 
 # --- RunPod API ---
 
-def get_config() -> dict:
-    """Get RunPod configuration from environment."""
-    sys.path.insert(0, str(Path(__file__).parent))
-    try:
-        from config import get_runpod_api_key
-        api_key = get_runpod_api_key()
-    except ImportError:
-        api_key = os.getenv("RUNPOD_API_KEY")
-
-    endpoint_id = os.getenv(ENV_VAR_NAME)
-
-    return {
-        "api_key": api_key,
-        "endpoint_id": endpoint_id,
-    }
-
-
-def _get_r2_config() -> Optional[dict]:
-    """Get R2 config for file transfer. Returns None if not configured."""
-    sys.path.insert(0, str(Path(__file__).parent))
-    try:
-        from config import get_r2_config
-        return get_r2_config()
-    except ImportError:
-        return None
-
-
-def call_endpoint(payload: dict, timeout: int = 600) -> tuple[dict, float]:
-    """Call RunPod endpoint and return (result, elapsed_seconds)."""
-    config = get_config()
-    api_key = config.get("api_key")
-    endpoint_id = config.get("endpoint_id")
-
-    if not api_key:
-        return {"error": "RUNPOD_API_KEY not set in .env"}, 0
-    if not endpoint_id:
-        return {"error": f"{ENV_VAR_NAME} not set. Run with --setup first."}, 0
-
-    headers = {
-        "Authorization": f"Bearer {api_key}",
-        "Content-Type": "application/json",
-    }
-
-    start = time.time()
-
-    try:
-        run_url = f"https://api.runpod.ai/v2/{endpoint_id}/run"
-        response = requests.post(run_url, json=payload, headers=headers, timeout=30)
-        response.raise_for_status()
-        result = response.json()
-
-        job_id = result.get("id")
-        status = result.get("status")
-
-        if status == "COMPLETED":
-            return result.get("output", result), time.time() - start
-
-        if status == "FAILED":
-            return {"error": result.get("error", "Unknown error")}, time.time() - start
-
-        # Poll for completion
-        log("Processing... (cold start may take 3-5 min on first run)", "warn")
-        status_url = f"https://api.runpod.ai/v2/{endpoint_id}/status/{job_id}"
-
-        poll_interval = 5
-        queue_timeout = 300
-        queue_start = time.time()
-        last_status = None
-        while time.time() - start < timeout:
-            time.sleep(poll_interval)
-            elapsed = time.time() - start
-
-            status_resp = requests.get(status_url, headers=headers, timeout=30)
-            status_data = status_resp.json()
-            status = status_data.get("status")
-
-            if status != last_status:
-                if status == "IN_PROGRESS":
-                    log(f"[{elapsed:.0f}s] Generating music...", "dim")
-                    queue_start = None
-                elif status == "IN_QUEUE":
-                    log(f"[{elapsed:.0f}s] Waiting for GPU...", "dim")
-                last_status = status
-
-            if status == "COMPLETED":
-                return status_data.get("output", status_data), time.time() - start
-
-            if status == "FAILED":
-                error = status_data.get("error", "Unknown error")
-                return {"error": error}, time.time() - start
-
-            if status in ("CANCELLED", "TIMED_OUT"):
-                return {"error": f"Job {status}"}, time.time() - start
-
-            # Cancel jobs stuck in queue
-            if status == "IN_QUEUE" and queue_start and (time.time() - queue_start > queue_timeout):
-                log(f"Job stuck in queue for {queue_timeout}s — cancelling", "warn")
-                cancel_url = f"https://api.runpod.ai/v2/{endpoint_id}/cancel/{job_id}"
-                try:
-                    requests.post(cancel_url, headers=headers, timeout=10)
-                except Exception:
-                    pass
-                return {"error": f"Cancelled: no GPU after {queue_timeout}s"}, time.time() - start
-
-        # Timeout
-        log("Polling timeout — cancelling job", "warn")
-        cancel_url = f"https://api.runpod.ai/v2/{endpoint_id}/cancel/{job_id}"
-        try:
-            requests.post(cancel_url, headers=headers, timeout=10)
-        except Exception:
-            pass
-        return {"error": "polling timeout (job cancelled)"}, time.time() - start
-
-    except requests.exceptions.Timeout:
-        return {"error": "timeout"}, time.time() - start
-    except Exception as e:
-        return {"error": str(e)}, time.time() - start
-
-
 # --- Generation functions ---
 
 def generate_music(
@@ -395,8 +278,9 @@ def generate_music(
     audio_format: str = "mp3",
     seed: Optional[int] = None,
     json_output: bool = False,
+    cloud: str = "runpod",
 ) -> Optional[dict]:
-    """Generate music from text prompt via RunPod."""
+    """Generate music from text prompt via cloud GPU."""
     log("ACE-Step 1.5 — Music Generation", "info")
     log("=" * 40, "dim")
     log(f"Prompt: {prompt[:80]}{'...' if len(prompt) > 80 else ''}", "info")
@@ -429,16 +313,19 @@ def generate_music(
         payload["input"]["seed"] = seed
 
     # R2 for file transfer
-    r2_config = _get_r2_config()
-    if r2_config:
-        payload["input"]["r2"] = {
-            "endpoint_url": r2_config["endpoint_url"],
-            "access_key_id": r2_config["access_key_id"],
-            "secret_access_key": r2_config["secret_access_key"],
-            "bucket_name": r2_config["bucket_name"],
-        }
+    r2_payload = get_r2_payload_config()
+    if r2_payload:
+        payload["input"]["r2"] = r2_payload
 
-    result, elapsed = call_endpoint(payload)
+    from cloud_gpu import call_cloud_endpoint
+
+    result, elapsed = call_cloud_endpoint(
+        provider=cloud,
+        payload=payload,
+        tool_name="music_gen",
+        timeout=600,
+        progress_label="Generating music",
+    )
 
     if "error" in result:
         log(f"Generation failed: {result['error']}", "error")
@@ -450,10 +337,7 @@ def generate_music(
 
     if "output_url" in result:
         log("Downloading from R2...", "dim")
-        resp = requests.get(result["output_url"], timeout=60)
-        resp.raise_for_status()
-        with open(output_path, "wb") as f:
-            f.write(resp.content)
+        download_from_url(result["output_url"], output_path, verbose=False)
     elif "audio_base64" in result:
         with open(output_path, "wb") as f:
             f.write(base64.b64decode(result["audio_base64"]))
@@ -501,6 +385,7 @@ def generate_cover(
     steps: int = 8,
     audio_format: str = "mp3",
     json_output: bool = False,
+    cloud: str = "runpod",
 ) -> Optional[dict]:
     """Generate a cover/style transfer from reference audio."""
     if not Path(reference_path).exists():
@@ -525,16 +410,19 @@ def generate_cover(
         }
     }
 
-    r2_config = _get_r2_config()
-    if r2_config:
-        payload["input"]["r2"] = {
-            "endpoint_url": r2_config["endpoint_url"],
-            "access_key_id": r2_config["access_key_id"],
-            "secret_access_key": r2_config["secret_access_key"],
-            "bucket_name": r2_config["bucket_name"],
-        }
+    r2_payload = get_r2_payload_config()
+    if r2_payload:
+        payload["input"]["r2"] = r2_payload
 
-    result, elapsed = call_endpoint(payload)
+    from cloud_gpu import call_cloud_endpoint
+
+    result, elapsed = call_cloud_endpoint(
+        provider=cloud,
+        payload=payload,
+        tool_name="music_gen",
+        timeout=600,
+        progress_label="Creating cover",
+    )
 
     if "error" in result:
         log(f"Cover failed: {result['error']}", "error")
@@ -543,10 +431,7 @@ def generate_cover(
     Path(output_path).parent.mkdir(parents=True, exist_ok=True)
 
     if "output_url" in result:
-        resp = requests.get(result["output_url"], timeout=60)
-        resp.raise_for_status()
-        with open(output_path, "wb") as f:
-            f.write(resp.content)
+        download_from_url(result["output_url"], output_path, verbose=False)
     elif "audio_base64" in result:
         with open(output_path, "wb") as f:
             f.write(base64.b64decode(result["audio_base64"]))
@@ -576,6 +461,7 @@ def extract_stem(
     steps: int = 8,
     audio_format: str = "mp3",
     json_output: bool = False,
+    cloud: str = "runpod",
 ) -> Optional[dict]:
     """Extract a stem (vocals, drums, bass, etc.) from mixed audio."""
     if not Path(input_path).exists():
@@ -597,16 +483,19 @@ def extract_stem(
         }
     }
 
-    r2_config = _get_r2_config()
-    if r2_config:
-        payload["input"]["r2"] = {
-            "endpoint_url": r2_config["endpoint_url"],
-            "access_key_id": r2_config["access_key_id"],
-            "secret_access_key": r2_config["secret_access_key"],
-            "bucket_name": r2_config["bucket_name"],
-        }
+    r2_payload = get_r2_payload_config()
+    if r2_payload:
+        payload["input"]["r2"] = r2_payload
 
-    result, elapsed = call_endpoint(payload)
+    from cloud_gpu import call_cloud_endpoint
+
+    result, elapsed = call_cloud_endpoint(
+        provider=cloud,
+        payload=payload,
+        tool_name="music_gen",
+        timeout=600,
+        progress_label="Extracting stem",
+    )
 
     if "error" in result:
         log(f"Extraction failed: {result['error']}", "error")
@@ -615,10 +504,7 @@ def extract_stem(
     Path(output_path).parent.mkdir(parents=True, exist_ok=True)
 
     if "output_url" in result:
-        resp = requests.get(result["output_url"], timeout=60)
-        resp.raise_for_status()
-        with open(output_path, "wb") as f:
-            f.write(resp.content)
+        download_from_url(result["output_url"], output_path, verbose=False)
     elif "audio_base64" in result:
         with open(output_path, "wb") as f:
             f.write(base64.b64decode(result["audio_base64"]))
@@ -859,8 +745,7 @@ def setup_runpod(gpu_id: str = "AMPERE_24,ADA_24", verbose: bool = True) -> dict
         "created_endpoint": False,
     }
 
-    config = get_config()
-    api_key = config.get("api_key")
+    api_key = os.getenv("RUNPOD_API_KEY")
 
     if not api_key:
         result["error"] = "RUNPOD_API_KEY not set. Add to .env file first."
@@ -1000,6 +885,11 @@ Examples:
                            help="Inference steps (default: 8 for turbo, use 32-64 for base model)")
     adv_group.add_argument("--seed", type=int, help="Random seed for reproducibility")
 
+    # Cloud provider
+    cloud_group = parser.add_argument_group("Cloud")
+    cloud_group.add_argument("--cloud", type=str, default="runpod", choices=["runpod", "modal"],
+                             help="Cloud GPU provider (default: runpod)")
+
     # Setup
     setup_group = parser.add_argument_group("Setup")
     setup_group.add_argument("--setup", action="store_true", help="Set up RunPod endpoint")
@@ -1052,6 +942,7 @@ Examples:
             steps=args.steps,
             audio_format=args.audio_format,
             json_output=args.json,
+            cloud=args.cloud,
         )
         if args.json and result:
             print(json.dumps(result, indent=2))
@@ -1089,6 +980,7 @@ Examples:
             steps=args.steps,
             audio_format=args.audio_format,
             json_output=args.json,
+            cloud=args.cloud,
         )
         if args.json and result:
             print(json.dumps(result, indent=2))
@@ -1167,6 +1059,7 @@ Examples:
         audio_format=args.audio_format,
         seed=args.seed,
         json_output=args.json,
+        cloud=args.cloud,
     )
 
     if args.json and result:

--- a/tools/qwen3_tts.py
+++ b/tools/qwen3_tts.py
@@ -55,6 +55,8 @@ from pathlib import Path
 
 import requests
 
+sys.path.insert(0, str(Path(__file__).parent))
+
 # Docker image for RunPod endpoint
 QWEN3_TTS_DOCKER_IMAGE = "ghcr.io/conalmullan/video-toolkit-qwen3-tts:latest"
 QWEN3_TTS_TEMPLATE_NAME = "video-toolkit-qwen3-tts"
@@ -106,170 +108,10 @@ def resolve_tone(tone: str | None, instruct: str) -> str:
     return ""
 
 
-def get_runpod_config() -> dict:
-    """Get RunPod configuration from environment."""
-    sys.path.insert(0, str(Path(__file__).parent))
-    try:
-        from config import get_runpod_api_key
-        api_key = get_runpod_api_key()
-    except ImportError:
-        from dotenv import load_dotenv
-        load_dotenv()
-        api_key = os.getenv("RUNPOD_API_KEY")
-
-    from dotenv import load_dotenv
-    load_dotenv()
-    endpoint_id = os.getenv("RUNPOD_QWEN3_TTS_ENDPOINT_ID")
-
-    return {
-        "api_key": api_key,
-        "endpoint_id": endpoint_id,
-    }
-
-
-def _get_r2_client():
-    """Get boto3 S3 client configured for Cloudflare R2."""
-    sys.path.insert(0, str(Path(__file__).parent))
-    try:
-        from config import get_r2_config
-        r2_config = get_r2_config()
-    except ImportError:
-        r2_config = None
-
-    if not r2_config:
-        return None, None
-
-    try:
-        import boto3
-        from botocore.config import Config
-
-        client = boto3.client(
-            "s3",
-            endpoint_url=r2_config["endpoint_url"],
-            aws_access_key_id=r2_config["access_key_id"],
-            aws_secret_access_key=r2_config["secret_access_key"],
-            config=Config(signature_version="s3v4"),
-        )
-        return client, r2_config
-    except ImportError:
-        print("  boto3 not installed, skipping R2", file=sys.stderr)
-        return None, None
-
-
-def _upload_to_r2(file_path: str, prefix: str) -> tuple[str | None, str | None]:
-    """Upload to Cloudflare R2 and return presigned download URL."""
-    client, config = _get_r2_client()
-    if not client:
-        return None, None
-
-    import uuid
-    file_name = Path(file_path).name
-    object_key = f"{prefix}/{uuid.uuid4().hex[:8]}_{file_name}"
-
-    try:
-        client.upload_file(file_path, config["bucket_name"], object_key)
-
-        url = client.generate_presigned_url(
-            "get_object",
-            Params={"Bucket": config["bucket_name"], "Key": object_key},
-            ExpiresIn=7200,
-        )
-        return url, object_key
-    except Exception as e:
-        print(f"  R2 upload error: {e}", file=sys.stderr)
-        return None, None
-
-
-def _delete_from_r2(object_key: str) -> bool:
-    """Delete object from R2 after job completion."""
-    client, config = _get_r2_client()
-    if not client or not object_key:
-        return False
-
-    try:
-        client.delete_object(Bucket=config["bucket_name"], Key=object_key)
-        return True
-    except Exception:
-        return False
-
-
-def _download_from_r2(object_key: str, output_path: str) -> bool:
-    """Download object from R2 to local path."""
-    client, config = _get_r2_client()
-    if not client:
-        return False
-
-    try:
-        client.download_file(config["bucket_name"], object_key, output_path)
-        return True
-    except Exception as e:
-        print(f"  R2 download error: {e}", file=sys.stderr)
-        return False
-
-
-def upload_to_storage(file_path: str, prefix: str) -> tuple[str | None, str | None]:
-    """Upload a file to temporary storage for job input."""
-    file_size = Path(file_path).stat().st_size
-    file_name = Path(file_path).name
-
-    print(f"Uploading {file_name} ({file_size // 1024}KB)...", file=sys.stderr)
-
-    url, r2_key = _upload_to_r2(file_path, prefix)
-    if url:
-        print(f"  Upload complete (R2)", file=sys.stderr)
-        return url, r2_key
-
-    # Fall back to free services
-    for service_name, upload_func in [("litterbox", _upload_to_litterbox), ("0x0.st", _upload_to_0x0)]:
-        try:
-            url = upload_func(file_path, file_name)
-            if url:
-                print(f"  Upload complete ({service_name})", file=sys.stderr)
-                return url, None
-        except Exception as e:
-            print(f"  {service_name} failed: {e}", file=sys.stderr)
-            continue
-
-    print("All upload services failed", file=sys.stderr)
-    return None, None
-
-
-def _upload_to_litterbox(file_path: str, file_name: str) -> str | None:
-    """Upload to litterbox.catbox.moe (200MB limit, 24h retention)."""
-    import subprocess
-    result = subprocess.run(
-        [
-            "curl", "-s",
-            "-F", "reqtype=fileupload",
-            "-F", "time=24h",
-            "-F", f"fileToUpload=@{file_path}",
-            "https://litterbox.catbox.moe/resources/internals/api.php",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=300,
-    )
-    if result.returncode == 0:
-        url = result.stdout.strip()
-        if url.startswith("http"):
-            return url
-    return None
-
-
-def _upload_to_0x0(file_path: str, file_name: str) -> str | None:
-    """Upload to 0x0.st (512MB limit, 30 day retention)."""
-    import subprocess
-    result = subprocess.run(
-        ["curl", "-s", "-F", f"file=@{file_path}", "https://0x0.st"],
-        capture_output=True,
-        text=True,
-        timeout=300,
-    )
-    if result.returncode == 0:
-        url = result.stdout.strip()
-        if url.startswith("http"):
-            return url
-    return None
+from file_transfer import (
+    upload_to_storage, download_from_r2, delete_from_r2,
+    download_from_url, get_r2_payload_config,
+)
 
 
 def get_audio_duration(file_path: str) -> float | None:
@@ -292,170 +134,6 @@ def get_audio_duration(file_path: str) -> float | None:
         pass  # ffprobe not installed or invalid output
     return None
 
-
-def submit_runpod_job(
-    endpoint_id: str,
-    api_key: str,
-    text: str,
-    mode: str = "custom_voice",
-    speaker: str = "Ryan",
-    language: str = "Auto",
-    instruct: str = "",
-    ref_audio_url: str | None = None,
-    ref_text: str | None = None,
-    output_format: str = "mp3",
-    r2_config: dict | None = None,
-    temperature: float | None = None,
-    top_p: float | None = None,
-) -> dict | None:
-    """Submit a Qwen3-TTS job to RunPod serverless endpoint."""
-    url = f"https://api.runpod.ai/v2/{endpoint_id}/run"
-
-    payload = {
-        "input": {
-            "text": text,
-            "mode": mode,
-            "language": language,
-            "output_format": output_format,
-        }
-    }
-
-    if mode == "clone":
-        payload["input"]["ref_audio_url"] = ref_audio_url
-        payload["input"]["ref_text"] = ref_text
-    else:
-        payload["input"]["speaker"] = speaker
-        if instruct:
-            payload["input"]["instruct"] = instruct
-
-    if temperature is not None:
-        payload["input"]["temperature"] = temperature
-    if top_p is not None:
-        payload["input"]["top_p"] = top_p
-
-    if r2_config:
-        payload["input"]["r2"] = {
-            "endpoint_url": r2_config["endpoint_url"],
-            "access_key_id": r2_config["access_key_id"],
-            "secret_access_key": r2_config["secret_access_key"],
-            "bucket_name": r2_config["bucket_name"],
-        }
-
-    try:
-        response = requests.post(
-            url,
-            json=payload,
-            headers={"Authorization": f"Bearer {api_key}"},
-            timeout=30,
-        )
-
-        if response.status_code == 200:
-            return response.json()
-        else:
-            print(f"Job submission failed: HTTP {response.status_code}", file=sys.stderr)
-            print(f"  Response: {response.text[:500]}", file=sys.stderr)
-            return None
-
-    except Exception as e:
-        print(f"Job submission error: {e}", file=sys.stderr)
-        return None
-
-
-def poll_runpod_job(
-    endpoint_id: str,
-    api_key: str,
-    job_id: str,
-    timeout: int = 300,
-    poll_interval: int = 3,
-    verbose: bool = True,
-) -> dict | None:
-    """Poll RunPod job until completion or timeout."""
-    url = f"https://api.runpod.ai/v2/{endpoint_id}/status/{job_id}"
-    headers = {"Authorization": f"Bearer {api_key}"}
-    start_time = time.time()
-    last_status = None
-    queue_timeout = 300  # Cancel job if stuck in queue for 5 min
-    queue_start = time.time()
-
-    while time.time() - start_time < timeout:
-        try:
-            response = requests.get(
-                url,
-                headers=headers,
-                timeout=30,
-            )
-
-            if response.status_code != 200:
-                print(f"Status check failed: HTTP {response.status_code}", file=sys.stderr)
-                time.sleep(poll_interval)
-                continue
-
-            data = response.json()
-            status = data.get("status")
-
-            if verbose and status != last_status:
-                elapsed = int(time.time() - start_time)
-                print(f"  [{elapsed}s] Status: {status}", file=sys.stderr)
-                last_status = status
-
-            if status == "COMPLETED":
-                return data
-            elif status == "FAILED":
-                print(f"Job failed: {data.get('error', 'Unknown error')}", file=sys.stderr)
-                return data
-
-            # Track queue-to-progress transition
-            if status == "IN_PROGRESS" and queue_start is not None:
-                queue_start = None
-
-            # Cancel jobs stuck in queue too long (prevents runaway billing)
-            if status == "IN_QUEUE" and queue_start is not None and (time.time() - queue_start > queue_timeout):
-                print(f"Job stuck in queue for {queue_timeout}s — cancelling to prevent runaway charges", file=sys.stderr)
-                cancel_url = f"https://api.runpod.ai/v2/{endpoint_id}/cancel/{job_id}"
-                try:
-                    requests.post(cancel_url, headers=headers, timeout=10)
-                except Exception:
-                    pass
-                return {"status": "FAILED", "error": f"Cancelled: no GPU available after {queue_timeout}s in queue"}
-
-            time.sleep(poll_interval)
-
-        except Exception as e:
-            print(f"Status check error: {e}", file=sys.stderr)
-            time.sleep(poll_interval)
-
-    # Overall timeout — cancel the job so it doesn't linger in RunPod's queue
-    print(f"Job timed out after {timeout}s — cancelling on RunPod", file=sys.stderr)
-    cancel_url = f"https://api.runpod.ai/v2/{endpoint_id}/cancel/{job_id}"
-    try:
-        requests.post(cancel_url, headers=headers, timeout=10)
-    except Exception:
-        pass
-    return None
-
-
-def download_from_url(url: str, output_path: str, verbose: bool = True) -> bool:
-    """Download file from URL to local path."""
-    try:
-        if verbose:
-            print(f"Downloading result...", file=sys.stderr)
-
-        response = requests.get(url, stream=True, timeout=300)
-        response.raise_for_status()
-
-        with open(output_path, 'wb') as f:
-            for chunk in response.iter_content(chunk_size=8192):
-                f.write(chunk)
-
-        if verbose:
-            size_kb = Path(output_path).stat().st_size // 1024
-            print(f"  Downloaded: {output_path} ({size_kb}KB)", file=sys.stderr)
-
-        return True
-
-    except Exception as e:
-        print(f"Download error: {e}", file=sys.stderr)
-        return False
 
 
 def generate_audio(
@@ -485,12 +163,7 @@ def generate_audio(
     r2_keys_to_cleanup = []
 
     # Get R2 config (used for file transfer regardless of cloud provider)
-    sys.path.insert(0, str(Path(__file__).parent))
-    try:
-        from config import get_r2_config
-        r2_config = get_r2_config()
-    except ImportError:
-        r2_config = None
+    r2_payload = get_r2_payload_config()
 
     # Determine mode
     mode = "clone" if ref_audio else "custom_voice"
@@ -539,13 +212,8 @@ def generate_audio(
     if top_p is not None:
         payload["input"]["top_p"] = top_p
 
-    if r2_config:
-        payload["input"]["r2"] = {
-            "endpoint_url": r2_config["endpoint_url"],
-            "access_key_id": r2_config["access_key_id"],
-            "secret_access_key": r2_config["secret_access_key"],
-            "bucket_name": r2_config["bucket_name"],
-        }
+    if r2_payload:
+        payload["input"]["r2"] = r2_payload
 
     # Submit job via cloud_gpu abstraction
     try:
@@ -577,7 +245,7 @@ def generate_audio(
     if output_r2_key:
         if verbose:
             print(f"Downloading result from R2...", file=sys.stderr)
-        downloaded = _download_from_r2(output_r2_key, output_path)
+        downloaded = download_from_r2(output_r2_key, output_path)
         if downloaded:
             r2_keys_to_cleanup.append(output_r2_key)
             if verbose:
@@ -601,7 +269,7 @@ def generate_audio(
 
     # Cleanup R2 objects
     for key in r2_keys_to_cleanup:
-        _delete_from_r2(key)
+        delete_from_r2(key)
 
     duration = get_audio_duration(output_path)
 
@@ -853,8 +521,9 @@ def setup_runpod(gpu_id: str = "AMPERE_24", verbose: bool = True) -> dict:
         "created_endpoint": False,
     }
 
-    config = get_runpod_config()
-    api_key = config.get("api_key")
+    from dotenv import load_dotenv
+    load_dotenv()
+    api_key = os.getenv("RUNPOD_API_KEY")
 
     if not api_key:
         result["error"] = "RUNPOD_API_KEY not set. Add to .env file first."

--- a/tools/qwen3_tts.py
+++ b/tools/qwen3_tts.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python3
 """
-Generate speech using Qwen3-TTS (via RunPod serverless).
+Generate speech using Qwen3-TTS (via cloud GPU).
 
 Supports built-in speakers with emotion control and voice cloning from reference audio.
+Cloud providers: RunPod (default), Modal.
 
 Usage:
-    # Built-in speaker
+    # Built-in speaker (RunPod, default)
     python tools/qwen3_tts.py --text "Hello world" --speaker Ryan --output hello.mp3
+
+    # Using Modal instead of RunPod
+    python tools/qwen3_tts.py --text "Hello world" --cloud modal --output hello.mp3
 
     # With tone preset
     python tools/qwen3_tts.py --text "Hello world" --tone warm --output hello.mp3
@@ -23,18 +27,22 @@ Usage:
     # List built-in voices
     python tools/qwen3_tts.py --list-voices
 
-    # Setup endpoint
+    # Setup endpoint (RunPod)
     python tools/qwen3_tts.py --setup
 
-Setup:
-    1. Create account at runpod.io
-    2. Run: python tools/qwen3_tts.py --setup
-    3. Or manually deploy docker/runpod-qwen3-tts/ and add endpoint ID to .env
+    # Setup endpoint (Modal)
+    python tools/qwen3_tts.py --setup --cloud modal
 
-Cost:
-    - ~$0.005 per sentence
-    - ~$0.05-0.10 per page of text
-    - Uses RTX 4090 ($0.00074/sec) by default
+Setup:
+    RunPod:
+        1. Create account at runpod.io
+        2. Run: python tools/qwen3_tts.py --setup
+        3. Or manually deploy docker/runpod-qwen3-tts/ and add endpoint ID to .env
+
+    Modal:
+        1. pip install modal && python3 -m modal setup
+        2. Run: python tools/qwen3_tts.py --setup --cloud modal
+        3. Or manually: modal deploy docker/modal-qwen3-tts/app.py
 """
 
 import argparse
@@ -463,25 +471,20 @@ def generate_audio(
     verbose: bool = True,
     temperature: float | None = None,
     top_p: float | None = None,
+    cloud: str = "runpod",
 ) -> dict:
-    """Generate audio using Qwen3-TTS via RunPod.
+    """Generate audio using Qwen3-TTS via cloud GPU.
 
     This is the main entry point, importable by voiceover.py.
     Returns dict with: success, output, duration_seconds, duration_frames_30fps
+
+    Args:
+        cloud: Cloud provider — "runpod" (default) or "modal".
     """
     start_time = time.time()
     r2_keys_to_cleanup = []
 
-    config = get_runpod_config()
-    api_key = config.get("api_key")
-    endpoint_id = config.get("endpoint_id")
-
-    if not api_key:
-        return {"success": False, "error": "RUNPOD_API_KEY not set. Add to .env file."}
-    if not endpoint_id:
-        return {"success": False, "error": "RUNPOD_QWEN3_TTS_ENDPOINT_ID not set. Run with --setup first."}
-
-    # Get R2 config
+    # Get R2 config (used for file transfer regardless of cloud provider)
     sys.path.insert(0, str(Path(__file__).parent))
     try:
         from config import get_r2_config
@@ -507,57 +510,60 @@ def generate_audio(
             r2_keys_to_cleanup.append(ref_r2_key)
 
     if verbose:
-        print(f"Using RunPod endpoint: {endpoint_id}", file=sys.stderr)
+        print(f"Cloud provider: {cloud}", file=sys.stderr)
         if mode == "clone":
             print(f"Mode: voice clone", file=sys.stderr)
         else:
             print(f"Speaker: {speaker}, Language: {language}", file=sys.stderr)
 
-    # Submit job
-    job_response = submit_runpod_job(
-        endpoint_id=endpoint_id,
-        api_key=api_key,
-        text=text,
-        mode=mode,
-        speaker=speaker,
-        language=language,
-        instruct=instruct,
-        ref_audio_url=ref_audio_url,
-        ref_text=ref_text,
-        output_format=output_format,
-        r2_config=r2_config,
-        temperature=temperature,
-        top_p=top_p,
-    )
+    # Build payload (same format for both providers)
+    payload = {
+        "input": {
+            "text": text,
+            "mode": mode,
+            "language": language,
+            "output_format": output_format,
+        }
+    }
 
-    if not job_response:
-        return {"success": False, "error": "Failed to submit job"}
+    if mode == "clone":
+        payload["input"]["ref_audio_url"] = ref_audio_url
+        payload["input"]["ref_text"] = ref_text
+    else:
+        payload["input"]["speaker"] = speaker
+        if instruct:
+            payload["input"]["instruct"] = instruct
 
-    job_id = job_response.get("id")
-    if not job_id:
-        return {"success": False, "error": f"No job ID in response: {job_response}"}
+    if temperature is not None:
+        payload["input"]["temperature"] = temperature
+    if top_p is not None:
+        payload["input"]["top_p"] = top_p
 
-    if verbose:
-        print(f"Job submitted: {job_id}", file=sys.stderr)
+    if r2_config:
+        payload["input"]["r2"] = {
+            "endpoint_url": r2_config["endpoint_url"],
+            "access_key_id": r2_config["access_key_id"],
+            "secret_access_key": r2_config["secret_access_key"],
+            "bucket_name": r2_config["bucket_name"],
+        }
 
-    # Poll for completion
-    result = poll_runpod_job(
-        endpoint_id=endpoint_id,
-        api_key=api_key,
-        job_id=job_id,
+    # Submit job via cloud_gpu abstraction
+    try:
+        from cloud_gpu import call_cloud_endpoint
+    except ImportError:
+        sys.path.insert(0, str(Path(__file__).parent))
+        from cloud_gpu import call_cloud_endpoint
+
+    output, elapsed = call_cloud_endpoint(
+        provider=cloud,
+        payload=payload,
+        tool_name="qwen3_tts",
         timeout=timeout,
+        poll_interval=3,
+        progress_label="Generating speech",
         verbose=verbose,
     )
 
-    if not result:
-        return {"success": False, "error": "Job timed out or failed to get status"}
-
-    status = result.get("status")
-    if status != "COMPLETED":
-        error = result.get("error") or result.get("output", {}).get("error") or "Unknown error"
-        return {"success": False, "error": f"Job failed: {error}"}
-
-    output = result.get("output", {})
     if isinstance(output, dict) and output.get("error"):
         return {"success": False, "error": output["error"]}
 
@@ -921,14 +927,172 @@ def setup_runpod(gpu_id: str = "AMPERE_24", verbose: bool = True) -> dict:
     return result
 
 
+# =============================================================================
+# Modal Setup
+# =============================================================================
+
+def setup_modal(verbose: bool = True) -> dict:
+    """Set up Modal endpoint for Qwen3-TTS.
+
+    Deploys the Modal app and saves the endpoint URL to .env.
+    Requires: pip install modal && python3 -m modal setup
+    """
+    import shutil
+    import subprocess
+
+    result = {
+        "success": False,
+        "endpoint_url": None,
+    }
+
+    if verbose:
+        print("=" * 60)
+        print("Modal Setup (Qwen3-TTS Speech Generation)")
+        print("=" * 60)
+        print()
+
+    # Check modal CLI is installed
+    if not shutil.which("modal"):
+        result["error"] = (
+            "Modal CLI not found. Install with:\n"
+            "  pip install modal\n"
+            "  python3 -m modal setup"
+        )
+        if verbose:
+            print(f"Error: {result['error']}", file=sys.stderr)
+        return result
+
+    # Find the app file
+    app_file = Path(__file__).parent.parent / "docker" / "modal-qwen3-tts" / "app.py"
+    if not app_file.exists():
+        result["error"] = f"Modal app file not found: {app_file}"
+        if verbose:
+            print(f"Error: {result['error']}", file=sys.stderr)
+        return result
+
+    if verbose:
+        print(f"[1/3] Deploying Modal app: {app_file}")
+        print("  This will build the container image and create the web endpoint.")
+        print("  First deploy may take 5-10 minutes (downloading model weights)...")
+        print()
+
+    try:
+        deploy_result = subprocess.run(
+            ["modal", "deploy", str(app_file)],
+            capture_output=True,
+            text=True,
+            timeout=900,  # 15 min for first deploy with model download
+        )
+
+        if deploy_result.returncode != 0:
+            result["error"] = f"Modal deploy failed:\n{deploy_result.stderr}"
+            if verbose:
+                print(f"Error: {result['error']}", file=sys.stderr)
+            return result
+
+        if verbose:
+            print(deploy_result.stdout)
+
+        # Parse endpoint URL from deploy output
+        # Modal prints lines like: Created web endpoint ... => https://workspace--app-name-fn.modal.run
+        endpoint_url = None
+        for line in deploy_result.stdout.splitlines():
+            if "modal.run" in line:
+                # Extract URL from the line
+                import re
+                urls = re.findall(r'https://[^\s"\']+modal\.run[^\s"\']*', line)
+                if urls:
+                    endpoint_url = urls[0]
+                    break
+
+        if not endpoint_url:
+            # Try stderr too (some modal versions output there)
+            for line in deploy_result.stderr.splitlines():
+                if "modal.run" in line:
+                    import re
+                    urls = re.findall(r'https://[^\s"\']+modal\.run[^\s"\']*', line)
+                    if urls:
+                        endpoint_url = urls[0]
+                        break
+
+        if not endpoint_url:
+            result["error"] = (
+                "Deploy succeeded but could not parse endpoint URL from output.\n"
+                "Check `modal app list` for the URL and add to .env manually:\n"
+                "  MODAL_QWEN3_TTS_ENDPOINT_URL=https://your-workspace--video-toolkit-qwen3-tts-qwen3tts-generate.modal.run"
+            )
+            if verbose:
+                print(f"Warning: {result['error']}", file=sys.stderr)
+            return result
+
+        result["endpoint_url"] = endpoint_url
+
+        if verbose:
+            print(f"[2/3] Endpoint URL: {endpoint_url}")
+            print("[3/3] Saving configuration...")
+
+        # Save to .env
+        env_path = Path(__file__).parent.parent / ".env"
+        env_var = "MODAL_QWEN3_TTS_ENDPOINT_URL"
+
+        if env_path.exists():
+            env_content = env_path.read_text()
+            if env_var in env_content:
+                # Update existing
+                lines = env_content.splitlines()
+                updated = False
+                for i, line in enumerate(lines):
+                    if line.startswith(f"{env_var}="):
+                        lines[i] = f"{env_var}={endpoint_url}"
+                        updated = True
+                        break
+                if updated:
+                    env_path.write_text("\n".join(lines) + "\n")
+            else:
+                with open(env_path, "a") as f:
+                    f.write(f"\n{env_var}={endpoint_url}\n")
+        else:
+            env_path.write_text(f"{env_var}={endpoint_url}\n")
+
+        if verbose:
+            print(f"  Saved: {env_var}={endpoint_url}")
+
+        result["success"] = True
+
+        if verbose:
+            print()
+            print("=" * 60)
+            print("Setup Complete!")
+            print("=" * 60)
+            print(f"Endpoint: {endpoint_url}")
+            print()
+            print("You can now run:")
+            print('  python tools/qwen3_tts.py --text "Hello world" --cloud modal --output hello.mp3')
+            print()
+
+    except subprocess.TimeoutExpired:
+        result["error"] = "Modal deploy timed out after 15 minutes"
+        if verbose:
+            print(f"Error: {result['error']}", file=sys.stderr)
+    except Exception as e:
+        result["error"] = str(e)
+        if verbose:
+            print(f"Error: {e}", file=sys.stderr)
+
+    return result
+
+
 def parse_args():
     parser = argparse.ArgumentParser(
-        description="Generate speech using Qwen3-TTS (via RunPod)",
+        description="Generate speech using Qwen3-TTS (via cloud GPU)",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  # Built-in speaker
+  # Built-in speaker (RunPod, default)
   python tools/qwen3_tts.py --text "Hello world" --speaker Ryan --output hello.mp3
+
+  # Using Modal instead
+  python tools/qwen3_tts.py --text "Hello world" --cloud modal --output hello.mp3
 
   # With emotion control
   python tools/qwen3_tts.py --text "Great news!" --instruct "Speak enthusiastically" --output excited.mp3
@@ -939,8 +1103,11 @@ Examples:
   # List voices
   python tools/qwen3_tts.py --list-voices
 
-  # Setup endpoint
+  # Setup endpoint (RunPod)
   python tools/qwen3_tts.py --setup
+
+  # Setup endpoint (Modal)
+  python tools/qwen3_tts.py --setup --cloud modal
         """,
     )
 
@@ -1012,17 +1179,24 @@ Examples:
         help="Nucleus sampling (default: model default ~0.8, range: 0.1-1.0)",
     )
 
-    # RunPod options
+    # Cloud GPU options
+    parser.add_argument(
+        "--cloud",
+        type=str,
+        default="runpod",
+        choices=["runpod", "modal"],
+        help="Cloud GPU provider (default: runpod)",
+    )
     parser.add_argument(
         "--timeout",
         type=int,
         default=300,
-        help="RunPod job timeout in seconds (default: 300)",
+        help="Job timeout in seconds (default: 300)",
     )
     parser.add_argument(
         "--setup",
         action="store_true",
-        help="Set up RunPod endpoint automatically",
+        help="Set up cloud endpoint automatically",
     )
     parser.add_argument(
         "--setup-gpu",
@@ -1090,7 +1264,10 @@ def main():
 
     # Handle --setup
     if args.setup:
-        result = setup_runpod(gpu_id=args.setup_gpu, verbose=verbose)
+        if args.cloud == "modal":
+            result = setup_modal(verbose=verbose)
+        else:
+            result = setup_runpod(gpu_id=args.setup_gpu, verbose=verbose)
         if args.json:
             print(json.dumps(result, indent=2))
         if result.get("error"):
@@ -1147,6 +1324,7 @@ def main():
         verbose=verbose,
         temperature=args.temperature,
         top_p=args.top_p,
+        cloud=args.cloud,
     )
 
     if not result.get("success"):

--- a/tools/sadtalker.py
+++ b/tools/sadtalker.py
@@ -30,13 +30,19 @@ Cost:
 """
 
 import argparse
+import base64
 import json
 import os
 import sys
-import time
 from pathlib import Path
 
 import requests
+
+sys.path.insert(0, str(Path(__file__).parent))
+from file_transfer import (
+    upload_to_storage, download_from_r2, delete_from_r2,
+    download_from_url, get_r2_payload_config,
+)
 
 # Docker image for RunPod endpoint
 SADTALKER_DOCKER_IMAGE = "ghcr.io/conalmullan/video-toolkit-sadtalker:latest"
@@ -76,333 +82,6 @@ def calculate_timeout(audio_duration: float) -> int:
     return int(processing_time + PROCESSING_TIME_BUFFER)
 
 
-def get_runpod_config() -> dict:
-    """Get RunPod configuration from environment."""
-    sys.path.insert(0, str(Path(__file__).parent))
-    try:
-        from config import get_runpod_api_key
-        api_key = get_runpod_api_key()
-    except ImportError:
-        from dotenv import load_dotenv
-        load_dotenv()
-        api_key = os.getenv("RUNPOD_API_KEY")
-
-    from dotenv import load_dotenv
-    load_dotenv()
-    endpoint_id = os.getenv("RUNPOD_SADTALKER_ENDPOINT_ID")
-
-    return {
-        "api_key": api_key,
-        "endpoint_id": endpoint_id,
-    }
-
-
-def _get_r2_client():
-    """Get boto3 S3 client configured for Cloudflare R2."""
-    sys.path.insert(0, str(Path(__file__).parent))
-    try:
-        from config import get_r2_config
-        r2_config = get_r2_config()
-    except ImportError:
-        r2_config = None
-
-    if not r2_config:
-        return None, None
-
-    try:
-        import boto3
-        from botocore.config import Config
-
-        client = boto3.client(
-            "s3",
-            endpoint_url=r2_config["endpoint_url"],
-            aws_access_key_id=r2_config["access_key_id"],
-            aws_secret_access_key=r2_config["secret_access_key"],
-            config=Config(signature_version="s3v4"),
-        )
-        return client, r2_config
-    except ImportError:
-        print("  boto3 not installed, skipping R2", file=sys.stderr)
-        return None, None
-
-
-def _upload_to_r2(file_path: str, prefix: str) -> tuple[str | None, str | None]:
-    """Upload to Cloudflare R2 and return presigned download URL."""
-    client, config = _get_r2_client()
-    if not client:
-        return None, None
-
-    import uuid
-    file_name = Path(file_path).name
-    object_key = f"{prefix}/{uuid.uuid4().hex[:8]}_{file_name}"
-
-    try:
-        client.upload_file(file_path, config["bucket_name"], object_key)
-
-        url = client.generate_presigned_url(
-            "get_object",
-            Params={"Bucket": config["bucket_name"], "Key": object_key},
-            ExpiresIn=7200,
-        )
-        return url, object_key
-    except Exception as e:
-        print(f"  R2 upload error: {e}", file=sys.stderr)
-        return None, None
-
-
-def _delete_from_r2(object_key: str) -> bool:
-    """Delete object from R2 after job completion."""
-    client, config = _get_r2_client()
-    if not client or not object_key:
-        return False
-
-    try:
-        client.delete_object(Bucket=config["bucket_name"], Key=object_key)
-        return True
-    except Exception:
-        return False
-
-
-def _download_from_r2(object_key: str, output_path: str) -> bool:
-    """Download object from R2 to local path."""
-    client, config = _get_r2_client()
-    if not client:
-        return False
-
-    try:
-        client.download_file(config["bucket_name"], object_key, output_path)
-        return True
-    except Exception as e:
-        print(f"  R2 download error: {e}", file=sys.stderr)
-        return False
-
-
-def upload_to_storage(file_path: str, prefix: str) -> tuple[str | None, str | None]:
-    """Upload a file to temporary storage for job input."""
-    file_size = Path(file_path).stat().st_size
-    file_name = Path(file_path).name
-
-    print(f"Uploading {file_name} ({file_size // 1024}KB)...", file=sys.stderr)
-
-    # Try R2 first if configured
-    url, r2_key = _upload_to_r2(file_path, prefix)
-    if url:
-        print(f"  Upload complete (R2)", file=sys.stderr)
-        return url, r2_key
-
-    # Fall back to free services
-    upload_services = [
-        ("litterbox", _upload_to_litterbox),
-        ("0x0.st", _upload_to_0x0),
-    ]
-
-    for service_name, upload_func in upload_services:
-        try:
-            url = upload_func(file_path, file_name)
-            if url:
-                print(f"  Upload complete ({service_name})", file=sys.stderr)
-                return url, None
-        except Exception as e:
-            print(f"  {service_name} failed: {e}", file=sys.stderr)
-            continue
-
-    print("All upload services failed", file=sys.stderr)
-    return None, None
-
-
-def _upload_to_litterbox(file_path: str, file_name: str) -> str | None:
-    """Upload to litterbox.catbox.moe (200MB limit, 24h retention)."""
-    import subprocess
-    result = subprocess.run(
-        [
-            "curl", "-s",
-            "-F", "reqtype=fileupload",
-            "-F", "time=24h",
-            "-F", f"fileToUpload=@{file_path}",
-            "https://litterbox.catbox.moe/resources/internals/api.php",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=300,
-    )
-    if result.returncode == 0:
-        url = result.stdout.strip()
-        if url.startswith("http"):
-            return url
-    return None
-
-
-def _upload_to_0x0(file_path: str, file_name: str) -> str | None:
-    """Upload to 0x0.st (512MB limit, 30 day retention)."""
-    import subprocess
-    result = subprocess.run(
-        ["curl", "-s", "-F", f"file=@{file_path}", "https://0x0.st"],
-        capture_output=True,
-        text=True,
-        timeout=300,
-    )
-    if result.returncode == 0:
-        url = result.stdout.strip()
-        if url.startswith("http"):
-            return url
-    return None
-
-
-def submit_runpod_job(
-    endpoint_id: str,
-    api_key: str,
-    image_url: str,
-    audio_url: str,
-    still_mode: bool = False,
-    enhancer: str = "gfpgan",
-    preprocess: str = "crop",
-    size: int = 256,
-    expression_scale: float = 1.0,
-    pose_style: int = 0,
-    r2_config: dict | None = None,
-) -> dict | None:
-    """Submit a SadTalker job to RunPod serverless endpoint."""
-    url = f"https://api.runpod.ai/v2/{endpoint_id}/run"
-
-    payload = {
-        "input": {
-            "image_url": image_url,
-            "audio_url": audio_url,
-            "still_mode": still_mode,
-            "enhancer": enhancer,
-            "preprocess": preprocess,
-            "size": size,
-            "expression_scale": expression_scale,
-            "pose_style": pose_style,
-        }
-    }
-
-    # Pass R2 credentials for result upload
-    if r2_config:
-        payload["input"]["r2"] = {
-            "endpoint_url": r2_config["endpoint_url"],
-            "access_key_id": r2_config["access_key_id"],
-            "secret_access_key": r2_config["secret_access_key"],
-            "bucket_name": r2_config["bucket_name"],
-        }
-
-    try:
-        response = requests.post(
-            url,
-            json=payload,
-            headers={"Authorization": f"Bearer {api_key}"},
-            timeout=30,
-        )
-
-        if response.status_code == 200:
-            return response.json()
-        else:
-            print(f"Job submission failed: HTTP {response.status_code}", file=sys.stderr)
-            print(f"  Response: {response.text[:500]}", file=sys.stderr)
-            return None
-
-    except Exception as e:
-        print(f"Job submission error: {e}", file=sys.stderr)
-        return None
-
-
-def poll_runpod_job(
-    endpoint_id: str,
-    api_key: str,
-    job_id: str,
-    timeout: int = 600,
-    poll_interval: int = 5,
-    verbose: bool = True,
-) -> dict | None:
-    """Poll RunPod job until completion or timeout."""
-    url = f"https://api.runpod.ai/v2/{endpoint_id}/status/{job_id}"
-    headers = {"Authorization": f"Bearer {api_key}"}
-    start_time = time.time()
-    last_status = None
-    queue_timeout = 300  # Cancel job if stuck in queue for 5 min
-    queue_start = time.time()
-
-    while time.time() - start_time < timeout:
-        try:
-            response = requests.get(
-                url,
-                headers=headers,
-                timeout=30,
-            )
-
-            if response.status_code != 200:
-                print(f"Status check failed: HTTP {response.status_code}", file=sys.stderr)
-                time.sleep(poll_interval)
-                continue
-
-            data = response.json()
-            status = data.get("status")
-
-            if verbose and status != last_status:
-                elapsed = int(time.time() - start_time)
-                print(f"  [{elapsed}s] Status: {status}", file=sys.stderr)
-                last_status = status
-
-            if status == "COMPLETED":
-                return data
-            elif status == "FAILED":
-                print(f"Job failed: {data.get('error', 'Unknown error')}", file=sys.stderr)
-                return data
-
-            # Track queue-to-progress transition
-            if status == "IN_PROGRESS" and queue_start is not None:
-                queue_start = None
-
-            # Cancel jobs stuck in queue too long (prevents runaway billing)
-            if status == "IN_QUEUE" and queue_start is not None and (time.time() - queue_start > queue_timeout):
-                print(f"Job stuck in queue for {queue_timeout}s — cancelling to prevent runaway charges", file=sys.stderr)
-                cancel_url = f"https://api.runpod.ai/v2/{endpoint_id}/cancel/{job_id}"
-                try:
-                    requests.post(cancel_url, headers=headers, timeout=10)
-                except Exception:
-                    pass
-                return {"status": "FAILED", "error": f"Cancelled: no GPU available after {queue_timeout}s in queue"}
-
-            time.sleep(poll_interval)
-
-        except Exception as e:
-            print(f"Status check error: {e}", file=sys.stderr)
-            time.sleep(poll_interval)
-
-    # Overall timeout — cancel the job so it doesn't linger in RunPod's queue
-    print(f"Job timed out after {timeout}s — cancelling on RunPod", file=sys.stderr)
-    cancel_url = f"https://api.runpod.ai/v2/{endpoint_id}/cancel/{job_id}"
-    try:
-        requests.post(cancel_url, headers=headers, timeout=10)
-    except Exception:
-        pass
-    return None
-
-
-def download_from_url(url: str, output_path: str, verbose: bool = True) -> bool:
-    """Download file from URL to local path."""
-    try:
-        if verbose:
-            print(f"Downloading result...", file=sys.stderr)
-
-        response = requests.get(url, stream=True, timeout=300)
-        response.raise_for_status()
-
-        with open(output_path, 'wb') as f:
-            for chunk in response.iter_content(chunk_size=8192):
-                f.write(chunk)
-
-        if verbose:
-            size_kb = Path(output_path).stat().st_size // 1024
-            print(f"  Downloaded: {output_path} ({size_kb}KB)", file=sys.stderr)
-
-        return True
-
-    except Exception as e:
-        print(f"Download error: {e}", file=sys.stderr)
-        return False
-
-
 def retrieve_job_result(
     job_id: str,
     output_path: str,
@@ -411,8 +90,11 @@ def retrieve_job_result(
     """Retrieve results from a completed RunPod job.
 
     Use this if a previous run timed out but the job completed on the server.
+    RunPod-specific (job retrieval is a RunPod concept).
     """
-    config = get_runpod_config()
+    from cloud_gpu import get_provider_config
+
+    config = get_provider_config("runpod", "sadtalker")
     api_key = config.get("api_key")
     endpoint_id = config.get("endpoint_id")
 
@@ -424,7 +106,6 @@ def retrieve_job_result(
     if verbose:
         print(f"Retrieving job: {job_id}", file=sys.stderr)
 
-    # Get job status
     url = f"https://api.runpod.ai/v2/{endpoint_id}/status/{job_id}"
     try:
         response = requests.get(
@@ -447,11 +128,9 @@ def retrieve_job_result(
 
         output = data.get("output", {})
 
-        # Check for error in output
         if output.get("error"):
             return {"error": output["error"]}
 
-        # Get the video URL (presigned R2 URL)
         video_url = output.get("video_url") or output.get("r2_url")
         if not video_url:
             return {"error": "No video_url in job output. Job may have failed."}
@@ -459,7 +138,6 @@ def retrieve_job_result(
         if verbose:
             print(f"  Downloading from: {video_url[:80]}...", file=sys.stderr)
 
-        # Download the video
         if not download_from_url(video_url, output_path, verbose=verbose):
             return {"error": "Failed to download video"}
 
@@ -474,7 +152,7 @@ def retrieve_job_result(
         return {"error": f"Failed to retrieve job: {e}"}
 
 
-def process_with_runpod(
+def process_with_cloud(
     image_path: str,
     audio_path: str,
     output_path: str,
@@ -486,31 +164,13 @@ def process_with_runpod(
     pose_style: int = 0,
     timeout: int = 600,
     verbose: bool = True,
+    cloud: str = "runpod",
 ) -> dict:
-    """Process image+audio using RunPod serverless endpoint."""
-    start_time = time.time()
+    """Process image+audio using cloud GPU endpoint."""
     r2_keys_to_cleanup = []
 
-    # Get RunPod config
-    config = get_runpod_config()
-    api_key = config.get("api_key")
-    endpoint_id = config.get("endpoint_id")
-
-    if not api_key:
-        return {"error": "RUNPOD_API_KEY not set. Add to .env file."}
-    if not endpoint_id:
-        return {"error": "RUNPOD_SADTALKER_ENDPOINT_ID not set. Run with --setup first."}
-
-    # Get R2 config (optional but recommended)
-    sys.path.insert(0, str(Path(__file__).parent))
-    try:
-        from config import get_r2_config
-        r2_config = get_r2_config()
-    except ImportError:
-        r2_config = None
-
-    if not r2_config:
-        print("Warning: R2 not configured. Video will be returned as base64.", file=sys.stderr)
+    if verbose:
+        print(f"Cloud provider: {cloud}", file=sys.stderr)
 
     # Auto-calculate timeout if not specified
     if timeout <= 0:
@@ -520,12 +180,9 @@ def process_with_runpod(
             if verbose:
                 print(f"Audio duration: {audio_duration:.1f}s, timeout: {timeout}s", file=sys.stderr)
         else:
-            timeout = 900  # Default 15 minutes if we can't determine duration
+            timeout = 900  # Default 15 minutes
             if verbose:
                 print(f"Could not determine audio duration, using default timeout: {timeout}s", file=sys.stderr)
-
-    if verbose:
-        print(f"Using RunPod endpoint: {endpoint_id}", file=sys.stderr)
 
     # Upload image
     image_url, image_r2_key = upload_to_storage(image_path, "sadtalker/input")
@@ -541,67 +198,55 @@ def process_with_runpod(
     if audio_r2_key:
         r2_keys_to_cleanup.append(audio_r2_key)
 
-    # Submit job
+    # Build payload
     if verbose:
         print(f"Submitting job (size={size}, enhancer={enhancer})...", file=sys.stderr)
 
-    job_response = submit_runpod_job(
-        endpoint_id=endpoint_id,
-        api_key=api_key,
-        image_url=image_url,
-        audio_url=audio_url,
-        still_mode=still_mode,
-        enhancer=enhancer,
-        preprocess=preprocess,
-        size=size,
-        expression_scale=expression_scale,
-        pose_style=pose_style,
-        r2_config=r2_config,
-    )
+    payload = {
+        "input": {
+            "image_url": image_url,
+            "audio_url": audio_url,
+            "still_mode": still_mode,
+            "enhancer": enhancer,
+            "preprocess": preprocess,
+            "size": size,
+            "expression_scale": expression_scale,
+            "pose_style": pose_style,
+        }
+    }
 
-    if not job_response:
-        return {"error": "Failed to submit job"}
+    r2_payload = get_r2_payload_config()
+    if r2_payload:
+        payload["input"]["r2"] = r2_payload
+    else:
+        print("Warning: R2 not configured. Video will be returned as base64.", file=sys.stderr)
 
-    job_id = job_response.get("id")
-    if not job_id:
-        return {"error": f"No job ID in response: {job_response}"}
+    # Call cloud GPU endpoint
+    from cloud_gpu import call_cloud_endpoint
 
-    if verbose:
-        print(f"Job submitted: {job_id}", file=sys.stderr)
-
-    # Poll for completion
-    result = poll_runpod_job(
-        endpoint_id=endpoint_id,
-        api_key=api_key,
-        job_id=job_id,
+    result, elapsed = call_cloud_endpoint(
+        provider=cloud,
+        payload=payload,
+        tool_name="sadtalker",
         timeout=timeout,
+        progress_label="Generating talking head",
         verbose=verbose,
     )
 
-    if not result:
-        return {"error": "Job timed out or failed to get status"}
-
-    status = result.get("status")
-    if status != "COMPLETED":
-        error = result.get("error") or result.get("output", {}).get("error") or "Unknown error"
-        return {"error": f"Job failed: {error}"}
-
-    # Get output from result
-    output = result.get("output", {})
-    if isinstance(output, dict) and output.get("error"):
-        return {"error": output["error"]}
+    if isinstance(result, dict) and result.get("error"):
+        return {"error": result["error"]}
 
     # Download result
     Path(output_path).parent.mkdir(parents=True, exist_ok=True)
     downloaded = False
 
-    output_r2_key = output.get("r2_key") if isinstance(output, dict) else None
-    output_url = output.get("video_url") if isinstance(output, dict) else None
+    output_r2_key = result.get("r2_key") if isinstance(result, dict) else None
+    output_url = result.get("video_url") if isinstance(result, dict) else None
 
     if output_r2_key:
         if verbose:
             print(f"Downloading result from R2...", file=sys.stderr)
-        downloaded = _download_from_r2(output_r2_key, output_path)
+        downloaded = download_from_r2(output_r2_key, output_path)
         if downloaded:
             r2_keys_to_cleanup.append(output_r2_key)
             if verbose:
@@ -613,9 +258,8 @@ def process_with_runpod(
 
     if not downloaded:
         # Try base64 fallback
-        video_base64 = output.get("video_base64")
+        video_base64 = result.get("video_base64")
         if video_base64:
-            import base64
             Path(output_path).write_bytes(base64.b64decode(video_base64))
             downloaded = True
             if verbose:
@@ -623,22 +267,18 @@ def process_with_runpod(
                 print(f"  Decoded from base64: {output_path} ({size_kb}KB)", file=sys.stderr)
 
     if not downloaded:
-        return {"error": f"No video in result: {list(output.keys()) if isinstance(output, dict) else output}"}
+        return {"error": f"No video in result: {list(result.keys()) if isinstance(result, dict) else result}"}
 
     # Cleanup R2 objects
-    if r2_keys_to_cleanup:
-        for key in r2_keys_to_cleanup:
-            _delete_from_r2(key)
-
-    elapsed = time.time() - start_time
+    for key in r2_keys_to_cleanup:
+        delete_from_r2(key)
 
     return {
         "success": True,
         "output": output_path,
-        "job_id": job_id,
         "processing_time_seconds": round(elapsed, 2),
-        "duration_seconds": output.get("duration_seconds"),
-        "chunks_processed": output.get("chunks_processed"),
+        "duration_seconds": result.get("duration_seconds"),
+        "chunks_processed": result.get("chunks_processed"),
     }
 
 
@@ -878,8 +518,9 @@ def setup_runpod(gpu_id: str = "AMPERE_24", verbose: bool = True) -> dict:
         "created_endpoint": False,
     }
 
-    config = get_runpod_config()
-    api_key = config.get("api_key")
+    from dotenv import load_dotenv
+    load_dotenv()
+    api_key = os.getenv("RUNPOD_API_KEY")
 
     if not api_key:
         result["error"] = "RUNPOD_API_KEY not set. Add to .env file first."
@@ -1035,18 +676,25 @@ Examples:
         help="Use a preset configuration (overrides other settings)",
     )
 
-    # RunPod options
+    # Cloud GPU options
+    parser.add_argument(
+        "--cloud",
+        type=str,
+        default="runpod",
+        choices=["runpod", "modal"],
+        help="Cloud GPU provider (default: runpod)",
+    )
     parser.add_argument(
         "--timeout",
         type=int,
         default=0,
-        help="RunPod job timeout in seconds (default: auto-calculated from audio duration)",
+        help="Job timeout in seconds (default: auto-calculated from audio duration)",
     )
     parser.add_argument(
         "--retrieve",
         type=str,
         metavar="JOB_ID",
-        help="Retrieve results from a completed job (e.g., if previous run timed out)",
+        help="Retrieve results from a completed RunPod job (e.g., if previous run timed out)",
     )
     parser.add_argument(
         "--setup",
@@ -1149,7 +797,7 @@ def main():
     if verbose:
         print("Generating talking head video with SadTalker...")
 
-    result = process_with_runpod(
+    result = process_with_cloud(
         image_path=args.image,
         audio_path=args.audio,
         output_path=args.output,
@@ -1161,6 +809,7 @@ def main():
         pose_style=pose_style,
         timeout=args.timeout,
         verbose=verbose,
+        cloud=args.cloud,
     )
 
     if result.get("error"):

--- a/tools/sadtalker.py
+++ b/tools/sadtalker.py
@@ -50,8 +50,8 @@ SADTALKER_TEMPLATE_NAME = "video-toolkit-sadtalker"
 SADTALKER_ENDPOINT_NAME = "video-toolkit-sadtalker"
 
 # Processing time estimate: ~4 minutes per minute of audio + buffer
-PROCESSING_TIME_MULTIPLIER = 4
-PROCESSING_TIME_BUFFER = 120  # 2 minute buffer for cold start, upload, etc.
+PROCESSING_TIME_MULTIPLIER = 12  # ~10x processing time per second of audio + margin
+PROCESSING_TIME_BUFFER = 180  # 3 minute buffer for cold start, upload, etc.
 
 
 def get_audio_duration(audio_path: str) -> float | None:

--- a/tools/upscale.py
+++ b/tools/upscale.py
@@ -2,33 +2,28 @@
 """
 Upscale images using AI (Real-ESRGAN).
 
-Supports cloud processing via RunPod serverless GPUs.
+Cloud providers: RunPod (default), Modal.
 
 Usage:
-    # Cloud processing via RunPod (works from any machine)
-    python tools/upscale.py --input image.jpg --output upscaled.png --runpod
+    # Cloud processing (RunPod, default)
+    python tools/upscale.py --input image.jpg --output upscaled.png --cloud runpod
+
+    # Using Modal
+    python tools/upscale.py --input image.jpg --output upscaled.png --cloud modal
 
     # Specify model and scale
-    python tools/upscale.py --input image.jpg --output upscaled.png --model anime --scale 4 --runpod
+    python tools/upscale.py --input image.jpg --output upscaled.png --model anime --scale 4 --cloud runpod
 
     # With face enhancement
-    python tools/upscale.py --input image.jpg --output upscaled.png --face-enhance --runpod
+    python tools/upscale.py --input image.jpg --output upscaled.png --face-enhance --cloud runpod
 
-RunPod Setup:
-    1. Create account at runpod.io
-    2. Deploy the realesrgan Docker image (see docker/runpod-realesrgan/)
-    3. Add to .env:
-       RUNPOD_API_KEY=your_key
-       RUNPOD_UPSCALE_ENDPOINT_ID=your_endpoint
+    # Legacy flag (deprecated, use --cloud runpod)
+    python tools/upscale.py --input image.jpg --output upscaled.png --runpod
 
 Models:
     - general: RealESRGAN_x4plus (default, good for most images)
     - anime: RealESRGAN_x4plus_anime_6B (optimized for anime/illustration)
     - photo: realesr-general-x4v3 (alternative general model)
-
-Cost (RunPod):
-    - ~$0.01-0.05 per image depending on size
-    - Uses RTX 3090 (~$0.34/hr) by default
 """
 
 import argparse
@@ -41,197 +36,45 @@ from pathlib import Path
 
 import requests
 
+sys.path.insert(0, str(Path(__file__).parent))
+from file_transfer import (
+    upload_to_storage, download_from_r2, delete_from_r2,
+    download_from_url, get_r2_payload_config,
+)
+
 # Docker image for RunPod endpoint
 REALESRGAN_DOCKER_IMAGE = "ghcr.io/conalmullan/video-toolkit-realesrgan:v2"
 REALESRGAN_TEMPLATE_NAME = "video-toolkit-realesrgan-v2"
 REALESRGAN_ENDPOINT_NAME = "video-toolkit-upscale"
 
 
-def get_runpod_config() -> dict:
-    """Get RunPod configuration from environment."""
-    sys.path.insert(0, str(Path(__file__).parent))
-    try:
-        from config import get_runpod_api_key
-        api_key = get_runpod_api_key()
-    except ImportError:
-        from dotenv import load_dotenv
-        load_dotenv()
-        api_key = os.getenv("RUNPOD_API_KEY")
-
-    # Try specific endpoint first, then fall back to general
-    from dotenv import load_dotenv
-    load_dotenv()
-    endpoint_id = os.getenv("RUNPOD_UPSCALE_ENDPOINT_ID")
-
-    return {
-        "api_key": api_key,
-        "endpoint_id": endpoint_id,
-    }
-
-
-def _get_r2_client():
-    """Get boto3 S3 client configured for Cloudflare R2."""
-    sys.path.insert(0, str(Path(__file__).parent))
-    try:
-        from config import get_r2_config
-        r2_config = get_r2_config()
-    except ImportError:
-        r2_config = None
-
-    if not r2_config:
-        return None, None
-
-    try:
-        import boto3
-        from botocore.config import Config
-
-        client = boto3.client(
-            "s3",
-            endpoint_url=r2_config["endpoint_url"],
-            aws_access_key_id=r2_config["access_key_id"],
-            aws_secret_access_key=r2_config["secret_access_key"],
-            config=Config(signature_version="s3v4"),
-        )
-        return client, r2_config
-    except ImportError:
-        print("  boto3 not installed, skipping R2", file=sys.stderr)
-        return None, None
-
-
-def _upload_to_r2(file_path: str, file_name: str) -> tuple[str | None, str | None]:
-    """Upload to Cloudflare R2 and return presigned download URL."""
-    client, config = _get_r2_client()
-    if not client:
-        return None, None
-
-    import uuid
-    object_key = f"upscale/{uuid.uuid4().hex[:8]}_{file_name}"
-
-    try:
-        client.upload_file(file_path, config["bucket_name"], object_key)
-
-        # Generate presigned URL (valid for 2 hours)
-        url = client.generate_presigned_url(
-            "get_object",
-            Params={"Bucket": config["bucket_name"], "Key": object_key},
-            ExpiresIn=7200,
-        )
-        return url, object_key
-    except Exception as e:
-        print(f"  R2 upload error: {e}", file=sys.stderr)
-        return None, None
-
-
-def _delete_from_r2(object_key: str) -> bool:
-    """Delete object from R2 after job completion."""
-    client, config = _get_r2_client()
-    if not client or not object_key:
-        return False
-
-    try:
-        client.delete_object(Bucket=config["bucket_name"], Key=object_key)
-        return True
-    except Exception:
-        return False
-
-
-def _download_from_r2(object_key: str, output_path: str) -> bool:
-    """Download object from R2 to local path."""
-    client, config = _get_r2_client()
-    if not client:
-        return False
-
-    try:
-        client.download_file(config["bucket_name"], object_key, output_path)
-        return True
-    except Exception as e:
-        print(f"  R2 download error: {e}", file=sys.stderr)
-        return False
-
-
-def upload_to_storage(file_path: str, api_key: str) -> tuple[str | None, str | None]:
-    """Upload a file to temporary storage for job input."""
-    file_size = Path(file_path).stat().st_size
-    file_name = Path(file_path).name
-
-    print(f"Uploading {file_name} ({file_size // 1024}KB)...", file=sys.stderr)
-
-    # Try R2 first if configured
-    url, r2_key = _upload_to_r2(file_path, file_name)
-    if url:
-        print(f"  Upload complete (R2)", file=sys.stderr)
-        return url, r2_key
-
-    # Fall back to free services
-    upload_services = [
-        ("litterbox", _upload_to_litterbox),
-        ("0x0.st", _upload_to_0x0),
-    ]
-
-    for service_name, upload_func in upload_services:
-        try:
-            url = upload_func(file_path, file_name)
-            if url:
-                print(f"  Upload complete ({service_name})", file=sys.stderr)
-                return url, None
-        except Exception as e:
-            print(f"  {service_name} failed: {e}", file=sys.stderr)
-            continue
-
-    print("All upload services failed", file=sys.stderr)
-    return None, None
-
-
-def _upload_to_litterbox(file_path: str, file_name: str) -> str | None:
-    """Upload to litterbox.catbox.moe (200MB limit, 24h retention)."""
-    import subprocess
-    result = subprocess.run(
-        [
-            "curl", "-s",
-            "-F", "reqtype=fileupload",
-            "-F", "time=24h",
-            "-F", f"fileToUpload=@{file_path}",
-            "https://litterbox.catbox.moe/resources/internals/api.php",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=300,
-    )
-    if result.returncode == 0:
-        url = result.stdout.strip()
-        if url.startswith("http"):
-            return url
-    return None
-
-
-def _upload_to_0x0(file_path: str, file_name: str) -> str | None:
-    """Upload to 0x0.st (512MB limit, 30 day retention)."""
-    import subprocess
-    result = subprocess.run(
-        ["curl", "-s", "-F", f"file=@{file_path}", "https://0x0.st"],
-        capture_output=True,
-        text=True,
-        timeout=300,
-    )
-    if result.returncode == 0:
-        url = result.stdout.strip()
-        if url.startswith("http"):
-            return url
-    return None
-
-
-def submit_runpod_job(
-    endpoint_id: str,
-    api_key: str,
-    image_url: str,
+def process_with_cloud(
+    input_path: str,
+    output_path: str,
     scale: int = 4,
     model: str = "general",
     face_enhance: bool = False,
     output_format: str = "png",
-    r2_config: dict | None = None,
-) -> dict | None:
-    """Submit an upscale job to RunPod serverless endpoint."""
-    url = f"https://api.runpod.ai/v2/{endpoint_id}/run"
+    timeout: int = 300,
+    verbose: bool = True,
+    cloud: str = "runpod",
+) -> dict:
+    """Process image using cloud GPU endpoint."""
+    r2_keys_to_cleanup = []
+
+    if verbose:
+        print(f"Cloud provider: {cloud}", file=sys.stderr)
+
+    # Upload image
+    image_url, image_r2_key = upload_to_storage(input_path, "upscale/input")
+    if not image_url:
+        return {"error": "Failed to upload image"}
+    if image_r2_key:
+        r2_keys_to_cleanup.append(image_r2_key)
+
+    # Build payload
+    if verbose:
+        print(f"Submitting job (scale={scale}, model={model})...", file=sys.stderr)
 
     payload = {
         "input": {
@@ -244,232 +87,36 @@ def submit_runpod_job(
         }
     }
 
-    # Pass R2 credentials for result upload (if configured)
-    if r2_config:
-        payload["input"]["r2"] = {
-            "endpoint_url": r2_config["endpoint_url"],
-            "access_key_id": r2_config["access_key_id"],
-            "secret_access_key": r2_config["secret_access_key"],
-            "bucket_name": r2_config["bucket_name"],
-        }
+    r2_payload = get_r2_payload_config()
+    if r2_payload:
+        payload["input"]["r2"] = r2_payload
 
-    try:
-        response = requests.post(
-            url,
-            json=payload,
-            headers={"Authorization": f"Bearer {api_key}"},
-            timeout=30,
-        )
+    # Call cloud GPU endpoint
+    from cloud_gpu import call_cloud_endpoint
 
-        if response.status_code == 200:
-            return response.json()
-        else:
-            print(f"Job submission failed: HTTP {response.status_code}", file=sys.stderr)
-            print(f"  Response: {response.text[:500]}", file=sys.stderr)
-            return None
-
-    except Exception as e:
-        print(f"Job submission error: {e}", file=sys.stderr)
-        return None
-
-
-def poll_runpod_job(
-    endpoint_id: str,
-    api_key: str,
-    job_id: str,
-    timeout: int = 300,
-    poll_interval: int = 2,
-    verbose: bool = True,
-) -> dict | None:
-    """Poll RunPod job until completion or timeout."""
-    url = f"https://api.runpod.ai/v2/{endpoint_id}/status/{job_id}"
-    headers = {"Authorization": f"Bearer {api_key}"}
-    start_time = time.time()
-    last_status = None
-    queue_timeout = 300  # Cancel job if stuck in queue for 5 min
-    queue_start = time.time()
-
-    while time.time() - start_time < timeout:
-        try:
-            response = requests.get(
-                url,
-                headers=headers,
-                timeout=30,
-            )
-
-            if response.status_code != 200:
-                print(f"Status check failed: HTTP {response.status_code}", file=sys.stderr)
-                time.sleep(poll_interval)
-                continue
-
-            data = response.json()
-            status = data.get("status")
-
-            if verbose and status != last_status:
-                elapsed = int(time.time() - start_time)
-                print(f"  [{elapsed}s] Status: {status}", file=sys.stderr)
-                last_status = status
-
-            if status == "COMPLETED":
-                return data
-            elif status == "FAILED":
-                print(f"Job failed: {data.get('error', 'Unknown error')}", file=sys.stderr)
-                return data
-
-            # Track queue-to-progress transition
-            if status == "IN_PROGRESS" and queue_start is not None:
-                queue_start = None
-
-            # Cancel jobs stuck in queue too long (prevents runaway billing)
-            if status == "IN_QUEUE" and queue_start is not None and (time.time() - queue_start > queue_timeout):
-                print(f"Job stuck in queue for {queue_timeout}s — cancelling to prevent runaway charges", file=sys.stderr)
-                cancel_url = f"https://api.runpod.ai/v2/{endpoint_id}/cancel/{job_id}"
-                try:
-                    requests.post(cancel_url, headers=headers, timeout=10)
-                except Exception:
-                    pass
-                return {"status": "FAILED", "error": f"Cancelled: no GPU available after {queue_timeout}s in queue"}
-
-            time.sleep(poll_interval)
-
-        except Exception as e:
-            print(f"Status check error: {e}", file=sys.stderr)
-            time.sleep(poll_interval)
-
-    # Overall timeout — cancel the job so it doesn't linger in RunPod's queue
-    print(f"Job timed out after {timeout}s — cancelling on RunPod", file=sys.stderr)
-    cancel_url = f"https://api.runpod.ai/v2/{endpoint_id}/cancel/{job_id}"
-    try:
-        requests.post(cancel_url, headers=headers, timeout=10)
-    except Exception:
-        pass
-    return None
-
-
-def download_from_url(url: str, output_path: str, verbose: bool = True) -> bool:
-    """Download file from URL to local path."""
-    try:
-        if verbose:
-            print(f"Downloading result...", file=sys.stderr)
-
-        response = requests.get(url, stream=True, timeout=300)
-        response.raise_for_status()
-
-        with open(output_path, 'wb') as f:
-            for chunk in response.iter_content(chunk_size=8192):
-                f.write(chunk)
-
-        if verbose:
-            size_kb = Path(output_path).stat().st_size // 1024
-            print(f"  Downloaded: {output_path} ({size_kb}KB)", file=sys.stderr)
-
-        return True
-
-    except Exception as e:
-        print(f"Download error: {e}", file=sys.stderr)
-        return False
-
-
-def process_with_runpod(
-    input_path: str,
-    output_path: str,
-    scale: int = 4,
-    model: str = "general",
-    face_enhance: bool = False,
-    output_format: str = "png",
-    timeout: int = 300,
-    verbose: bool = True,
-) -> dict:
-    """Process image using RunPod serverless endpoint."""
-    start_time = time.time()
-    r2_keys_to_cleanup = []
-
-    # Get RunPod config
-    config = get_runpod_config()
-    api_key = config.get("api_key")
-    endpoint_id = config.get("endpoint_id")
-
-    if not api_key:
-        return {"error": "RUNPOD_API_KEY not set. Add to .env file."}
-    if not endpoint_id:
-        return {"error": "RUNPOD_UPSCALE_ENDPOINT_ID not set. Run with --setup first."}
-
-    # Get R2 config (optional)
-    sys.path.insert(0, str(Path(__file__).parent))
-    try:
-        from config import get_r2_config
-        r2_config = get_r2_config()
-    except ImportError:
-        r2_config = None
-
-    if verbose:
-        print(f"Using RunPod endpoint: {endpoint_id}", file=sys.stderr)
-
-    # Upload image
-    image_url, image_r2_key = upload_to_storage(input_path, api_key)
-    if not image_url:
-        return {"error": "Failed to upload image"}
-    if image_r2_key:
-        r2_keys_to_cleanup.append(image_r2_key)
-
-    # Submit job
-    if verbose:
-        print(f"Submitting job (scale={scale}, model={model})...", file=sys.stderr)
-
-    job_response = submit_runpod_job(
-        endpoint_id=endpoint_id,
-        api_key=api_key,
-        image_url=image_url,
-        scale=scale,
-        model=model,
-        face_enhance=face_enhance,
-        output_format=output_format,
-        r2_config=r2_config,
-    )
-
-    if not job_response:
-        return {"error": "Failed to submit job"}
-
-    job_id = job_response.get("id")
-    if not job_id:
-        return {"error": f"No job ID in response: {job_response}"}
-
-    if verbose:
-        print(f"Job submitted: {job_id}", file=sys.stderr)
-
-    # Poll for completion
-    result = poll_runpod_job(
-        endpoint_id=endpoint_id,
-        api_key=api_key,
-        job_id=job_id,
+    result, elapsed = call_cloud_endpoint(
+        provider=cloud,
+        payload=payload,
+        tool_name="upscale",
         timeout=timeout,
+        progress_label="Upscaling image",
         verbose=verbose,
     )
 
-    if not result:
-        return {"error": "Job timed out or failed to get status"}
-
-    status = result.get("status")
-    if status != "COMPLETED":
-        error = result.get("error") or result.get("output", {}).get("error") or "Unknown error"
-        return {"error": f"Job failed: {error}"}
-
-    # Get output from result
-    output = result.get("output", {})
-    if isinstance(output, dict) and output.get("error"):
-        return {"error": output["error"]}
+    if isinstance(result, dict) and result.get("error"):
+        return {"error": result["error"]}
 
     # Download result
     Path(output_path).parent.mkdir(parents=True, exist_ok=True)
     downloaded = False
 
-    output_r2_key = output.get("r2_key") if isinstance(output, dict) else None
-    output_url = output.get("output_url") if isinstance(output, dict) else None
+    output_r2_key = result.get("r2_key") if isinstance(result, dict) else None
+    output_url = result.get("output_url") if isinstance(result, dict) else None
 
     if output_r2_key:
         if verbose:
             print(f"Downloading result from R2...", file=sys.stderr)
-        downloaded = _download_from_r2(output_r2_key, output_path)
+        downloaded = download_from_r2(output_r2_key, output_path)
         if downloaded:
             r2_keys_to_cleanup.append(output_r2_key)
             if verbose:
@@ -480,21 +127,17 @@ def process_with_runpod(
         downloaded = download_from_url(output_url, output_path, verbose=verbose)
 
     if not downloaded:
-        return {"error": f"No output_url or r2_key in result: {output}"}
+        return {"error": f"No output_url or r2_key in result: {result}"}
 
     # Cleanup R2 objects
-    if r2_keys_to_cleanup:
-        for key in r2_keys_to_cleanup:
-            _delete_from_r2(key)
-
-    elapsed = time.time() - start_time
+    for key in r2_keys_to_cleanup:
+        delete_from_r2(key)
 
     return {
         "success": True,
         "output": output_path,
-        "job_id": job_id,
         "processing_time_seconds": round(elapsed, 2),
-        "runpod_output": output,
+        "cloud_output": result,
     }
 
 
@@ -734,8 +377,9 @@ def setup_runpod(gpu_id: str = "AMPERE_24", verbose: bool = True) -> dict:
         "created_endpoint": False,
     }
 
-    config = get_runpod_config()
-    api_key = config.get("api_key")
+    from dotenv import load_dotenv
+    load_dotenv()
+    api_key = os.getenv("RUNPOD_API_KEY")
 
     if not api_key:
         result["error"] = "RUNPOD_API_KEY not set. Add to .env file first."
@@ -814,14 +458,14 @@ def parse_args():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  # Upscale image 4x using RunPod
-  python tools/upscale.py --input photo.jpg --output photo_4x.png --runpod
+  # Upscale image 4x using cloud GPU
+  python tools/upscale.py --input photo.jpg --output photo_4x.png --cloud runpod
 
   # Use anime model for illustrations
-  python tools/upscale.py --input art.png --output art_4x.png --model anime --runpod
+  python tools/upscale.py --input art.png --output art_4x.png --model anime --cloud runpod
 
   # With face enhancement
-  python tools/upscale.py --input portrait.jpg --output portrait_4x.png --face-enhance --runpod
+  python tools/upscale.py --input portrait.jpg --output portrait_4x.png --face-enhance --cloud runpod
 
   # Setup RunPod endpoint (first-time)
   python tools/upscale.py --setup
@@ -865,17 +509,25 @@ Examples:
         help="Output format (default: png)",
     )
 
-    # RunPod options
+    # Cloud GPU options
+    parser.add_argument(
+        "--cloud",
+        type=str,
+        default=None,
+        choices=["runpod", "modal"],
+        help="Cloud GPU provider (default: runpod)",
+    )
     parser.add_argument(
         "--runpod",
         action="store_true",
-        help="Process on RunPod serverless GPU",
+        help="[Deprecated] Use --cloud runpod instead",
     )
     parser.add_argument(
-        "--runpod-timeout",
+        "--timeout", "--runpod-timeout",
         type=int,
         default=300,
-        help="RunPod job timeout in seconds (default: 300)",
+        dest="timeout",
+        help="Job timeout in seconds (default: 300)",
     )
     parser.add_argument(
         "--setup",
@@ -909,6 +561,12 @@ def main():
     args = parse_args()
     verbose = not args.json
 
+    # Handle deprecated --runpod flag
+    if args.runpod:
+        print("Note: --runpod is deprecated, use --cloud runpod instead", file=sys.stderr)
+        if not args.cloud:
+            args.cloud = "runpod"
+
     # Handle --setup
     if args.setup:
         result = setup_runpod(gpu_id=args.setup_gpu, verbose=verbose)
@@ -933,7 +591,6 @@ def main():
 
     # Dry run
     if args.dry_run:
-        config = get_runpod_config()
         result = {
             "dry_run": True,
             "input": args.input,
@@ -942,9 +599,7 @@ def main():
             "model": args.model,
             "face_enhance": args.face_enhance,
             "output_format": args.format,
-            "runpod": args.runpod,
-            "endpoint_configured": bool(config.get("endpoint_id")),
-            "api_key_configured": bool(config.get("api_key")),
+            "cloud": args.cloud,
         }
         if args.json:
             print(json.dumps(result, indent=2))
@@ -954,20 +609,18 @@ def main():
                 print(f"  {k}: {v}")
         return
 
-    # RunPod processing
-    if args.runpod:
-        if verbose:
-            print("Processing with RunPod cloud GPU...")
-
-        result = process_with_runpod(
+    # Cloud processing
+    if args.cloud:
+        result = process_with_cloud(
             input_path=args.input,
             output_path=args.output,
             scale=args.scale,
             model=args.model,
             face_enhance=args.face_enhance,
             output_format=args.format,
-            timeout=args.runpod_timeout,
+            timeout=args.timeout,
             verbose=verbose,
+            cloud=args.cloud,
         )
 
         if result.get("error"):
@@ -977,7 +630,7 @@ def main():
         if args.json:
             print(json.dumps(result, indent=2))
         else:
-            output_info = result.get("runpod_output", {})
+            output_info = result.get("cloud_output", {})
             input_dims = output_info.get("input_dimensions", "?")
             output_dims = output_info.get("output_dimensions", "?")
             print(f"Upscaled: {result['output']}")
@@ -986,9 +639,9 @@ def main():
 
         return
 
-    # Local processing not implemented yet
-    print("Error: Local processing not implemented. Use --runpod for cloud processing.", file=sys.stderr)
-    print("       Or run --setup first to configure RunPod endpoint.", file=sys.stderr)
+    # No cloud provider specified
+    print("Error: Specify --cloud runpod or --cloud modal for cloud processing.", file=sys.stderr)
+    print("       Or run --setup first to configure a RunPod endpoint.", file=sys.stderr)
     sys.exit(1)
 
 

--- a/tools/verify_setup.py
+++ b/tools/verify_setup.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""Verify toolkit setup — checks prerequisites, cloud GPU, R2, and voice configuration.
+
+Run after /setup to confirm everything is working, or anytime to diagnose issues.
+
+Usage:
+    python3 tools/verify_setup.py           # Full check (no cloud calls)
+    python3 tools/verify_setup.py --test    # Full check + smoke tests (makes cloud GPU calls)
+    python3 tools/verify_setup.py --json    # Machine-readable output
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def check_command(cmd: list[str]) -> tuple[bool, str]:
+    """Check if a command exists and return its version."""
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+        if result.returncode == 0:
+            version = result.stdout.strip().split("\n")[0]
+            return True, version
+        return False, result.stderr.strip()[:100]
+    except FileNotFoundError:
+        return False, "not installed"
+    except Exception as e:
+        return False, str(e)[:100]
+
+
+def check_prerequisites() -> list[dict]:
+    """Check required and optional prerequisites."""
+    results = []
+
+    # Node.js (required)
+    ok, version = check_command(["node", "--version"])
+    results.append({
+        "name": "Node.js",
+        "required": True,
+        "ok": ok,
+        "detail": version if ok else "Install from https://nodejs.org/",
+    })
+
+    # Python (recommended)
+    ok, version = check_command(["python3", "--version"])
+    results.append({
+        "name": "Python",
+        "required": False,
+        "ok": ok,
+        "detail": version if ok else "Install from https://python.org/",
+    })
+
+    # FFmpeg (optional)
+    ok, version = check_command(["ffmpeg", "-version"])
+    if ok:
+        # Parse just the version line
+        version = version.split(" Copyright")[0] if " Copyright" in version else version
+    results.append({
+        "name": "FFmpeg",
+        "required": False,
+        "ok": ok,
+        "detail": version if ok else "brew install ffmpeg (macOS)",
+    })
+
+    # pip packages
+    try:
+        import requests  # noqa: F401
+        results.append({"name": "pip packages", "required": False, "ok": True, "detail": "OK"})
+    except ImportError:
+        results.append({
+            "name": "pip packages",
+            "required": False,
+            "ok": False,
+            "detail": "pip install -r tools/requirements.txt",
+        })
+
+    # Modal CLI
+    ok, version = check_command(["modal", "--version"])
+    results.append({
+        "name": "Modal CLI",
+        "required": False,
+        "ok": ok,
+        "detail": version if ok else "pip install modal",
+    })
+
+    return results
+
+
+def check_r2() -> dict:
+    """Check Cloudflare R2 configuration."""
+    account_id = os.getenv("R2_ACCOUNT_ID")
+    access_key = os.getenv("R2_ACCESS_KEY_ID")
+    secret_key = os.getenv("R2_SECRET_ACCESS_KEY")
+    bucket = os.getenv("R2_BUCKET_NAME", "video-toolkit")
+
+    if not account_id or account_id == "your_account_id_here":
+        return {"ok": False, "detail": "R2_ACCOUNT_ID not set", "bucket": None}
+    if not access_key or access_key == "your_access_key_id_here":
+        return {"ok": False, "detail": "R2_ACCESS_KEY_ID not set", "bucket": None}
+    if not secret_key:
+        return {"ok": False, "detail": "R2_SECRET_ACCESS_KEY not set", "bucket": None}
+
+    return {"ok": True, "detail": f"bucket: {bucket}", "bucket": bucket}
+
+
+def test_r2_connectivity() -> dict:
+    """Actually test R2 upload/download (only with --test flag)."""
+    try:
+        from file_transfer import upload_to_r2, delete_from_r2
+
+        tmp = tempfile.NamedTemporaryFile(suffix=".txt", delete=False)
+        tmp.write(b"verify_setup connectivity test")
+        tmp.close()
+
+        url, key = upload_to_r2(tmp.name, "setup-verify")
+        os.unlink(tmp.name)
+
+        if url and key:
+            delete_from_r2(key)
+            return {"ok": True, "detail": "upload/download verified"}
+        return {"ok": False, "detail": "upload returned no URL"}
+    except Exception as e:
+        return {"ok": False, "detail": str(e)[:200]}
+
+
+def check_modal_apps() -> dict:
+    """Check which Modal apps are deployed."""
+    if not shutil.which("modal"):
+        return {"ok": False, "apps": [], "detail": "Modal CLI not installed"}
+
+    try:
+        result = subprocess.run(
+            ["modal", "app", "list", "--json"],
+            capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode != 0:
+            return {"ok": False, "apps": [], "detail": "modal app list failed — run `modal setup`?"}
+
+        apps = json.loads(result.stdout)
+        toolkit_apps = [
+            a for a in apps
+            if a.get("Description", "").startswith("video-toolkit-")
+            and a.get("State") == "deployed"
+        ]
+
+        app_names = [a["Description"] for a in toolkit_apps]
+        return {
+            "ok": len(toolkit_apps) > 0,
+            "apps": app_names,
+            "detail": f"{len(toolkit_apps)} deployed" if toolkit_apps else "no toolkit apps deployed",
+        }
+    except Exception as e:
+        return {"ok": False, "apps": [], "detail": str(e)[:200]}
+
+
+def check_modal_env_vars() -> list[dict]:
+    """Check which Modal endpoint URLs are configured."""
+    tools = {
+        "MODAL_QWEN3_TTS_ENDPOINT_URL": "Speech (Qwen3-TTS)",
+        "MODAL_FLUX2_ENDPOINT_URL": "Images (FLUX.2)",
+        "MODAL_IMAGE_EDIT_ENDPOINT_URL": "Image Editing (Qwen-Edit)",
+        "MODAL_UPSCALE_ENDPOINT_URL": "Upscaling (RealESRGAN)",
+        "MODAL_MUSIC_GEN_ENDPOINT_URL": "Music (ACE-Step)",
+        "MODAL_SADTALKER_ENDPOINT_URL": "Talking Heads (SadTalker)",
+        "MODAL_DEWATERMARK_ENDPOINT_URL": "Watermark Removal (ProPainter)",
+    }
+
+    results = []
+    for env_var, name in tools.items():
+        url = os.getenv(env_var)
+        results.append({
+            "name": name,
+            "env_var": env_var,
+            "ok": bool(url and url.startswith("https://")),
+            "detail": "configured" if url and url.startswith("https://") else "not set",
+        })
+    return results
+
+
+def check_runpod_env_vars() -> list[dict]:
+    """Check which RunPod endpoint IDs are configured."""
+    api_key = os.getenv("RUNPOD_API_KEY")
+    if not api_key:
+        return [{"name": "RunPod API Key", "ok": False, "detail": "not set"}]
+
+    tools = {
+        "RUNPOD_QWEN3_TTS_ENDPOINT_ID": "Speech (Qwen3-TTS)",
+        "RUNPOD_FLUX2_ENDPOINT_ID": "Images (FLUX.2)",
+        "RUNPOD_QWEN_EDIT_ENDPOINT_ID": "Image Editing (Qwen-Edit)",
+        "RUNPOD_UPSCALE_ENDPOINT_ID": "Upscaling (RealESRGAN)",
+        "RUNPOD_ACESTEP_ENDPOINT_ID": "Music (ACE-Step)",
+        "RUNPOD_SADTALKER_ENDPOINT_ID": "Talking Heads (SadTalker)",
+        "RUNPOD_ENDPOINT_ID": "Watermark Removal (ProPainter)",
+    }
+
+    results = [{"name": "RunPod API Key", "ok": True, "detail": "configured"}]
+    for env_var, name in tools.items():
+        val = os.getenv(env_var)
+        results.append({
+            "name": name,
+            "env_var": env_var,
+            "ok": bool(val),
+            "detail": "configured" if val else "not set",
+        })
+    return results
+
+
+def check_voice() -> dict:
+    """Check voice/TTS configuration."""
+    elevenlabs_key = os.getenv("ELEVENLABS_API_KEY")
+    elevenlabs_voice = os.getenv("ELEVENLABS_VOICE_ID")
+
+    # Qwen3-TTS is "configured" if its endpoint exists (either Modal or RunPod)
+    qwen3_modal = os.getenv("MODAL_QWEN3_TTS_ENDPOINT_URL")
+    qwen3_runpod = os.getenv("RUNPOD_QWEN3_TTS_ENDPOINT_ID")
+    qwen3_ok = bool(qwen3_modal) or bool(qwen3_runpod)
+
+    return {
+        "qwen3_tts": {"ok": qwen3_ok, "detail": "Modal" if qwen3_modal else ("RunPod" if qwen3_runpod else "not configured")},
+        "elevenlabs": {"ok": bool(elevenlabs_key), "detail": "configured" if elevenlabs_key else "not configured (optional)"},
+    }
+
+
+def test_cloud_endpoint(tool_name: str, provider: str = "modal") -> dict:
+    """Smoke test a cloud GPU endpoint (only with --test flag)."""
+    try:
+        from cloud_gpu import call_cloud_endpoint
+
+        if tool_name == "qwen3_tts":
+            payload = {
+                "text": "Test.",
+                "speaker": "Ryan",
+                "tone": "neutral",
+            }
+            result, elapsed = call_cloud_endpoint(
+                provider=provider,
+                payload={"input": payload} if provider == "runpod" else payload,
+                tool_name="qwen3_tts",
+                timeout=120,
+                progress_label="Testing TTS",
+                verbose=False,
+            )
+            ok = isinstance(result, dict) and not result.get("error")
+            return {"ok": ok, "detail": f"{elapsed:.1f}s" if ok else result.get("error", "failed")[:100]}
+
+        elif tool_name == "flux2":
+            payload = {
+                "prompt": "solid blue square",
+                "steps": 4,
+                "guidance_scale": 1.0,
+            }
+            result, elapsed = call_cloud_endpoint(
+                provider=provider,
+                payload={"input": payload} if provider == "runpod" else payload,
+                tool_name="flux2",
+                timeout=120,
+                progress_label="Testing image gen",
+                verbose=False,
+            )
+            ok = isinstance(result, dict) and not result.get("error")
+            return {"ok": ok, "detail": f"{elapsed:.1f}s" if ok else result.get("error", "failed")[:100]}
+
+        return {"ok": False, "detail": f"no smoke test for {tool_name}"}
+    except Exception as e:
+        return {"ok": False, "detail": str(e)[:200]}
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Verify toolkit setup")
+    parser.add_argument("--test", action="store_true", help="Run smoke tests (makes cloud GPU calls, costs ~$0.01)")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    verbose = not args.json
+    results = {}
+
+    # 1. Prerequisites
+    prereqs = check_prerequisites()
+    results["prerequisites"] = prereqs
+    if verbose:
+        print("Prerequisites:")
+        for p in prereqs:
+            status = "OK" if p["ok"] else ("MISSING" if p["required"] else "not found")
+            req = " (required)" if p["required"] else ""
+            print(f"  {'[x]' if p['ok'] else '[ ]'} {p['name']}{req}: {p['detail']}")
+        print()
+
+    # 2. Cloudflare R2
+    r2 = check_r2()
+    results["r2"] = r2
+    if verbose:
+        print(f"Cloudflare R2: {'[x]' if r2['ok'] else '[ ]'} {r2['detail']}")
+
+    if args.test and r2["ok"]:
+        r2_test = test_r2_connectivity()
+        results["r2_test"] = r2_test
+        if verbose:
+            print(f"  Connectivity: {'[x]' if r2_test['ok'] else '[ ]'} {r2_test['detail']}")
+    print()
+
+    # 3. Modal
+    modal_env = check_modal_env_vars()
+    modal_configured = sum(1 for t in modal_env if t["ok"])
+    results["modal_tools"] = modal_env
+    if verbose:
+        print(f"Modal ({modal_configured}/7 tools):")
+        for t in modal_env:
+            print(f"  {'[x]' if t['ok'] else '[ ]'} {t['name']}: {t['detail']}")
+
+    if shutil.which("modal"):
+        modal_apps = check_modal_apps()
+        results["modal_apps"] = modal_apps
+        if verbose:
+            print(f"  Deployed apps: {modal_apps['detail']}")
+    print()
+
+    # 4. RunPod
+    runpod_env = check_runpod_env_vars()
+    results["runpod_tools"] = runpod_env
+    if verbose:
+        runpod_configured = sum(1 for t in runpod_env if t["ok"])
+        print(f"RunPod ({runpod_configured}/{len(runpod_env)} configured):")
+        for t in runpod_env:
+            print(f"  {'[x]' if t['ok'] else '[ ]'} {t['name']}: {t['detail']}")
+        print()
+
+    # 5. Voice
+    voice = check_voice()
+    results["voice"] = voice
+    if verbose:
+        print("Voice:")
+        print(f"  {'[x]' if voice['qwen3_tts']['ok'] else '[ ]'} Qwen3-TTS: {voice['qwen3_tts']['detail']}")
+        print(f"  {'[x]' if voice['elevenlabs']['ok'] else '[ ]'} ElevenLabs: {voice['elevenlabs']['detail']}")
+        print()
+
+    # 6. Smoke tests (optional)
+    if args.test:
+        if verbose:
+            print("Smoke tests:")
+
+        # Pick best available provider
+        provider = "modal" if modal_configured > 0 else "runpod"
+
+        # Test TTS if available
+        qwen3_ok = voice["qwen3_tts"]["ok"]
+        if qwen3_ok:
+            tts_test = test_cloud_endpoint("qwen3_tts", provider)
+            results["test_qwen3_tts"] = tts_test
+            if verbose:
+                print(f"  {'[x]' if tts_test['ok'] else '[ ]'} Qwen3-TTS ({provider}): {tts_test['detail']}")
+
+        # Test FLUX.2 if available
+        flux2_ok = any(t["ok"] for t in modal_env if "FLUX2" in t.get("env_var", ""))
+        if not flux2_ok:
+            flux2_ok = any(t["ok"] for t in runpod_env if "FLUX2" in t.get("env_var", ""))
+        if flux2_ok:
+            flux2_test = test_cloud_endpoint("flux2", provider)
+            results["test_flux2"] = flux2_test
+            if verbose:
+                print(f"  {'[x]' if flux2_test['ok'] else '[ ]'} FLUX.2 ({provider}): {flux2_test['detail']}")
+
+        if verbose:
+            print()
+
+    # Summary
+    all_ok = all(p["ok"] for p in prereqs if p["required"])
+    cloud_ok = modal_configured > 0 or sum(1 for t in runpod_env if t["ok"]) > 1
+    r2_ok = r2["ok"]
+    voice_ok = voice["qwen3_tts"]["ok"] or voice["elevenlabs"]["ok"]
+
+    results["summary"] = {
+        "prerequisites": all_ok,
+        "cloud_gpu": cloud_ok,
+        "file_transfer": r2_ok,
+        "voice": voice_ok,
+        "ready": all_ok,  # Only prereqs are truly required
+    }
+
+    if args.json:
+        print(json.dumps(results, indent=2))
+    else:
+        print("=" * 40)
+        print(f"  Prerequisites:  {'ready' if all_ok else 'ISSUES'}")
+        print(f"  Cloud GPU:      {'ready' if cloud_ok else 'not configured'}")
+        print(f"  File transfer:  {'ready' if r2_ok else 'not configured (using fallback)'}")
+        print(f"  Voice:          {'ready' if voice_ok else 'not configured'}")
+        print()
+        if all_ok and cloud_ok and r2_ok and voice_ok:
+            print("  All systems go! Run /video to create a video.")
+        elif all_ok:
+            print("  Basics ready. Run /setup to configure cloud features.")
+        else:
+            print("  Some prerequisites missing. Check above for details.")
+        print("=" * 40)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/voiceover.py
+++ b/tools/voiceover.py
@@ -199,6 +199,15 @@ Examples:
         help="Qwen3-TTS nucleus sampling (default: model default ~0.8, range: 0.1-1.0)",
     )
 
+    # Cloud GPU provider (for Qwen3-TTS)
+    parser.add_argument(
+        "--cloud",
+        type=str,
+        default="runpod",
+        choices=["runpod", "modal"],
+        help="Cloud GPU provider for Qwen3-TTS (default: runpod)",
+    )
+
     # Brand integration
     parser.add_argument(
         "--brand",
@@ -311,6 +320,7 @@ def generate_single_audio_qwen3(
     ref_text: str | None = None,
     temperature: float | None = None,
     top_p: float | None = None,
+    cloud: str = "runpod",
 ) -> dict:
     """Generate a single audio file from script text using Qwen3-TTS. Returns result dict."""
     from qwen3_tts import generate_audio
@@ -328,6 +338,7 @@ def generate_single_audio_qwen3(
         verbose=False,
         temperature=temperature,
         top_p=top_p,
+        cloud=cloud,
     )
 
 
@@ -353,6 +364,7 @@ def process_scene_directory(
     ref_text: str | None = None,
     temperature: float | None = None,
     top_p: float | None = None,
+    cloud: str = "runpod",
 ) -> list[dict]:
     """Process all .txt files in directory, generate .mp3 for each."""
     txt_files = sorted(scene_dir.glob("*.txt"))
@@ -419,6 +431,7 @@ def process_scene_directory(
                     ref_text=ref_text,
                     temperature=temperature,
                     top_p=top_p,
+                    cloud=cloud,
                 )
             else:
                 result = generate_single_audio(
@@ -631,6 +644,7 @@ def main():
                 ref_text=args.ref_text,
                 temperature=args.temperature,
                 top_p=args.top_p,
+                cloud=args.cloud,
             )
             result = {
                 "dry_run": True,
@@ -684,6 +698,7 @@ def main():
             ref_text=args.ref_text,
             temperature=args.temperature,
             top_p=args.top_p,
+            cloud=args.cloud,
         )
 
         # Build final result
@@ -785,6 +800,7 @@ def main():
             ref_text=args.ref_text,
             temperature=args.temperature,
             top_p=args.top_p,
+            cloud=args.cloud,
         )
     else:
         result = generate_single_audio(


### PR DESCRIPTION
## Summary

Major overhaul of the cloud GPU infrastructure to add [Modal](https://modal.com/) as the recommended provider alongside RunPod.

- **Shared cloud GPU abstraction** (`tools/cloud_gpu.py`) — all 7 cloud tools now use a unified interface with `--cloud modal|runpod` flag
- **7 Modal apps** deployed from `docker/modal-*/app.py` — Modal builds and hosts containers, no GHCR needed
- **`/setup` wizard** — interactive first-time setup for cloud GPU, file transfer (R2), and voice config
- **Refactored all cloud tools** (image_edit, upscale, dewatermark, sadtalker, qwen3_tts, flux2, music_gen) to use the shared abstraction
- **OpenClaw skill** — autonomous video creation skill (alpha)
- **Transition fixes** — removed invalid `@remotion/transitions` re-exports from barrel
- **OffthreadVideo guidance** — added CLAUDE.md note to never use raw `<video>` in Remotion
- **README restructured** — quick start first, Modal recommended, cost estimates per tool

## Why Modal?

After repeated RunPod outages and slow cold starts, Modal was added as a reliability alternative. Modal offers:
- $30/month free compute on Starter plan (enough for a few 5-minute videos/month)
- Faster cold starts
- Simpler deployment (`modal deploy` vs Docker build + push + endpoint creation)
- No need to manage Docker images on GHCR

## Migration for existing users

**RunPod setups continue to work unchanged.** All tools still accept `--cloud runpod`. The change is:
- Modal is now the **recommended** provider in docs and README
- New users running `/setup` will be guided toward Modal first
- `--cloud modal` is the new default when Modal is configured

To add Modal alongside an existing RunPod setup:
```bash
pip install modal
python3 -m modal setup
/setup   # in Claude Code — deploys Modal apps interactively
```

## Test plan

- [x] All 7 Modal apps deployed and tested (image_edit, upscale, sadtalker, qwen3_tts, flux2, music_gen, propainter)
- [x] RunPod fallback still works for all tools
- [x] `/setup` wizard walks through full configuration
- [x] Existing `.env` files with RunPod config are not affected
- [ ] Fresh clone + `/setup` from scratch (recommend testing before tagging release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)