### PR TITLE
Add LTX-2.3 video generation (v0.13.1)

### DIFF
--- a/.claude/skills/ltx2/SKILL.md
+++ b/.claude/skills/ltx2/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: ltx2
+description: AI video generation with LTX-2.3 22B — text-to-video, image-to-video clips for video production. Use when generating video clips, animating images, creating b-roll, animated backgrounds, or motion content. Triggers include video generation, animate image, b-roll, motion, video clip, text-to-video, image-to-video.
+---
+
+# LTX-2.3 Video Generation
+
+Generate ~5 second video clips from text prompts or images using the LTX-2.3 22B DiT model.
+Runs on Modal (A100-80GB). Requires `MODAL_LTX2_ENDPOINT_URL` in `.env`.
+
+## Quick Reference
+
+```bash
+# Text-to-video
+python3 tools/ltx2.py --prompt "A sunset over the ocean, golden light on waves, cinematic" --output sunset.mp4
+
+# Image-to-video (animate a still image)
+python3 tools/ltx2.py --prompt "Gentle camera drift, soft ambient motion" --input photo.jpg --output animated.mp4
+
+# Custom resolution and duration
+python3 tools/ltx2.py --prompt "..." --width 1024 --height 576 --num-frames 161 --output wide.mp4
+
+# Fast mode (fewer steps, quicker)
+python3 tools/ltx2.py --prompt "..." --quality fast --output quick.mp4
+
+# Reproducible output
+python3 tools/ltx2.py --prompt "..." --seed 42 --output reproducible.mp4
+```
+
+## Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `--prompt` | (required) | Text description of the video |
+| `--input` | - | Input image for image-to-video |
+| `--width` | 768 | Video width (divisible by 64) |
+| `--height` | 512 | Video height (divisible by 64) |
+| `--num-frames` | 121 | Frame count, must satisfy `(n-1) % 8 == 0` |
+| `--fps` | 24 | Frames per second |
+| `--quality` | standard | `standard` (30 steps) or `fast` (15 steps) |
+| `--steps` | 30 | Override inference steps directly |
+| `--seed` | random | Seed for reproducibility |
+| `--output` | auto | Output file path |
+| `--negative-prompt` | sensible default | What to avoid |
+
+## Valid Frame Counts
+
+`(n - 1) % 8 == 0`: 25 (~1s), 49 (~2s), 73 (~3s), 97 (~4s), **121 (~5s default)**, 161 (~6.7s), 193 (~8s max practical).
+
+## Common Resolutions
+
+| Resolution | Ratio | Notes |
+|------------|-------|-------|
+| 768x512 | 3:2 | Default, good balance |
+| 512x512 | 1:1 | Square, fastest |
+| 1024x576 | 16:9 | Widescreen |
+| 576x1024 | 9:16 | Portrait/vertical |
+
+## Prompting Guide
+
+LTX-2 responds well to cinematographic descriptions. Layer these dimensions:
+
+- **Camera:** "Slow dolly forward", "Aerial drone shot", "Tracking shot", "Static wide angle"
+- **Lighting:** "Golden hour", "Cinematic lighting", "Neon-lit", "Soft diffused light"
+- **Motion:** "Timelapse of...", "Slow motion", "Gentle camera drift", "Gradually transitions"
+- **Style:** "Shot on 35mm film", "Documentary style", "Clean minimal aesthetic"
+- **Negative:** Always implicitly avoids "worst quality, blurry, jittery, watermark, text, logo"
+
+Keep prompts under 200 words. Be specific about the scene.
+
+### Good Prompts
+
+```
+# Atmospheric b-roll
+"Aerial drone shot slowly flying over turquoise ocean waves breaking on white sand, golden hour sunlight, cinematic"
+
+# Product/tech scene
+"Close-up of hands typing on a mechanical keyboard, shallow depth of field, soft desk lamp lighting, cozy atmosphere"
+
+# Abstract background
+"Dark moody abstract background with flowing blue light streaks, subtle geometric grid, bokeh particles floating, cinematic tech atmosphere"
+
+# Animate a portrait
+"Professional headshot, subtle natural head movement, confident warm expression, studio lighting, shallow depth of field"
+
+# Animate a slide/screenshot
+"Gentle subtle particle effects floating across a presentation slide, soft ambient light shifts, very slight camera drift"
+```
+
+### Bad Prompts
+
+```
+# Too vague
+"A cool video"
+
+# Too many competing ideas
+"A cat riding a skateboard while juggling fire on the moon during a thunderstorm"
+
+# Describing text/UI (model can't render text reliably)
+"A website showing the text 'Welcome to our platform'"
+```
+
+## Video Production Use Cases
+
+### B-Roll Clips
+Generate atmospheric 5s shots for cutaways between narrated scenes:
+```bash
+python3 tools/ltx2.py --prompt "Futuristic holographic interface, glowing data visualizations, clean workspace, cinematic" --output broll_tech.mp4
+python3 tools/ltx2.py --prompt "Aerial view of European city at golden hour, modern architecture" --output broll_europe.mp4
+```
+
+### Animated Slide Backgrounds
+Feed a slide screenshot and add subtle motion:
+```bash
+python3 tools/ltx2.py --prompt "Gentle particle effects, soft ambient light shifts, very slight camera drift" --input slide.png --output animated_slide.mp4
+```
+
+### Animated Portraits
+Bring still headshots to life:
+```bash
+python3 tools/ltx2.py --prompt "Subtle natural head movement, warm expression, professional lighting" --input headshot.png --output animated_portrait.mp4
+```
+
+### Branded Intro/Outro
+Generate abstract motion backgrounds for title cards:
+```bash
+python3 tools/ltx2.py --prompt "Dark moody background with flowing blue and coral light streaks, bokeh particles, cinematic tech atmosphere, no text" --output intro_bg.mp4
+```
+
+### Combining with Other Tools
+
+LTX-2 generates raw clips. Combine with the rest of the toolkit:
+
+| Workflow | Tools |
+|----------|-------|
+| Generate clip → upscale | `ltx2.py` → `upscale.py` |
+| Generate clip → add to Remotion | `ltx2.py` → use as `<OffthreadVideo>` in composition |
+| Generate image → animate | `flux2.py` → `ltx2.py --input` |
+| Generate clip → extract audio | `ltx2.py` → `ffmpeg -i clip.mp4 -vn audio.wav` |
+| Generate clip → add voiceover | `ltx2.py` → mix with `qwen3_tts.py` output |
+
+## Technical Details
+
+- **Model:** LTX-2.3 22B DiT (Lightricks), bf16
+- **GPU:** A100-80GB on Modal (~$4.68/hr)
+- **Inference:** ~2.5 min per clip (768x512, 121 frames, 30 steps)
+- **Cost:** ~$0.20-0.25 per 5s clip
+- **Cold start:** ~60-90s (loading ~55GB weights)
+- **Output:** H.264 MP4 with synchronized ambient audio (24fps)
+- **Max duration:** ~8s (193 frames) per clip
+
+### Known Limitations
+
+- **Training data artifacts:** ~30% of generations may have unwanted logos/text from training data. Re-run with different `--seed`.
+- **Text rendering:** Cannot reliably generate readable text in video. Use Remotion overlays instead.
+- **Max duration:** ~8s per clip. Longer content needs stitching.
+- **Audio:** Generated audio is ambient/environmental only. Use voiceover/music tools for speech and music.
+- **License:** Community License — free under $10M revenue, commercial license needed above that.
+
+## Setup
+
+```bash
+# 1. Create Modal secret for HuggingFace (one-time)
+modal secret create huggingface-token HF_TOKEN=hf_your_token
+
+# 2. Deploy (downloads ~55GB of weights, takes ~10 min)
+modal deploy docker/modal-ltx2/app.py
+
+# 3. Save endpoint URL to .env
+echo "MODAL_LTX2_ENDPOINT_URL=https://yourname--video-toolkit-ltx2-ltx2-generate.modal.run" >> .env
+
+# 4. Test
+python3 tools/ltx2.py --prompt "A candle flickering on a dark table, cinematic" --output test.mp4
+```
+
+**Important:** HuggingFace token needs read-access scope. Accept the [Gemma 3 license](https://huggingface.co/google/gemma-3-12b-it-qat-q4_0-unquantized) before deploying. Unauthenticated downloads are severely rate-limited.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Claude Code has deep knowledge in:
 | **frontend-design** | Visual design refinement for distinctive, production-grade aesthetics |
 | **qwen-edit** | AI image editing — prompting patterns and best practices |
 | **acestep** | AI music generation — prompts, lyrics, scene presets, video integration |
+| **ltx2** | AI video generation — text-to-video, image-to-video clips, prompting guide |
 | **runpod** | Cloud GPU — setup, Docker images, endpoint management, costs |
 
 ### Commands
@@ -211,6 +212,10 @@ python tools/sadtalker.py --image portrait.png --audio voiceover.mp3 --output ta
 python tools/flux2.py --prompt "A sunset over mountains" --cloud modal
 python tools/flux2.py --preset title-bg --brand digital-samba --cloud modal
 python tools/flux2.py --list-presets
+
+# AI video generation (LTX-2.3 22B — text-to-video + image-to-video)
+python tools/ltx2.py --prompt "A sunset over the ocean, cinematic" --cloud modal
+python tools/ltx2.py --prompt "Gentle camera drift" --input photo.jpg --cloud modal
 ```
 
 **Tool Categories:**
@@ -219,11 +224,11 @@ python tools/flux2.py --list-presets
 |------|-------|---------|
 | **Project** | voiceover, music, music_gen, sfx | Used during video creation workflow |
 | **Utility** | redub, addmusic, notebooklm_brand, locate_watermark | Quick transformations, no project needed |
-| **Cloud GPU** | image_edit, upscale, dewatermark, sadtalker, qwen3_tts, flux2, music_gen | AI processing via Modal or RunPod |
+| **Cloud GPU** | image_edit, upscale, dewatermark, sadtalker, qwen3_tts, flux2, music_gen, ltx2 | AI processing via Modal or RunPod |
 
 ### Cloud GPU (Modal + RunPod)
 
-7 AI tools run on cloud GPUs. Use `--cloud modal` (recommended) or `--cloud runpod` on any tool.
+8 AI tools run on cloud GPUs. Use `--cloud modal` (recommended) or `--cloud runpod` on any tool.
 
 | Tool | What It Does | Est. Cost |
 |------|--------------|-----------|
@@ -233,6 +238,7 @@ python tools/flux2.py --list-presets
 | `upscale` | AI image upscaling (2x/4x) | ~$0.01 |
 | `music_gen` | AI music generation (8 scene presets) | ~$0.05 |
 | `sadtalker` | Talking head video from portrait + audio | ~$0.10 |
+| `ltx2` | AI video generation (text-to-video, image-to-video) | ~$0.23 |
 | `dewatermark` | Video watermark removal | ~$0.10 |
 
 **Modal (recommended):** Each tool deploys from `docker/modal-*/app.py` — Modal builds and hosts the containers. $30/month free compute on the Starter plan, typical usage is $1-2/month. Run `/setup` to deploy all tools automatically.

--- a/_internal/CHANGELOG.md
+++ b/_internal/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to claude-code-video-toolkit.
 
 ---
 
+## 2026-03-25 (v0.13.1)
+
+### Added
+- **`tools/ltx2.py`** — AI video generation using LTX-2.3 22B DiT model
+  - Text-to-video generation from prompts (~5s clips at up to 1024x1536)
+  - Image-to-video — animate still images with motion prompts
+  - Joint audio+video generation (synchronized ambient audio)
+  - Quality presets: `standard` (30 steps) and `fast` (15 steps)
+  - Valid frame counts: 25-193 frames ((n-1)%8==0), 24fps default
+  - Modal deployment on A100-80GB with baked weights (~55GB)
+  - Estimated cost: ~$0.23 per 5-second clip
+- **LTX-2 skill** (`.claude/skills/ltx2/`) — prompting guide, parameters, video production use cases
+- **Openclaw skill updated** — LTX-2 added as section 4d (video clips), setup instructions, cost table
+
+### Technical Notes
+- `torch.inference_mode()` required around pipeline call — without it, Gemma text encoder retains ~37GB of autograd activations causing OOM (upstream bug: Lightricks/LTX-2#152)
+- Weights hosted on `Lightricks/LTX-2.3` HuggingFace repo (separate from the code repo `Lightricks/LTX-2`)
+- `transformers` pinned to 4.57.6 (5.x breaks `Gemma3TextConfig.rope_local_base_freq`)
+- HuggingFace token required for both LTX-2 (rate limiting) and Gemma 3 (gated model)
+
+---
+
 ## 2026-03-22 (v0.12.0)
 
 ### Added

--- a/_internal/toolkit-registry.json
+++ b/_internal/toolkit-registry.json
@@ -1,9 +1,8 @@
 {
   "name": "claude-code-video-toolkit",
-  "version": "0.12.0",
+  "version": "0.13.1",
   "description": "AI-native video production workspace for Claude Code",
   "repository": "https://github.com/digitalsamba/claude-code-video-toolkit",
-
   "skills": {
     "remotion-official": {
       "path": ".claude/skills/remotion-official/",
@@ -79,7 +78,6 @@
       "updated": "2026-03-25"
     }
   },
-
   "commands": {
     "video": {
       "path": ".claude/commands/video.md",
@@ -173,7 +171,6 @@
       "updated": "2026-03-23"
     }
   },
-
   "tools": {
     "voiceover": {
       "path": "tools/voiceover.py",
@@ -210,8 +207,20 @@
         "format": "Audio format: mp3, wav, flac",
         "steps": "Inference steps (default: 8 for turbo)"
       },
-      "presets": ["corporate-bg", "upbeat-tech", "ambient", "dramatic", "tension", "hopeful", "cta", "lofi"],
-      "envVars": ["RUNPOD_API_KEY", "RUNPOD_ACESTEP_ENDPOINT_ID"],
+      "presets": [
+        "corporate-bg",
+        "upbeat-tech",
+        "ambient",
+        "dramatic",
+        "tension",
+        "hopeful",
+        "cta",
+        "lofi"
+      ],
+      "envVars": [
+        "RUNPOD_API_KEY",
+        "RUNPOD_ACESTEP_ENDPOINT_ID"
+      ],
       "created": "2026-03-22",
       "updated": "2026-03-22"
     },
@@ -246,7 +255,14 @@
       "status": "beta",
       "optional": true,
       "requires": "RunPod account OR local NVIDIA GPU + ProPainter (~2GB)",
-      "presets": ["notebooklm", "tiktok", "sora", "stock-br", "stock-bl", "stock-center"],
+      "presets": [
+        "notebooklm",
+        "tiktok",
+        "sora",
+        "stock-br",
+        "stock-bl",
+        "stock-center"
+      ],
       "created": "2025-12-29",
       "updated": "2025-12-30"
     },
@@ -256,7 +272,14 @@
       "usage": "python tools/locate_watermark.py --input video.mp4 --grid --output-dir ./review/",
       "status": "beta",
       "requires": "ImageMagick (brew install imagemagick)",
-      "presets": ["notebooklm", "tiktok", "sora", "stock-br", "stock-bl", "stock-center"],
+      "presets": [
+        "notebooklm",
+        "tiktok",
+        "sora",
+        "stock-br",
+        "stock-bl",
+        "stock-center"
+      ],
       "created": "2025-12-29",
       "updated": "2025-12-30"
     },
@@ -285,11 +308,42 @@
       "backend": "qwen-image-edit-2511",
       "requires": "RunPod account",
       "presets": {
-        "background": ["office", "studio", "outdoors", "pyramids", "beach", "city", "mountains", "space", "forest", "cafe"],
-        "style": ["cyberpunk", "anime", "oil-painting", "watercolor", "pixel-art", "noir", "pop-art", "sketch", "vintage", "cinematic"],
-        "viewpoint": ["front", "profile", "three-quarter", "looking-up", "looking-down"]
+        "background": [
+          "office",
+          "studio",
+          "outdoors",
+          "pyramids",
+          "beach",
+          "city",
+          "mountains",
+          "space",
+          "forest",
+          "cafe"
+        ],
+        "style": [
+          "cyberpunk",
+          "anime",
+          "oil-painting",
+          "watercolor",
+          "pixel-art",
+          "noir",
+          "pop-art",
+          "sketch",
+          "vintage",
+          "cinematic"
+        ],
+        "viewpoint": [
+          "front",
+          "profile",
+          "three-quarter",
+          "looking-up",
+          "looking-down"
+        ]
       },
-      "envVars": ["RUNPOD_API_KEY", "RUNPOD_QWEN_EDIT_ENDPOINT_ID"],
+      "envVars": [
+        "RUNPOD_API_KEY",
+        "RUNPOD_QWEN_EDIT_ENDPOINT_ID"
+      ],
       "estimatedCost": "$0.01-0.02 per image",
       "created": "2026-01-01",
       "updated": "2026-01-05"
@@ -303,12 +357,26 @@
       "backend": "realesrgan",
       "requires": "RunPod account",
       "options": {
-        "scale": [2, 4],
-        "model": ["general", "anime", "photo"],
+        "scale": [
+          2,
+          4
+        ],
+        "model": [
+          "general",
+          "anime",
+          "photo"
+        ],
         "faceEnhance": true,
-        "format": ["png", "jpg", "webp"]
+        "format": [
+          "png",
+          "jpg",
+          "webp"
+        ]
       },
-      "envVars": ["RUNPOD_API_KEY", "RUNPOD_UPSCALE_ENDPOINT_ID"],
+      "envVars": [
+        "RUNPOD_API_KEY",
+        "RUNPOD_UPSCALE_ENDPOINT_ID"
+      ],
       "estimatedCost": "$0.01-0.05 per image",
       "created": "2026-01-04",
       "updated": "2026-01-05"
@@ -322,13 +390,29 @@
       "backend": "sadtalker",
       "requires": "RunPod account",
       "options": {
-        "presets": ["default", "natural", "expressive", "professional", "fullbody"],
-        "preprocess": ["crop", "resize", "full"],
-        "size": [256, 512],
+        "presets": [
+          "default",
+          "natural",
+          "expressive",
+          "professional",
+          "fullbody"
+        ],
+        "preprocess": [
+          "crop",
+          "resize",
+          "full"
+        ],
+        "size": [
+          256,
+          512
+        ],
         "still": true,
         "expressionScale": "0.5-2.0"
       },
-      "envVars": ["RUNPOD_API_KEY", "RUNPOD_SADTALKER_ENDPOINT_ID"],
+      "envVars": [
+        "RUNPOD_API_KEY",
+        "RUNPOD_SADTALKER_ENDPOINT_ID"
+      ],
       "estimatedCost": "$0.02-0.15 per video (depends on audio length)",
       "documentation": "docs/sadtalker.md",
       "created": "2026-01-11",
@@ -343,12 +427,43 @@
       "backend": "qwen3-tts",
       "requires": "RunPod account",
       "options": {
-        "speakers": ["Ryan", "Aiden", "Vivian", "Serena", "Uncle_Fu", "Dylan", "Eric", "Ono_Anna", "Sohee"],
-        "languages": ["Auto", "English", "Chinese", "French", "German", "Italian", "Japanese", "Korean", "Portuguese", "Russian", "Spanish"],
-        "modes": ["custom_voice", "clone"],
-        "formats": ["mp3", "wav"]
+        "speakers": [
+          "Ryan",
+          "Aiden",
+          "Vivian",
+          "Serena",
+          "Uncle_Fu",
+          "Dylan",
+          "Eric",
+          "Ono_Anna",
+          "Sohee"
+        ],
+        "languages": [
+          "Auto",
+          "English",
+          "Chinese",
+          "French",
+          "German",
+          "Italian",
+          "Japanese",
+          "Korean",
+          "Portuguese",
+          "Russian",
+          "Spanish"
+        ],
+        "modes": [
+          "custom_voice",
+          "clone"
+        ],
+        "formats": [
+          "mp3",
+          "wav"
+        ]
       },
-      "envVars": ["RUNPOD_API_KEY", "RUNPOD_QWEN3_TTS_ENDPOINT_ID"],
+      "envVars": [
+        "RUNPOD_API_KEY",
+        "RUNPOD_QWEN3_TTS_ENDPOINT_ID"
+      ],
       "estimatedCost": "$0.005-0.10 per generation",
       "created": "2026-02-19",
       "updated": "2026-02-19"
@@ -372,17 +487,44 @@
       "backend": "flux2-klein-4b",
       "requires": "RunPod account",
       "options": {
-        "modes": ["generate", "edit"],
-        "presets": ["title-bg", "problem", "solution", "demo-bg", "stats-bg", "cta", "thumbnail", "portrait-bg"],
+        "modes": [
+          "generate",
+          "edit"
+        ],
+        "presets": [
+          "title-bg",
+          "problem",
+          "solution",
+          "demo-bg",
+          "stats-bg",
+          "cta",
+          "thumbnail",
+          "portrait-bg"
+        ],
         "brand": true,
-        "width": [512, 768, 1024, 1280, 1920],
-        "height": [512, 768, 1024, 1080, 1280],
+        "width": [
+          512,
+          768,
+          1024,
+          1280,
+          1920
+        ],
+        "height": [
+          512,
+          768,
+          1024,
+          1080,
+          1280
+        ],
         "steps": "4 (fast) to 50 (quality)",
         "guidance": "1.0 (fast) to 4.0 (quality)",
         "seed": true,
         "multiImage": true
       },
-      "envVars": ["RUNPOD_API_KEY", "RUNPOD_FLUX2_ENDPOINT_ID"],
+      "envVars": [
+        "RUNPOD_API_KEY",
+        "RUNPOD_FLUX2_ENDPOINT_ID"
+      ],
       "estimatedCost": "$0.01-0.03 per image",
       "created": "2026-03-14",
       "updated": "2026-03-15"
@@ -396,22 +538,37 @@
       "backend": "ltx-2.3-22b",
       "requires": "Modal account, HuggingFace token",
       "options": {
-        "modes": ["text-to-video", "image-to-video"],
-        "width": [512, 768, 1024],
-        "height": [512, 576, 1024],
+        "modes": [
+          "text-to-video",
+          "image-to-video"
+        ],
+        "width": [
+          512,
+          768,
+          1024
+        ],
+        "height": [
+          512,
+          576,
+          1024
+        ],
         "numFrames": "25-193 ((n-1)%8==0)",
         "fps": 24,
-        "quality": ["standard", "fast"],
+        "quality": [
+          "standard",
+          "fast"
+        ],
         "steps": "15 (fast) to 30+ (standard)",
         "seed": true
       },
-      "envVars": ["MODAL_LTX2_ENDPOINT_URL"],
+      "envVars": [
+        "MODAL_LTX2_ENDPOINT_URL"
+      ],
       "estimatedCost": "$0.20-0.25 per 5s clip",
       "created": "2026-03-25",
       "updated": "2026-03-25"
     }
   },
-
   "optionalComponents": {
     "propainter": {
       "name": "ProPainter",
@@ -429,61 +586,76 @@
       "documentation": "docs/optional-components.md"
     }
   },
-
   "cloudProviders": {
     "runpod": {
       "name": "RunPod",
       "description": "Serverless GPU cloud for video and image processing",
       "documentation": "docs/runpod-setup.md",
-      "envVars": ["RUNPOD_API_KEY"],
+      "envVars": [
+        "RUNPOD_API_KEY"
+      ],
       "endpoints": {
         "propainter": {
           "image": "ghcr.io/conalmullan/video-toolkit-propainter:latest",
           "dockerfile": "docker/runpod-propainter/",
           "envVar": "RUNPOD_ENDPOINT_ID",
-          "operations": ["dewatermark"],
+          "operations": [
+            "dewatermark"
+          ],
           "estimatedCost": "$0.05-0.30 per video"
         },
         "qwen-edit": {
           "image": "ghcr.io/conalmullan/video-toolkit-qwen-edit:latest",
           "dockerfile": "docker/runpod-qwen-edit/",
           "envVar": "RUNPOD_QWEN_EDIT_ENDPOINT_ID",
-          "operations": ["image_edit"],
+          "operations": [
+            "image_edit"
+          ],
           "estimatedCost": "$0.01-0.02 per image"
         },
         "realesrgan": {
           "image": "ghcr.io/conalmullan/video-toolkit-realesrgan:latest",
           "dockerfile": "docker/runpod-realesrgan/",
           "envVar": "RUNPOD_UPSCALE_ENDPOINT_ID",
-          "operations": ["upscale"],
+          "operations": [
+            "upscale"
+          ],
           "estimatedCost": "$0.01-0.05 per image"
         },
         "sadtalker": {
           "image": "ghcr.io/conalmullan/video-toolkit-sadtalker:latest",
           "dockerfile": "docker/runpod-sadtalker/",
           "envVar": "RUNPOD_SADTALKER_ENDPOINT_ID",
-          "operations": ["sadtalker"],
+          "operations": [
+            "sadtalker"
+          ],
           "estimatedCost": "$0.02-0.15 per video"
         },
         "qwen3-tts": {
           "image": "ghcr.io/conalmullan/video-toolkit-qwen3-tts:latest",
           "dockerfile": "docker/runpod-qwen3-tts/",
           "envVar": "RUNPOD_QWEN3_TTS_ENDPOINT_ID",
-          "operations": ["qwen3_tts"],
+          "operations": [
+            "qwen3_tts"
+          ],
           "estimatedCost": "$0.005-0.10 per generation"
         },
         "flux2": {
           "image": "ghcr.io/conalmullan/video-toolkit-flux2:latest",
           "dockerfile": "docker/runpod-flux2/",
           "envVar": "RUNPOD_FLUX2_ENDPOINT_ID",
-          "operations": ["flux2"],
+          "operations": [
+            "flux2"
+          ],
           "estimatedCost": "$0.01-0.03 per image"
         },
         "acestep": {
           "image": "ghcr.io/conalmullan/video-toolkit-acestep:latest",
           "dockerfile": "docker/runpod-acestep/",
           "envVar": "RUNPOD_ACESTEP_ENDPOINT_ID",
-          "operations": ["music_gen"],
+          "operations": [
+            "music_gen"
+          ],
           "estimatedCost": "$0.01-0.05 per track"
         }
       },
@@ -494,61 +666,81 @@
       "name": "Modal",
       "description": "Serverless GPU cloud with Python-native deployment and fast cold starts",
       "documentation": "docs/modal-setup.md",
-      "envVars": ["MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET"],
+      "envVars": [
+        "MODAL_TOKEN_ID",
+        "MODAL_TOKEN_SECRET"
+      ],
       "endpoints": {
         "qwen3-tts": {
           "appFile": "docker/modal-qwen3-tts/app.py",
           "envVar": "MODAL_QWEN3_TTS_ENDPOINT_URL",
-          "operations": ["qwen3_tts"],
+          "operations": [
+            "qwen3_tts"
+          ],
           "gpu": "A10G",
           "estimatedCost": "$0.005-0.10 per generation"
         },
         "flux2": {
           "appFile": "docker/modal-flux2/app.py",
           "envVar": "MODAL_FLUX2_ENDPOINT_URL",
-          "operations": ["flux2"],
+          "operations": [
+            "flux2"
+          ],
           "gpu": "A10G",
           "estimatedCost": "$0.01-0.03 per image"
         },
         "upscale": {
           "appFile": "docker/modal-upscale/app.py",
           "envVar": "MODAL_UPSCALE_ENDPOINT_URL",
-          "operations": ["upscale"],
+          "operations": [
+            "upscale"
+          ],
           "gpu": "A10G",
           "estimatedCost": "$0.005-0.02 per image"
         },
         "image-edit": {
           "appFile": "docker/modal-image-edit/app.py",
           "envVar": "MODAL_IMAGE_EDIT_ENDPOINT_URL",
-          "operations": ["image_edit"],
+          "operations": [
+            "image_edit"
+          ],
           "gpu": "A100",
           "estimatedCost": "$0.02-0.05 per image"
         },
         "music-gen": {
           "appFile": "docker/modal-music-gen/app.py",
           "envVar": "MODAL_MUSIC_GEN_ENDPOINT_URL",
-          "operations": ["music_gen"],
+          "operations": [
+            "music_gen"
+          ],
           "gpu": "A10G",
           "estimatedCost": "$0.02-0.10 per generation"
         },
         "sadtalker": {
           "appFile": "docker/modal-sadtalker/app.py",
           "envVar": "MODAL_SADTALKER_ENDPOINT_URL",
-          "operations": ["sadtalker"],
+          "operations": [
+            "sadtalker"
+          ],
           "gpu": "A10G",
           "estimatedCost": "$0.05-0.30 per video"
         },
         "dewatermark": {
           "appFile": "docker/modal-propainter/app.py",
           "envVar": "MODAL_DEWATERMARK_ENDPOINT_URL",
-          "operations": ["dewatermark"],
+          "operations": [
+            "dewatermark"
+          ],
           "gpu": "A10G",
           "estimatedCost": "$0.05-0.50 per video"
         },
         "ltx2": {
           "appFile": "docker/modal-ltx2/app.py",
           "envVar": "MODAL_LTX2_ENDPOINT_URL",
-          "operations": ["text-to-video", "image-to-video"],
+          "operations": [
+            "text-to-video",
+            "image-to-video"
+          ],
           "gpu": "A100-80GB",
           "estimatedCost": "$0.20-0.25 per 5s clip"
         }
@@ -557,7 +749,6 @@
       "updated": "2026-03-25"
     }
   },
-
   "templates": {
     "sprint-review": {
       "path": "templates/sprint-review/",
@@ -581,60 +772,96 @@
       "updated": "2025-12-10"
     }
   },
-
   "transitions": {
     "glitch": {
       "path": "lib/transitions/presentations/glitch.tsx",
       "description": "Digital distortion with RGB shift and scan lines",
-      "options": ["intensity", "slices", "rgbShift"],
+      "options": [
+        "intensity",
+        "slices",
+        "rgbShift"
+      ],
       "bestFor": "Tech demos, edgy reveals, cyberpunk aesthetic",
       "status": "stable"
     },
     "rgbSplit": {
       "path": "lib/transitions/presentations/rgb-split.tsx",
       "description": "Chromatic aberration / color separation effect",
-      "options": ["direction", "displacement"],
+      "options": [
+        "direction",
+        "displacement"
+      ],
       "bestFor": "Modern tech, energetic transitions",
       "status": "stable"
     },
     "zoomBlur": {
       "path": "lib/transitions/presentations/zoom-blur.tsx",
       "description": "Radial motion blur with scale",
-      "options": ["direction", "blurAmount"],
+      "options": [
+        "direction",
+        "blurAmount"
+      ],
       "bestFor": "CTAs, high-energy moments, impact",
       "status": "stable"
     },
     "lightLeak": {
       "path": "lib/transitions/presentations/light-leak.tsx",
       "description": "Cinematic lens flare and overexposure",
-      "options": ["temperature", "direction"],
+      "options": [
+        "temperature",
+        "direction"
+      ],
       "bestFor": "Celebrations, film aesthetic, warm moments",
       "status": "stable"
     },
     "clockWipe": {
       "path": "lib/transitions/presentations/clock-wipe.tsx",
       "description": "Radial sweep reveal like clock hands",
-      "options": ["startAngle", "direction", "segments"],
+      "options": [
+        "startAngle",
+        "direction",
+        "segments"
+      ],
       "bestFor": "Time-related content, playful reveals",
       "status": "stable"
     },
     "pixelate": {
       "path": "lib/transitions/presentations/pixelate.tsx",
       "description": "Digital mosaic dissolution with glitch artifacts",
-      "options": ["maxBlockSize", "gridSize", "scanlines", "glitchArtifacts", "randomness"],
+      "options": [
+        "maxBlockSize",
+        "gridSize",
+        "scanlines",
+        "glitchArtifacts",
+        "randomness"
+      ],
       "bestFor": "Retro/gaming themes, digital transformations",
       "status": "stable"
     },
     "checkerboard": {
       "path": "lib/transitions/presentations/checkerboard.tsx",
       "description": "Grid-based reveal with multiple patterns",
-      "options": ["gridSize", "pattern", "stagger", "squareAnimation"],
-      "patterns": ["sequential", "random", "diagonal", "alternating", "spiral", "rows", "columns", "center-out", "corners-in"],
+      "options": [
+        "gridSize",
+        "pattern",
+        "stagger",
+        "squareAnimation"
+      ],
+      "patterns": [
+        "sequential",
+        "random",
+        "diagonal",
+        "alternating",
+        "spiral",
+        "rows",
+        "columns",
+        "center-out",
+        "corners-in"
+      ],
       "bestFor": "Playful reveals, structured transitions",
       "status": "stable"
     }
   },
-
   "components": {
     "AnimatedBackground": {
       "path": "lib/components/AnimatedBackground.tsx",
@@ -704,7 +931,6 @@
       "updated": "2026-02-19"
     }
   },
-
   "brands": {
     "default": {
       "path": "brands/default/",
@@ -719,7 +945,6 @@
       "updated": "2025-12-09"
     }
   },
-
   "examples": {
     "hello-world": {
       "path": "examples/hello-world/",
@@ -751,7 +976,6 @@
       "created": "2026-03-15"
     }
   },
-
   "config": {
     "voiceId": "YOUR_VOICE_ID_HERE",
     "defaultFps": 30,

--- a/_internal/toolkit-registry.json
+++ b/_internal/toolkit-registry.json
@@ -70,6 +70,13 @@
       "status": "beta",
       "created": "2026-03-22",
       "updated": "2026-03-22"
+    },
+    "ltx2": {
+      "path": ".claude/skills/ltx2/",
+      "description": "AI video generation — prompting guide, parameters, video production use cases (b-roll, animated slides, portraits)",
+      "status": "beta",
+      "created": "2026-03-25",
+      "updated": "2026-03-25"
     }
   },
 
@@ -379,6 +386,29 @@
       "estimatedCost": "$0.01-0.03 per image",
       "created": "2026-03-14",
       "updated": "2026-03-15"
+    },
+    "ltx2": {
+      "path": "tools/ltx2.py",
+      "description": "AI video generation using LTX-2.3 22B - text-to-video, image-to-video clips with synchronized audio",
+      "usage": "python tools/ltx2.py --prompt \"A sunset over the ocean\" --output sunset.mp4",
+      "status": "beta",
+      "category": "video-generation",
+      "backend": "ltx-2.3-22b",
+      "requires": "Modal account, HuggingFace token",
+      "options": {
+        "modes": ["text-to-video", "image-to-video"],
+        "width": [512, 768, 1024],
+        "height": [512, 576, 1024],
+        "numFrames": "25-193 ((n-1)%8==0)",
+        "fps": 24,
+        "quality": ["standard", "fast"],
+        "steps": "15 (fast) to 30+ (standard)",
+        "seed": true
+      },
+      "envVars": ["MODAL_LTX2_ENDPOINT_URL"],
+      "estimatedCost": "$0.20-0.25 per 5s clip",
+      "created": "2026-03-25",
+      "updated": "2026-03-25"
     }
   },
 
@@ -514,10 +544,17 @@
           "operations": ["dewatermark"],
           "gpu": "A10G",
           "estimatedCost": "$0.05-0.50 per video"
+        },
+        "ltx2": {
+          "appFile": "docker/modal-ltx2/app.py",
+          "envVar": "MODAL_LTX2_ENDPOINT_URL",
+          "operations": ["text-to-video", "image-to-video"],
+          "gpu": "A100-80GB",
+          "estimatedCost": "$0.20-0.25 per 5s clip"
         }
       },
       "created": "2026-03-23",
-      "updated": "2026-03-23"
+      "updated": "2026-03-25"
     }
   },
 

--- a/docker/modal-ltx2/app.py
+++ b/docker/modal-ltx2/app.py
@@ -1,0 +1,410 @@
+"""
+Modal deployment for LTX-2.3 video generation.
+
+Text-to-video and image-to-video generation using LTX-2.3 22B DiT model.
+Generates ~5s video clips at up to 1024x1536 resolution with audio.
+
+Deploy:
+    modal deploy docker/modal-ltx2/app.py
+
+Input format (POST JSON to web endpoint):
+{
+    "prompt": str,                     # Required: text description
+    "negative_prompt": str,            # Optional (sensible default provided)
+    "image_url": str,                  # Optional: URL for image-to-video
+    "image_base64": str,              # Optional: base64 for image-to-video
+    "width": int,                      # Default: 768 (must be divisible by 64)
+    "height": int,                     # Default: 512 (must be divisible by 64)
+    "num_frames": int,                 # Default: 121 (must satisfy (n-1)%8==0)
+    "fps": int,                        # Default: 24
+    "num_inference_steps": int,        # Default: 30
+    "seed": int,                       # Optional: random if not set
+    "quality": "standard" | "fast",    # Default: "standard"
+    "r2": dict                         # Optional: R2 upload config
+}
+
+Output format:
+{
+    "success": true,
+    "seed": int,
+    "duration": float,
+    "width": int,
+    "height": int,
+    "num_frames": int,
+    "fps": int,
+    "inference_time_ms": int,
+    "video_base64": str,               # If no R2
+    "output_url": str,                 # If R2 configured
+    "r2_key": str                      # If R2 configured
+}
+"""
+
+import modal
+
+app = modal.App("video-toolkit-ltx2")
+
+# HuggingFace model repos (2.3 weights are split across repos)
+HF_REPO = "Lightricks/LTX-2.3"
+HF_REPO_FP8 = "Lightricks/LTX-2.3-fp8"
+# Local path inside the container where weights are stored
+MODEL_DIR = "/models/ltx2"
+# Gemma 3 text encoder (quantized variant — smaller, faster)
+GEMMA_REPO = "google/gemma-3-12b-it-qat-q4_0-unquantized"
+GEMMA_DIR = "/models/gemma3"
+
+# Build the container image with all dependencies + baked weights
+image = (
+    modal.Image.debian_slim(python_version="3.12")
+    .apt_install("git", "ffmpeg")
+    # PyTorch with CUDA 12.6 (separate index)
+    .pip_install(
+        "torch==2.7.0",
+        "torchaudio==2.7.0",
+        index_url="https://download.pytorch.org/whl/cu126",
+    )
+    # Other dependencies (from PyPI)
+    .pip_install(
+        "einops",
+        "numpy>=1.26",
+        "transformers==4.57.6",
+        "safetensors",
+        "accelerate",
+        "scipy>=1.14",
+        "av",
+        "tqdm",
+        "Pillow",
+        "boto3",
+        "requests",
+        "fastapi[standard]",
+        "huggingface_hub>=0.25.0",
+    )
+    # Install flash-attn for optimized attention (optional, best-effort)
+    .pip_install("packaging")
+    .run_commands(
+        "pip install --no-cache-dir flash-attn --no-build-isolation "
+        "|| echo 'flash-attn not available, using SDPA fallback'"
+    )
+    # Clone LTX-2 and install its packages
+    .run_commands(
+        "git clone --depth 1 https://github.com/Lightricks/LTX-2.git /app/ltx2",
+        "pip install -e /app/ltx2/packages/ltx-core",
+        "pip install -e /app/ltx2/packages/ltx-pipelines",
+    )
+    # Bake LTX-2.3 model weights — full quality bf16 dev checkpoint + distilled LoRA + upsampler
+    # Dev checkpoint (46.1GB) + distilled LoRA (7.6GB) + spatial upsampler (1GB) = ~55GB
+    .run_commands(
+        "python -c \""
+        "from huggingface_hub import snapshot_download; "
+        f"snapshot_download('{HF_REPO}', local_dir='{MODEL_DIR}', "
+        "allow_patterns=['ltx-2.3-22b-dev.safetensors', "
+        "'ltx-2.3-22b-distilled-lora-384.safetensors', "
+        "'ltx-2.3-spatial-upscaler-x2-1.1.safetensors'])"
+        "\"",
+        secrets=[modal.Secret.from_name("huggingface-token")],
+    )
+    # Bake Gemma 3 12B text encoder (~7GB quantized)
+    # Gemma is a gated model — needs HF_TOKEN at build time
+    .run_commands(
+        "python -c \""
+        "from huggingface_hub import snapshot_download; "
+        f"snapshot_download('{GEMMA_REPO}', local_dir='{GEMMA_DIR}', "
+        ")"
+        "\"",
+        secrets=[modal.Secret.from_name("huggingface-token")],
+    )
+)
+
+
+@app.cls(
+    image=image.env({"PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"}),
+    gpu="A100-80GB",
+    timeout=900,
+    scaledown_window=60,
+    secrets=[modal.Secret.from_name("huggingface-token")],
+)
+@modal.concurrent(max_inputs=1)
+class LTX2:
+    """LTX-2.3 video generation."""
+
+    @modal.enter()
+    def load_pipeline(self):
+        """Load the LTX-2 pipeline when the container starts."""
+        import time
+
+        import torch
+
+        print(f"CUDA available: {torch.cuda.is_available()}")
+        if torch.cuda.is_available():
+            props = torch.cuda.get_device_properties(0)
+            print(f"GPU: {props.name}, VRAM: {props.total_memory // (1024**3)}GB")
+
+        print("Loading LTX-2.3 pipeline...")
+        start = time.time()
+
+        from ltx_pipelines.ti2vid_two_stages import TI2VidTwoStagesPipeline
+        from ltx_core.loader import LTXV_LORA_COMFY_RENAMING_MAP, LoraPathStrengthAndSDOps
+
+        # Resolve checkpoint paths
+        import glob
+        import os
+
+        def find_file(pattern):
+            matches = glob.glob(os.path.join(MODEL_DIR, pattern))
+            return matches[0] if matches else None
+
+        checkpoint = find_file("ltx-2.3-22b-dev.safetensors")
+        distilled_lora = find_file("ltx-2.3-22b-distilled-lora-*.safetensors")
+        spatial_upsampler = find_file("ltx-2.3-spatial-upscaler-x2-1.1.safetensors")
+
+        if not checkpoint:
+            raise RuntimeError(
+                f"LTX-2.3 checkpoint not found in {MODEL_DIR}. "
+                f"Files: {os.listdir(MODEL_DIR)}"
+            )
+
+        print(f"  Checkpoint: {checkpoint}")
+        print(f"  Distilled LoRA: {distilled_lora}")
+        print(f"  Spatial upsampler: {spatial_upsampler}")
+        print(f"  Gemma: {GEMMA_DIR}")
+
+        lora_list = []
+        if distilled_lora:
+            lora_list = [
+                LoraPathStrengthAndSDOps(distilled_lora, 0.8, LTXV_LORA_COMFY_RENAMING_MAP)
+            ]
+
+        self.pipeline = TI2VidTwoStagesPipeline(
+            checkpoint_path=checkpoint,
+            distilled_lora=lora_list,
+            spatial_upsampler_path=spatial_upsampler,
+            gemma_root=GEMMA_DIR,
+            loras=[],
+        )
+
+        print(f"Pipeline loaded in {time.time() - start:.1f}s")
+
+    @modal.fastapi_endpoint(method="POST")
+    def generate(self, request: dict) -> dict:
+        """Generate video from text prompt (and optional image)."""
+        import base64
+        import io
+        import random
+        import shutil
+        import tempfile
+        import time
+        import uuid
+
+        import torch
+        from PIL import Image
+
+        prompt = request.get("prompt")
+        if not prompt:
+            return {"error": "Missing required 'prompt' field"}
+
+        negative_prompt = request.get(
+            "negative_prompt",
+            "worst quality, inconsistent motion, blurry, jittery, distorted, "
+            "watermark, text, logo",
+        )
+
+        # Video parameters
+        width = request.get("width", 768)
+        height = request.get("height", 512)
+        num_frames = request.get("num_frames", 121)
+        fps = request.get("fps", 24)
+        num_inference_steps = request.get("num_inference_steps", 30)
+        seed = request.get("seed")
+        quality = request.get("quality", "standard")
+        r2_config = request.get("r2")
+
+        # Enforce dimension constraints
+        width = (width // 64) * 64
+        height = (height // 64) * 64
+
+        # Enforce frame count constraint: (num_frames - 1) % 8 == 0
+        if (num_frames - 1) % 8 != 0:
+            # Round to nearest valid frame count
+            num_frames = ((num_frames - 1 + 4) // 8) * 8 + 1
+
+        if seed is None:
+            seed = random.randint(0, 2**32 - 1)
+
+        # Fast mode: fewer steps
+        if quality == "fast":
+            num_inference_steps = min(num_inference_steps, 15)
+
+        # Decode input image for I2V — pipeline expects file paths on disk
+        images = []
+        image_base64 = request.get("image_base64")
+        image_url = request.get("image_url")
+
+        work_dir = tempfile.mkdtemp(prefix="ltx2_")
+
+        if image_base64 or image_url:
+            try:
+                if image_url:
+                    import requests as req
+
+                    resp = req.get(image_url, timeout=60)
+                    resp.raise_for_status()
+                    img = Image.open(io.BytesIO(resp.content)).convert("RGB")
+                else:
+                    b64 = image_base64
+                    if "," in b64:
+                        b64 = b64.split(",", 1)[1]
+                    img = Image.open(io.BytesIO(base64.b64decode(b64))).convert("RGB")
+
+                # Save to disk — pipeline loads images from file paths
+                import os
+
+                img_path = os.path.join(work_dir, "input.png")
+                img.save(img_path)
+
+                from ltx_pipelines.utils.args import ImageConditioningInput
+
+                images = [
+                    ImageConditioningInput(
+                        path=img_path,
+                        frame_idx=0,
+                        strength=0.8,
+                        crf=0,  # lossless — no H.264 preprocessing
+                    )
+                ]
+            except Exception as e:
+                return {"error": f"Failed to decode input image: {e}"}
+        start_time = time.time()
+
+        try:
+            from ltx_core.components.guiders import MultiModalGuiderParams
+
+            video_guider = MultiModalGuiderParams(
+                cfg_scale=3.0,
+                stg_scale=1.0,
+                rescale_scale=0.7,
+                modality_scale=3.0,
+                stg_blocks=[28],
+            )
+            audio_guider = MultiModalGuiderParams(
+                cfg_scale=7.0,
+                stg_scale=1.0,
+                rescale_scale=0.7,
+                modality_scale=3.0,
+                stg_blocks=[28],
+            )
+
+            print(
+                f"Generating: {width}x{height}, {num_frames} frames, "
+                f"{num_inference_steps} steps, seed={seed}"
+            )
+
+            # CRITICAL: torch.inference_mode() prevents PyTorch from retaining
+            # the autograd graph. Without it, the Gemma text encoder's ~37GB of
+            # activations stay in VRAM even after del, causing OOM when the
+            # transformer loads. This is a known issue (GitHub #152) — the
+            # pipeline's __call__ doesn't set inference_mode, but the CLI does.
+            # The scope must include encode_video() because the pipeline returns
+            # a lazy iterator — frames are decoded when the iterator is consumed.
+            import os
+
+            output_path = os.path.join(work_dir, "output.mp4")
+
+            from ltx_pipelines.utils.media_io import encode_video
+
+            with torch.inference_mode():
+                video_iter, audio = self.pipeline(
+                    prompt=prompt,
+                    negative_prompt=negative_prompt,
+                    seed=seed,
+                    height=height,
+                    width=width,
+                    num_frames=num_frames,
+                    frame_rate=float(fps),
+                    num_inference_steps=num_inference_steps,
+                    video_guider_params=video_guider,
+                    audio_guider_params=audio_guider,
+                    images=images if images else [],
+                )
+
+                encode_video(
+                    video=video_iter,
+                    fps=fps,
+                    audio=audio,
+                    output_path=output_path,
+                    video_chunks_number=1,
+                )
+
+            elapsed_ms = int((time.time() - start_time) * 1000)
+            duration = num_frames / fps
+
+            result = {
+                "success": True,
+                "seed": seed,
+                "duration": round(duration, 2),
+                "width": width,
+                "height": height,
+                "num_frames": num_frames,
+                "fps": fps,
+                "inference_time_ms": elapsed_ms,
+            }
+
+            # Upload to R2 or return as base64
+            if r2_config:
+                try:
+                    import boto3
+                    from botocore.config import Config
+
+                    client = boto3.client(
+                        "s3",
+                        endpoint_url=r2_config["endpoint_url"],
+                        aws_access_key_id=r2_config["access_key_id"],
+                        aws_secret_access_key=r2_config["secret_access_key"],
+                        config=Config(signature_version="s3v4"),
+                    )
+                    object_key = f"ltx2/results/{uuid.uuid4().hex[:12]}.mp4"
+                    client.upload_file(
+                        output_path,
+                        r2_config["bucket_name"],
+                        object_key,
+                        ExtraArgs={"ContentType": "video/mp4"},
+                    )
+                    presigned_url = client.generate_presigned_url(
+                        "get_object",
+                        Params={
+                            "Bucket": r2_config["bucket_name"],
+                            "Key": object_key,
+                        },
+                        ExpiresIn=7200,
+                    )
+                    result["output_url"] = presigned_url
+                    result["r2_key"] = object_key
+                except Exception as e:
+                    print(f"R2 upload error: {e}")
+                    # Fall back to base64
+                    with open(output_path, "rb") as f:
+                        result["video_base64"] = base64.b64encode(f.read()).decode(
+                            "utf-8"
+                        )
+            else:
+                print(
+                    "Warning: Returning video as base64 (use R2 for large files)"
+                )
+                with open(output_path, "rb") as f:
+                    result["video_base64"] = base64.b64encode(f.read()).decode(
+                        "utf-8"
+                    )
+
+            return result
+
+        except torch.cuda.OutOfMemoryError as e:
+            torch.cuda.empty_cache()
+            return {
+                "error": f"GPU out of memory: {e}. Try smaller dimensions or fewer frames."
+            }
+        except Exception as e:
+            import traceback
+
+            print(f"Error: {e}")
+            print(traceback.format_exc())
+            return {"error": f"Internal error: {str(e)}"}
+        finally:
+            shutil.rmtree(work_dir, ignore_errors=True)

--- a/docs/ltx2.md
+++ b/docs/ltx2.md
@@ -1,0 +1,198 @@
+# LTX-2 - AI Video Generation
+
+Generate ~5 second video clips from text prompts or images using the LTX-2.3 22B model from Lightricks. Produces video with synchronized audio — both generated simultaneously by the model.
+
+## Quick Start
+
+```bash
+# Text-to-video
+python3 tools/ltx2.py --prompt "A cat playing with yarn in a sunlit room"
+
+# Image-to-video (animate a still image)
+python3 tools/ltx2.py --prompt "Camera slowly pans right" --input photo.jpg
+
+# Higher resolution
+python3 tools/ltx2.py --prompt "Ocean waves at sunset" --width 1024 --height 576
+
+# Fast mode (fewer steps, quicker but lower quality)
+python3 tools/ltx2.py --prompt "A rocket launch" --quality fast
+```
+
+## Setup
+
+LTX-2 runs on Modal cloud GPU (A100-80GB). Setup takes about 15 minutes — most of that is baking ~62GB of model weights into the container image so future cold starts are fast.
+
+### Prerequisites
+
+- Modal account and CLI installed (`pip install modal && python3 -m modal setup`)
+- HuggingFace account with a **read-access** token ([create one here](https://huggingface.co/settings/tokens) — "Read access to contents of all repos" scope is sufficient)
+- Accept the [Gemma 3 license](https://huggingface.co/google/gemma-3-12b-it-qat-q4_0-unquantized) (one-click "Agree" on the model page)
+
+### Steps
+
+1. **Create a Modal secret** with your HuggingFace token:
+
+   ```bash
+   modal secret create huggingface-token HF_TOKEN=hf_your_token_here
+   ```
+
+   > **Important:** This token is used for both the LTX-2 weights (~55GB) and the Gemma text encoder (~7GB). While LTX-2 isn't a gated model, unauthenticated downloads from HuggingFace are severely rate-limited — a 46GB checkpoint that takes ~10 minutes with a token can take over an hour without one. The Gemma model is gated and will fail entirely without auth.
+
+2. **Deploy the Modal app** (downloads and bakes all model weights — takes 10-15 min):
+
+   ```bash
+   modal deploy docker/modal-ltx2/app.py
+   ```
+
+3. **Save the endpoint URL** printed by `modal deploy` to your `.env`:
+
+   ```
+   MODAL_LTX2_ENDPOINT_URL=https://yourname--video-toolkit-ltx2-ltx2-generate.modal.run
+   ```
+
+4. **Test it:**
+
+   ```bash
+   python3 tools/ltx2.py --prompt "A single lit candle flickering on a dark table, cinematic lighting"
+   ```
+
+## Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `--prompt` | (required) | Text description of the video |
+| `--input` | - | Input image for image-to-video |
+| `--width` | 768 | Video width (must be divisible by 64) |
+| `--height` | 512 | Video height (must be divisible by 64) |
+| `--num-frames` | 121 | Frame count. Must satisfy `(n-1) % 8 == 0`. 121 frames = ~5s at 24fps |
+| `--fps` | 24 | Frames per second |
+| `--quality` | standard | `standard` (30 steps) or `fast` (15 steps) |
+| `--steps` | 30 | Override inference steps directly |
+| `--seed` | random | Seed for reproducible results |
+| `--output` | auto | Output file path (defaults to prompt-based `.mp4`) |
+| `--no-open` | - | Don't auto-open the result on macOS |
+| `--negative-prompt` | sensible default | What to avoid in generation |
+
+## Valid Frame Counts
+
+Frame counts must satisfy `(n - 1) % 8 == 0`. Common values:
+
+| Frames | Duration (24fps) |
+|--------|-------------------|
+| 25 | ~1s |
+| 49 | ~2s |
+| 73 | ~3s |
+| 97 | ~4s |
+| 121 | ~5s (default) |
+| 161 | ~6.7s |
+| 193 | ~8s |
+
+If you pass an invalid count, the tool auto-adjusts to the nearest valid value.
+
+## Dimension Constraints
+
+Width and height must each be divisible by 64. Common presets:
+
+| Resolution | Aspect Ratio | Notes |
+|------------|--------------|-------|
+| 768x512 | 3:2 | Default, good balance of quality and speed |
+| 512x512 | 1:1 | Square, fastest |
+| 1024x576 | 16:9 | Widescreen |
+| 576x1024 | 9:16 | Portrait/vertical video |
+| 1024x1536 | 2:3 | Maximum quality (slow, high VRAM) |
+
+Higher resolutions take longer and use more VRAM. The two-stage pipeline generates at half resolution first, then upscales.
+
+## Prompting Tips
+
+LTX-2 responds well to cinematographic descriptions:
+
+- **Camera motion:** "Slow dolly forward", "Aerial drone shot", "Handheld camera", "Tracking shot following..."
+- **Lighting:** "Golden hour", "Cinematic lighting", "Neon-lit", "Soft diffused light"
+- **Temporal:** "Timelapse of...", "Slow motion", "Gradually transitions from..."
+- **Style:** "Shot on 35mm film", "Documentary style", "Studio photography"
+
+Keep prompts under 200 words. Be specific about the scene rather than abstract.
+
+### Example Prompts
+
+```
+# Simple scene with motion
+"A single lit candle on a dark wooden table, flame gently flickering, soft bokeh background, cinematic lighting"
+
+# Nature with camera motion
+"Aerial drone shot slowly flying over turquoise ocean waves breaking on a white sand beach, golden hour sunlight"
+
+# Urban scene
+"Rain falling on a neon-lit Tokyo street at night, puddles reflecting colorful signs, people with umbrellas, cinematic"
+
+# Product/tech (for video production)
+"Close-up of hands typing on a mechanical keyboard, shallow depth of field, soft desk lamp lighting, cozy atmosphere"
+```
+
+## How It Works
+
+LTX-2.3 is a 22B parameter diffusion transformer with a two-stage pipeline:
+
+1. **Stage 1:** Generate video at half resolution (e.g., 384x256) over 30 denoising steps
+2. **Stage 2:** Upscale to full resolution using a spatial upsampler with 4 distilled steps
+
+The model generates **video and audio simultaneously** through bidirectional cross-attention between video and audio streams. Audio is generated as a mel spectrogram and decoded by a HiFi-GAN vocoder.
+
+### Components
+
+| Component | Size | Role |
+|-----------|------|------|
+| Transformer (22B DiT) | 46 GB | Core video+audio generation |
+| Gemma 3 12B (QAT bf16) | ~24 GB | Text understanding |
+| Spatial upsampler | ~1 GB | Resolution upscaling |
+| Distilled LoRA | ~8 GB | Faster inference |
+
+Total baked weight: ~55 GB. The pipeline manages memory by loading and freeing components sequentially — peak VRAM is ~44GB (the transformer alone), not the sum of all components.
+
+## Cost & Performance
+
+- **GPU:** A100-80GB on Modal (~$4.68/hr)
+- **Cold start:** ~60-90s (loading ~55GB weights into VRAM)
+- **Generation:** ~2.5 min for default 768x512, 121 frames, 30 steps
+- **Estimated cost:** ~$0.23 per 5-second clip
+- **Scale to zero:** Container shuts down after 60s idle (no cost when not in use)
+
+## Known Limitations
+
+- **Training data artifacts:** The model occasionally generates unwanted logos, text overlays, or watermark-like artifacts from its training data (~30% of generations). Re-generating with a different seed usually fixes this.
+- **No visible watermarks:** LTX-2 does not intentionally add watermarks to output.
+- **Max duration:** Practical limit is ~8s (193 frames). Longer clips need stitching.
+- **Audio quality:** Generated audio is ambient/environmental. It won't produce speech or music — use the toolkit's voiceover and music tools for that.
+
+## Troubleshooting
+
+### "GPU out of memory"
+
+Reduce dimensions or frame count:
+```bash
+# Try smaller resolution
+python3 tools/ltx2.py --prompt "..." --width 512 --height 512
+
+# Or fewer frames
+python3 tools/ltx2.py --prompt "..." --num-frames 73
+```
+
+### "Modal endpoint is scaling up"
+
+First request after idle triggers a cold start (~30-60s). Retry after a moment.
+
+### Training data artifacts in output
+
+Re-run with a different `--seed`. Adding "no text, no watermark, no logo" to the prompt can help.
+
+### "Modal function timed out"
+
+High-resolution or long videos can exceed the timeout. Use `--quality fast` or reduce dimensions.
+
+## License
+
+LTX-2 uses a [Community License](https://github.com/Lightricks/LTX-2/blob/main/LICENSE) from Lightricks. Key points:
+- Free for individuals and companies under $10M annual revenue
+- Entities over $10M revenue need a commercial license from Lightricks
+- Cannot be used to build directly competing products without a commercial license

--- a/skills/openclaw-video-toolkit/SKILL.md
+++ b/skills/openclaw-video-toolkit/SKILL.md
@@ -68,6 +68,12 @@ modal deploy docker/modal-sadtalker/app.py
 modal deploy docker/modal-image-edit/app.py
 modal deploy docker/modal-upscale/app.py
 modal deploy docker/modal-propainter/app.py
+modal deploy docker/modal-ltx2/app.py      # Requires: modal secret create huggingface-token HF_TOKEN=hf_...
+```
+
+**LTX-2 prerequisite:** Before deploying LTX-2, create a HuggingFace secret and accept the [Gemma 3 license](https://huggingface.co/google/gemma-3-12b-it-qat-q4_0-unquantized):
+```bash
+modal secret create huggingface-token HF_TOKEN=hf_your_read_access_token
 ```
 
 Add each URL to `.env`:
@@ -79,6 +85,7 @@ MODAL_SADTALKER_ENDPOINT_URL=https://...modal.run
 MODAL_IMAGE_EDIT_ENDPOINT_URL=https://...modal.run
 MODAL_UPSCALE_ENDPOINT_URL=https://...modal.run
 MODAL_DEWATERMARK_ENDPOINT_URL=https://...modal.run
+MODAL_LTX2_ENDPOINT_URL=https://...modal.run
 ```
 
 Optional but recommended — Cloudflare R2 for reliable file transfer:
@@ -248,7 +255,47 @@ python3 tools/flux2.py \
   --cloud modal
 ```
 
-#### 4d. Talking Head Narrator (optional)
+#### 4d. Video Clips — B-Roll & Animated Backgrounds (optional)
+
+Generate AI video clips for b-roll cutaways, animated slide backgrounds, or intro/outro sequences:
+
+```bash
+cd ~/.openclaw/workspace/claude-code-video-toolkit
+
+# B-roll clip from text
+python3 tools/ltx2.py \
+  --prompt "Aerial drone shot over a European city at golden hour, cinematic wide angle" \
+  --output projects/PROJECT_NAME/public/videos/broll-europe.mp4 \
+  --cloud modal
+
+# Animate a slide/screenshot (image-to-video)
+python3 tools/ltx2.py \
+  --prompt "Gentle particle effects, soft ambient light shifts, very slight camera drift" \
+  --input projects/PROJECT_NAME/public/images/title-bg.png \
+  --output projects/PROJECT_NAME/public/videos/animated-title.mp4 \
+  --cloud modal
+
+# Abstract intro/outro background
+python3 tools/ltx2.py \
+  --prompt "Dark moody abstract background with flowing blue light streaks, bokeh particles, cinematic" \
+  --output projects/PROJECT_NAME/public/videos/intro-bg.mp4 \
+  --cloud modal
+```
+
+Use in Remotion compositions with `<OffthreadVideo>`:
+```tsx
+<OffthreadVideo src={staticFile('videos/broll-europe.mp4')} />
+```
+
+**LTX-2 rules:**
+- Max ~8 seconds per clip (193 frames at 24fps). Default is ~5s (121 frames).
+- Width/height must be divisible by 64. Default: 768x512.
+- ~$0.20-0.25 per clip, ~2.5 min generation time.
+- Cold start ~60-90s. Subsequent clips on warm GPU are faster.
+- Generated audio is ambient only — use voiceover/music tools for speech and music.
+- ~30% of generations may have training data artifacts (logos/text). Re-run with `--seed` to vary.
+
+#### 4e. Talking Head Narrator (optional)
 
 Generate a presenter portrait, then animate per-scene clips:
 
@@ -402,6 +449,7 @@ import { lightLeak } from '../../../lib/transitions/presentations/light-leak';
 | SadTalker | ~$0.05-0.20/scene | ~3-4 min per 10s audio |
 | Qwen-Edit | ~$0.03-0.15 | ~8 min cold start (25GB model) |
 | RealESRGAN | ~$0.005/image | Very fast |
+| LTX-2.3 | ~$0.20-0.25/clip | ~2.5 min per 5s clip, A100-80GB |
 
 **Total for a 60s video:** ~$1-3 depending on scenes and narrator clips.
 

--- a/tools/cloud_gpu.py
+++ b/tools/cloud_gpu.py
@@ -40,6 +40,7 @@ _MODAL_ENV_VARS = {
     "image_edit": "MODAL_IMAGE_EDIT_ENDPOINT_URL",
     "music_gen": "MODAL_MUSIC_GEN_ENDPOINT_URL",
     "dewatermark": "MODAL_DEWATERMARK_ENDPOINT_URL",
+    "ltx2": "MODAL_LTX2_ENDPOINT_URL",
 }
 
 
@@ -98,6 +99,7 @@ _TOOL_GPU = {
         "image_edit": "A10G",
         "music_gen": "A10G",
         "dewatermark": "A10G",
+        "ltx2": "A100-80GB",
     },
     "runpod": {
         "qwen3_tts": "ADA_24",

--- a/tools/ltx2.py
+++ b/tools/ltx2.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""
+AI video generation using LTX-2.3 (22B DiT model).
+
+Generates ~5 second video clips from text prompts or images via Modal cloud GPU.
+Supports text-to-video and image-to-video with joint audio generation.
+
+Examples:
+  # Text-to-video
+  python tools/ltx2.py --prompt "A cat playing with yarn in a sunlit room"
+
+  # Higher resolution
+  python tools/ltx2.py --prompt "Ocean waves at sunset" --width 1024 --height 576
+
+  # Image-to-video (animate a still image)
+  python tools/ltx2.py --prompt "Camera slowly pans right" --input photo.jpg
+
+  # Fast mode (fewer steps, lower quality)
+  python tools/ltx2.py --prompt "A rocket launch" --quality fast
+
+  # Custom parameters
+  python tools/ltx2.py --prompt "A timelapse of flowers blooming" \\
+      --num-frames 161 --fps 24 --steps 40 --seed 42
+
+  # Output to specific file
+  python tools/ltx2.py --prompt "A dog running on the beach" --output dog_beach.mp4
+"""
+
+import argparse
+import base64
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+try:
+    import requests
+    from dotenv import load_dotenv
+except ImportError as e:
+    print(f"Missing dependency: {e}")
+    print("Install with: pip install requests python-dotenv")
+    sys.exit(1)
+
+load_dotenv()
+
+sys.path.insert(0, str(Path(__file__).parent))
+from file_transfer import download_from_url, get_r2_payload_config
+
+
+def log(msg: str, level: str = "info"):
+    """Print formatted log message."""
+    colors = {
+        "info": "\033[94m",
+        "success": "\033[92m",
+        "error": "\033[91m",
+        "warn": "\033[93m",
+        "dim": "\033[90m",
+    }
+    reset = "\033[0m"
+    prefix = {"info": "->", "success": "OK", "error": "!!", "warn": "??", "dim": "  "}
+    color = colors.get(level, "")
+    print(f"{color}{prefix.get(level, '->')} {msg}{reset}")
+
+
+def encode_image(path: str) -> str:
+    """Encode image file to base64."""
+    with open(path, "rb") as f:
+        return base64.b64encode(f.read()).decode("utf-8")
+
+
+def validate_frames(num_frames: int) -> int:
+    """Ensure num_frames satisfies (n-1) % 8 == 0 constraint."""
+    if (num_frames - 1) % 8 != 0:
+        adjusted = ((num_frames - 1 + 4) // 8) * 8 + 1
+        log(f"Adjusted num_frames {num_frames} -> {adjusted} (must satisfy (n-1)%8==0)", "warn")
+        return adjusted
+    return num_frames
+
+
+def validate_dimensions(width: int, height: int) -> tuple[int, int]:
+    """Ensure dimensions are divisible by 64."""
+    w = (width // 64) * 64
+    h = (height // 64) * 64
+    if w != width or h != height:
+        log(f"Adjusted dimensions {width}x{height} -> {w}x{h} (must be divisible by 64)", "warn")
+    return w, h
+
+
+def generate_video(
+    prompt: str,
+    input_path: Optional[str] = None,
+    output_path: Optional[str] = None,
+    negative_prompt: Optional[str] = None,
+    width: int = 768,
+    height: int = 512,
+    num_frames: int = 121,
+    fps: int = 24,
+    steps: Optional[int] = None,
+    seed: Optional[int] = None,
+    quality: str = "standard",
+    open_result: bool = True,
+    cloud: str = "modal",
+) -> Optional[str]:
+    """
+    Generate video from text prompt (and optional input image).
+
+    Returns output path on success, None on failure.
+    """
+    # Validate parameters
+    width, height = validate_dimensions(width, height)
+    num_frames = validate_frames(num_frames)
+
+    if output_path is None:
+        slug = prompt[:40].strip().replace(" ", "_").lower()
+        slug = "".join(c for c in slug if c.isalnum() or c == "_")
+        output_path = f"{slug}.mp4"
+
+    duration = num_frames / fps
+
+    log(f"Prompt: {prompt}", "info")
+    log(f"Size: {width}x{height}, {num_frames} frames @ {fps}fps ({duration:.1f}s)", "dim")
+    if input_path:
+        log(f"Input image: {input_path}", "info")
+
+    payload = {
+        "input": {
+            "prompt": prompt,
+            "width": width,
+            "height": height,
+            "num_frames": num_frames,
+            "fps": fps,
+            "quality": quality,
+        }
+    }
+
+    if negative_prompt:
+        payload["input"]["negative_prompt"] = negative_prompt
+    if steps is not None:
+        payload["input"]["num_inference_steps"] = steps
+    if seed is not None:
+        payload["input"]["seed"] = seed
+
+    # Encode input image for I2V
+    if input_path:
+        if not Path(input_path).exists():
+            log(f"File not found: {input_path}", "error")
+            return None
+        payload["input"]["image_base64"] = encode_image(input_path)
+
+    # R2 config for large video files
+    r2_payload = get_r2_payload_config()
+    if r2_payload:
+        payload["input"]["r2"] = r2_payload
+
+    from cloud_gpu import call_cloud_endpoint
+
+    result, elapsed = call_cloud_endpoint(
+        provider=cloud,
+        payload=payload,
+        tool_name="ltx2",
+        timeout=900,
+        progress_label="Generating video",
+        verbose=True,
+    )
+
+    if "error" in result:
+        log(f"Generation failed: {result['error']}", "error")
+        return None
+
+    # Download or decode result
+    if "output_url" in result:
+        log("Downloading from R2...", "dim")
+        download_from_url(result["output_url"], output_path, verbose=False)
+    elif "video_base64" in result:
+        with open(output_path, "wb") as f:
+            f.write(base64.b64decode(result["video_base64"]))
+    else:
+        log("No video data in response", "error")
+        return None
+
+    inference_ms = result.get("inference_time_ms", 0)
+    out_duration = result.get("duration", duration)
+    out_seed = result.get("seed", "unknown")
+
+    log(f"Saved: {output_path}", "success")
+    log(f"Duration: {out_duration}s, {result.get('num_frames', num_frames)} frames @ {result.get('fps', fps)}fps", "dim")
+    log(f"Time: {elapsed:.1f}s total, {inference_ms/1000:.1f}s inference", "dim")
+    log(f"Seed: {out_seed}", "dim")
+
+    if open_result and sys.platform == "darwin":
+        import subprocess
+        subprocess.run(["open", output_path], check=False)
+
+    return output_path
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="AI video generation using LTX-2.3 (22B DiT model)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --prompt "A cat playing with yarn"
+  %(prog)s --prompt "Camera pans over a city" --width 1024 --height 576
+  %(prog)s --prompt "Slow zoom in" --input photo.jpg
+  %(prog)s --prompt "A rocket launch" --quality fast
+  %(prog)s --prompt "Waves crashing" --num-frames 161 --seed 42
+        """
+    )
+
+    # Input
+    input_group = parser.add_argument_group("Input")
+    input_group.add_argument("--prompt", "-p", required=True, help="Text description of the video")
+    input_group.add_argument("--input", "-i", help="Input image for image-to-video")
+    input_group.add_argument("--negative-prompt", help="What to avoid (has sensible default)")
+
+    # Video parameters
+    video_group = parser.add_argument_group("Video parameters")
+    video_group.add_argument("--width", "-W", type=int, default=768,
+                             help="Video width, divisible by 64 (default: 768)")
+    video_group.add_argument("--height", "-H", type=int, default=512,
+                             help="Video height, divisible by 64 (default: 512)")
+    video_group.add_argument("--num-frames", "-n", type=int, default=121,
+                             help="Number of frames, (n-1)%%8==0 (default: 121, ~5s)")
+    video_group.add_argument("--fps", type=int, default=24,
+                             help="Frames per second (default: 24)")
+
+    # Quality
+    quality_group = parser.add_argument_group("Quality")
+    quality_group.add_argument("--quality", "-q", choices=["standard", "fast"], default="standard",
+                               help="Quality preset (default: standard)")
+    quality_group.add_argument("--steps", type=int,
+                               help="Inference steps (default: 30 standard, 15 fast)")
+    quality_group.add_argument("--seed", type=int, help="Random seed for reproducibility")
+
+    # Output
+    output_group = parser.add_argument_group("Output")
+    output_group.add_argument("--output", "-o", help="Output file path (default: auto-named .mp4)")
+    output_group.add_argument("--no-open", action="store_true", help="Don't open result automatically")
+    output_group.add_argument("--json", action="store_true", help="Output result as JSON")
+
+    # Cloud GPU
+    cloud_group = parser.add_argument_group("Cloud GPU")
+    cloud_group.add_argument("--cloud", type=str, default="modal", choices=["modal"],
+                             help="Cloud GPU provider (default: modal)")
+
+    args = parser.parse_args()
+
+    print()
+    log("LTX-2.3 Video Generation (22B DiT)", "info")
+    log("=" * 45, "dim")
+
+    result_path = generate_video(
+        prompt=args.prompt,
+        input_path=args.input,
+        output_path=args.output,
+        negative_prompt=args.negative_prompt,
+        width=args.width,
+        height=args.height,
+        num_frames=args.num_frames,
+        fps=args.fps,
+        steps=args.steps,
+        seed=args.seed,
+        quality=args.quality,
+        open_result=not args.no_open,
+        cloud=args.cloud,
+    )
+
+    if result_path is None:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add AI video generation using LTX-2.3 22B DiT model via Modal (A100-80GB)
- Text-to-video and image-to-video — generates ~5s clips with synchronized audio
- Full toolkit integration: skill, CLI tool, cloud_gpu routing, docs, registry, openclaw skill

## What's Included
- `docker/modal-ltx2/app.py` — Modal deployment with baked weights (~55GB)
- `tools/ltx2.py` — CLI: `--prompt`, `--input` (I2V), `--width/--height`, `--quality`, `--seed`
- `tools/cloud_gpu.py` — LTX-2 endpoint routing and cost estimation
- `.claude/skills/ltx2/SKILL.md` — Prompting guide, parameters, video production use cases
- `skills/openclaw-video-toolkit/SKILL.md` — Updated with LTX-2 section and setup
- `docs/ltx2.md` — Setup guide, troubleshooting, known limitations
- `_internal/toolkit-registry.json` — Tool, skill, and Modal endpoint entries
- `_internal/CHANGELOG.md` — v0.13.1 release notes
- `README.md` — Updated skills, tools, and cloud GPU tables

## Key Technical Decisions
- **`torch.inference_mode()`** wraps pipeline call — without it, Gemma 3 retains ~37GB of autograd activations causing OOM on 80GB GPU (upstream bug: Lightricks/LTX-2#152)
- **`transformers==4.57.6`** — v5.x breaks `Gemma3TextConfig.rope_local_base_freq`
- **Weights from `Lightricks/LTX-2.3`** HF repo (separate from the code repo)
- **HuggingFace token** required for both download speed and gated Gemma model access
- **Full quality bf16** — no FP8 compromises, pipeline manages VRAM sequentially

## Test plan
- [x] Text-to-video: candle scene generates successfully
- [x] Image-to-video: portrait animation works
- [x] Cold start + warm container performance verified
- [x] Cost estimation: ~$0.23 per 5s clip
- [ ] Test on fresh Modal account (setup flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)