### PR TITLE
FIX: restore Python 3.9 compatibility in tools/

### DIFF
--- a/tools/addmusic.py
+++ b/tools/addmusic.py
@@ -21,6 +21,7 @@ Usage:
     # Dry run to preview
     python tools/addmusic.py -i video.mp4 -p "Upbeat tech" --dry-run
 """
+from __future__ import annotations
 
 import argparse
 import json

--- a/tools/cloud_gpu.py
+++ b/tools/cloud_gpu.py
@@ -8,6 +8,7 @@ Supported providers:
 - runpod: RunPod serverless endpoints (existing)
 - modal: Modal web endpoints (new)
 """
+from __future__ import annotations
 
 import json as _json
 import os

--- a/tools/config.py
+++ b/tools/config.py
@@ -1,4 +1,5 @@
 """Shared configuration for video toolkit tools."""
+from __future__ import annotations
 
 import json
 import os

--- a/tools/dewatermark.py
+++ b/tools/dewatermark.py
@@ -39,6 +39,7 @@ Cost:
     - Modal: A10G GPU, scales to zero when idle
     - RunPod: RTX 3090 (~$0.34/hr) by default
 """
+from __future__ import annotations
 
 import argparse
 import json

--- a/tools/file_transfer.py
+++ b/tools/file_transfer.py
@@ -3,6 +3,7 @@
 Provides R2 upload/download with fallback to free services (litterbox, 0x0.st).
 Used by all cloud GPU tools to avoid duplicating file transfer logic.
 """
+from __future__ import annotations
 
 import os
 import sys

--- a/tools/flux2.py
+++ b/tools/flux2.py
@@ -30,6 +30,7 @@ Examples:
   # Setup RunPod endpoint (first-time)
   python tools/flux2.py --setup
 """
+from __future__ import annotations
 
 import argparse
 import base64

--- a/tools/locate_watermark.py
+++ b/tools/locate_watermark.py
@@ -25,6 +25,7 @@ Presets:
     stock-bl    - Bottom-left stock footage watermark
     stock-center - Center watermark (common in stock footage)
 """
+from __future__ import annotations
 
 import argparse
 import json

--- a/tools/music.py
+++ b/tools/music.py
@@ -9,6 +9,7 @@ Usage:
     # JSON output for machine parsing
     python tools/music.py --prompt "Calm ambient" --duration 60 --output bg.mp3 --json
 """
+from __future__ import annotations
 
 import argparse
 import json

--- a/tools/notebooklm_brand.py
+++ b/tools/notebooklm_brand.py
@@ -46,6 +46,7 @@ Usage:
         --outro-duration 5 \\
         --output video_final.mp4
 """
+from __future__ import annotations
 
 import argparse
 import json

--- a/tools/qwen3_tts.py
+++ b/tools/qwen3_tts.py
@@ -44,6 +44,7 @@ Setup:
         2. Run: python tools/qwen3_tts.py --setup --cloud modal
         3. Or manually: modal deploy docker/modal-qwen3-tts/app.py
 """
+from __future__ import annotations
 
 import argparse
 import base64

--- a/tools/redub.py
+++ b/tools/redub.py
@@ -37,6 +37,7 @@ Sync Mode:
     This ensures each word in the video aligns with its corresponding TTS audio,
     even when the overall pacing differs significantly.
 """
+from __future__ import annotations
 
 import argparse
 import base64

--- a/tools/sadtalker.py
+++ b/tools/sadtalker.py
@@ -28,6 +28,7 @@ Cost:
     - ~$0.27 per 3 minutes of video
     - Uses RTX 4090 ($0.00074/sec) by default
 """
+from __future__ import annotations
 
 import argparse
 import base64

--- a/tools/sfx.py
+++ b/tools/sfx.py
@@ -12,6 +12,7 @@ Usage:
     # JSON output for machine parsing
     python tools/sfx.py --prompt "UI click" --duration 0.5 --output click.mp3 --json
 """
+from __future__ import annotations
 
 import argparse
 import json

--- a/tools/sync_timing.py
+++ b/tools/sync_timing.py
@@ -25,6 +25,7 @@ Usage:
     # JSON output for scripting
     python3 tools/sync_timing.py --json
 """
+from __future__ import annotations
 
 import argparse
 import json

--- a/tools/upscale.py
+++ b/tools/upscale.py
@@ -25,6 +25,7 @@ Models:
     - anime: RealESRGAN_x4plus_anime_6B (optimized for anime/illustration)
     - photo: realesr-general-x4v3 (alternative general model)
 """
+from __future__ import annotations
 
 import argparse
 import json

--- a/tools/voiceover.py
+++ b/tools/voiceover.py
@@ -26,6 +26,7 @@ Usage:
     python tools/voiceover.py --provider qwen3 --tone warm --scene-dir public/audio/scenes --json
     python tools/voiceover.py --provider qwen3 --instruct "Speak warmly" --script script.txt --output out.mp3
 """
+from __future__ import annotations
 
 import argparse
 import json


### PR DESCRIPTION
## Summary

16 tools in `tools/` use PEP 604 union syntax (`X | None`) in type annotations. Because these appear on function signatures, they are evaluated at function-definition time and raise `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'` on Python 3.9 (PEP 604 unions require 3.10+).

This breaks **every cloud GPU tool** on import — e.g. `file_transfer.py` fails to import, which cascades to all R2/Modal/RunPod tooling — despite `CLAUDE.md` and `verify_setup.py` both advertising "Python 3.9+" support.

## Fix

Add `from __future__ import annotations` to each affected file, so all annotations are treated as lazy strings and never evaluated at runtime.

Verified there is **no non-annotation 3.10+ usage** (no `match` statements, no runtime `isinstance(x, A | B)` unions), so this fully restores Python 3.9 support with zero behavior change.

## Files (16)

`addmusic`, `cloud_gpu`, `config`, `dewatermark`, `file_transfer`, `flux2`, `locate_watermark`, `music`, `notebooklm_brand`, `qwen3_tts`, `redub`, `sadtalker`, `sfx`, `sync_timing`, `upscale`, `voiceover`

## Testing

- All 16 files byte-compile cleanly on Python 3.9.6
- Full cloud pipeline verified end-to-end on Python 3.9.6: Qwen3-TTS voiceover generated via Modal (R2 upload → GPU → R2 download)

🤖 Generated with [Claude Code](https://claude.com/claude-code)