### PR TITLE
FIX: modal-upscale basicsr build conflict (cuda-toolkit/nvidia-cublas)

### DIFF
--- a/docker/modal-upscale/app.py
+++ b/docker/modal-upscale/app.py
@@ -25,15 +25,24 @@ GFPGAN_URL = "https://github.com/TencentARC/GFPGAN/releases/download/v1.3.0/GFPG
 image = (
     modal.Image.debian_slim(python_version="3.11")
     .apt_install("libgl1", "libglib2.0-0")
+    # Pre-install torch + pinned setuptools to avoid basicsr setup_requires CUDA conflict
     .pip_install(
+        "setuptools<70",
+        "wheel",
+        "numpy>=1.24.0,<2.0",
         "torch==2.1.2",
         "torchvision==0.16.2",
-        "realesrgan>=0.3.0",
+    )
+    # basicsr with --no-build-isolation so its setup.py sees the already-installed torch
+    .pip_install(
         "basicsr>=1.4.2",
+        extra_options="--no-build-isolation",
+    )
+    .pip_install(
+        "realesrgan>=0.3.0",
         "facexlib>=0.3.0",
         "gfpgan>=1.3.8",
         "opencv-python-headless>=4.8.0",
-        "numpy>=1.24.0,<2.0",
         "Pillow>=10.0.0",
         "boto3",
         "requests",


### PR DESCRIPTION
## Summary

- `modal deploy docker/modal-upscale/app.py` was failing during the build with `pkg_resources.ContextualVersionConflict: nvidia-cublas 13.4.1.1 vs Requirement.parse('nvidia-cublas==13.1.0.3.*')` from `cuda-toolkit`.
- Root cause: basicsr's `setup.py` triggers a `setup_requires` resolution that pulls `cuda-toolkit`, which strict-pins `nvidia-cublas` to a version that conflicts with what torch already provides. setuptools 70+ tightened how `setup_requires` is resolved, so the build fails.
- Fix: pre-install torch + `setuptools<70` + wheel + numpy in their own layer, then install basicsr with `--no-build-isolation` so its `setup.py` reuses the resolved environment instead of fetching its own build deps. Remaining packages install on top in a third layer.

## Test plan

- [x] `modal deploy docker/modal-upscale/app.py` succeeds end-to-end
- [x] Endpoint registered: `https://{username}--video-toolkit-upscale-upscaler-upscale.modal.run`
- [ ] Smoke test the endpoint with a real image (skipped here to avoid cold-start costs in setup; verified during /setup wizard)