### PR TITLE
Add Ideogram 4 text-to-image (best-in-class in-image text)

### DIFF
--- a/.claude/skills/ideogram4/SKILL.md
+++ b/.claude/skills/ideogram4/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: ideogram4
+description: Prompting patterns for Ideogram 4 text-to-image — best-in-class in-image text rendering and exact color/layout control via structured JSON captions. Use when generating images that need legible on-image text (title cards, thumbnails, logos, signage, CTAs), precise brand colors, or controlled spatial layout. Triggers include title slide image, thumbnail with text, on-image text, legible text in image, brand color palette image, bounding-box layout, Ideogram.
+---
+
+# Ideogram 4 Skill
+
+Text-to-image generation with **Ideogram 4** (9.3B, open-weight, released June 2026). Its
+superpower is **best-in-class in-image text rendering** — it beats much larger models
+(FLUX.2 dev 32B, Qwen-Image 20B, Hunyuan 80B) at rendering legible signage, logos, captions,
+and multi-line text — plus **exact color-palette and bounding-box control**.
+
+That advantage is **locked behind a structured JSON caption format**. A plain-text prompt gets
+you FLUX-level results and misses the entire point of using this model. This skill teaches
+Claude to act as the "magic prompt" expander — turning a user's casual request into the JSON
+caption Ideogram 4 was trained on.
+
+> **Backend:** The toolkit uses Ideogram's **hosted v4 API** (not self-hosted weights). The API
+> accepts a structured `json_prompt`, so everything this skill teaches applies directly — Claude
+> builds the caption, the tool posts it as `json_prompt`. Paid API plans include a **commercial
+> license**, which the self-hostable weights (non-commercial) do not — that's why we use the API.
+> Cost is ~$0.03/image (turbo) to ~$0.09/image (quality).
+
+## When to Use This Skill
+
+Reach for Ideogram 4 (over FLUX.2) when the image needs:
+- **Legible on-image text** — title cards, thumbnails, lower-thirds backgrounds, signage, logos,
+  quote cards, CTAs with a headline baked in
+- **Exact brand colors** — hex color-palette conditioning, per-element
+- **Controlled layout** — bounding boxes place text/objects in specific regions
+- **Multilingual text** in the image
+
+Use **FLUX.2** instead when: the image has no critical text, you need commercial-licensed output,
+or you just want a fast atmospheric background. FLUX takes plain natural-language prompts; Ideogram
+wants JSON. See `tools/flux2.py`.
+
+## The One Thing to Get Right
+
+**Always emit a structured JSON caption, not a plain sentence.** The model is trained
+*exclusively* on JSON captions that name every element explicitly. Claude is a better expander
+than Ideogram's free hosted magic-prompt (their own docs note the shipped one "is not the same
+used in production"), so build the caption yourself using this skill rather than passing raw text.
+
+Minimal valid caption:
+
+```json
+{"high_level_description":"A sailboat at sunset on calm water.","style_description":{"aesthetics":"serene, warm, golden hour","lighting":"golden hour backlighting","photo":"wide angle, f/8","medium":"photograph","color_palette":["#FF6B35","#F7C59F","#004E89"]},"compositional_deconstruction":{"background":"Calm ocean at low horizon with orange-pink sky.","elements":[{"type":"obj","desc":"White triangular sail silhouetted against the setting sun."}]}}
+```
+
+Full schema, strict key-ordering rules, and the bbox coordinate system are in **`prompting.md`**.
+Worked title-card / thumbnail / quote-card examples are in **`examples.md`**.
+
+## Quick Reference — `tools/ideogram4.py`
+
+> Thin wrapper over Ideogram's hosted v4 API. Needs `IDEOGRAM_API_KEY` in `.env`
+> (key from developer.ideogram.ai). `--json` posts the caption as the API's `json_prompt`
+> field (no server-side magic prompt — Claude is the expander); `--prompt` posts `text_prompt`.
+
+```bash
+# Hand-authored JSON caption (the recommended path for text/layout) — Claude writes caption.json
+python3 tools/ideogram4.py --json caption.json --output title.png
+
+# Caption from stdin (Claude can pipe it directly)
+cat caption.json | python3 tools/ideogram4.py --json - --output title.png
+
+# Plain prompt — Ideogram's server-side magic prompt expands it (weaker; prefer --json)
+python3 tools/ideogram4.py --prompt "Title card: 'AI ENGINEERING REVIEW' bold white on dark" --output title.png
+
+# Inject brand hex colors into the caption's palette (JSON mode)
+python3 tools/ideogram4.py --json caption.json --brand digital-samba --output cta.png
+
+# Quality tier + resolution
+python3 tools/ideogram4.py --json caption.json --speed QUALITY --resolution 2048x2048 --output slide.png
+```
+
+## Key Files
+
+- `prompting.md` — full JSON schema, strict key ordering, bbox coordinate system, palette rules
+- `examples.md` — worked captions for title cards, thumbnails, quote cards, brand CTAs
+
+## Video Production Fit
+
+Ideogram 4's niche in the toolkit is **slides and thumbnails with baked-in text**, where FLUX and
+LTX-2 fail (both render garbled text). Natural pairings:
+
+| Use case | Why Ideogram 4 |
+|----------|----------------|
+| Title-card / CTA background **with headline text** | Legible text + exact brand hex colors in one pass |
+| YouTube/social **thumbnail with a punchy phrase** | Big readable text is its strongest suit |
+| Quote card / stat card | Multi-line text + layout control via bboxes |
+| Signage/logos inside a product-demo scene | In-image text other models can't render |
+
+Then feed the still into Remotion (`<OffthreadVideo>`/`Img`) or animate it with `tools/ltx2.py --input`.

--- a/.claude/skills/ideogram4/examples.md
+++ b/.claude/skills/ideogram4/examples.md
@@ -1,0 +1,224 @@
+# Ideogram 4 — Worked Examples
+
+Real caption examples for the toolkit's bread-and-butter use cases. Each shows the user's casual
+ask and the JSON caption Claude should produce (this *is* the magic-prompt expansion). JSON is
+shown pretty-printed for readability — serialize compact (`separators=(",",":")`) when passing.
+
+---
+
+## 1. Title card with headline text (the flagship use case)
+
+**User:** "Title card for the AI Engineering Review video — big bold 'AI ENGINEERING REVIEW' on a
+dark techy background."
+
+```json
+{
+  "high_level_description": "A dark modern tech title card with a large bold headline reading 'AI ENGINEERING REVIEW' centered in the upper-middle.",
+  "style_description": {
+    "aesthetics": "bold, modern, high-contrast corporate tech, generous negative space",
+    "lighting": "soft cyan rim glow from below, deep shadows",
+    "medium": "flat vector graphic design with subtle gradient backdrop",
+    "art_style": "minimalist tech poster, clean geometric",
+    "color_palette": ["#0B0B1A", "#00E0C6", "#1B2A4A", "#FFFFFF"]
+  },
+  "compositional_deconstruction": {
+    "background": "Deep near-black navy gradient with a faint geometric grid and a soft cyan glow rising from the lower edge.",
+    "elements": [
+      {
+        "type": "text",
+        "bbox": [340, 120, 540, 880],
+        "text": "AI ENGINEERING REVIEW",
+        "desc": "Bold heavy sans-serif headline, all caps, crisp white, tight letter spacing, centered.",
+        "color_palette": ["#FFFFFF"]
+      },
+      {
+        "type": "obj",
+        "bbox": [580, 380, 620, 620],
+        "desc": "A thin glowing cyan horizontal accent rule beneath the headline.",
+        "color_palette": ["#00E0C6"]
+      }
+    ]
+  }
+}
+```
+
+Why it works: the headline is a `text` element with the literal string (legible-text strength),
+the brand cyan is pinned via per-element palette on the accent rule, and the bbox keeps the title
+in the upper-middle band.
+
+---
+
+## 2. Thumbnail with a punchy phrase
+
+**User:** "YouTube thumbnail, the words 'SHIP FASTER' huge on the left, a rocket on the right."
+
+```json
+{
+  "high_level_description": "A high-energy thumbnail with the huge two-line phrase 'SHIP FASTER' on the left and a stylized rocket launching on the right.",
+  "style_description": {
+    "aesthetics": "loud, saturated, high-energy, big-text thumbnail style",
+    "lighting": "bright punchy lighting with strong contrast",
+    "medium": "bold flat illustration",
+    "art_style": "modern poster illustration, thick outlines",
+    "color_palette": ["#FF3B30", "#FFD60A", "#0B0B1A", "#FFFFFF"]
+  },
+  "compositional_deconstruction": {
+    "background": "Bold diagonal split background, deep navy on the right, warm yellow burst on the left.",
+    "elements": [
+      {
+        "type": "text",
+        "bbox": [250, 40, 750, 520],
+        "text": "SHIP FASTER",
+        "desc": "Massive heavy condensed sans-serif, two lines, all caps, white with a thick dark outline, left-aligned.",
+        "color_palette": ["#FFFFFF", "#0B0B1A"]
+      },
+      {
+        "type": "obj",
+        "bbox": [200, 560, 850, 960],
+        "desc": "A stylized cartoon rocket launching upward with a bright flame trail, slight tilt.",
+        "color_palette": ["#FF3B30", "#FFD60A", "#FFFFFF"]
+      }
+    ]
+  }
+}
+```
+
+Keep thumbnail phrases to 1–3 words — that's where the text rendering is strongest.
+
+---
+
+## 3. Brand CTA with exact colors
+
+**User:** "End-card CTA for Digital Samba: 'Start your free trial' button, on-brand colors."
+
+> When the user names a brand, read `brands/<brand>/brand.json` for the real hex values and place
+> them in the palettes. The placeholders below stand in for those.
+
+```json
+{
+  "high_level_description": "A clean end-card with the headline 'Start your free trial' and a rounded call-to-action button, in Digital Samba brand colors.",
+  "style_description": {
+    "aesthetics": "clean, trustworthy, modern SaaS",
+    "lighting": "even soft lighting, airy",
+    "medium": "flat UI-style vector graphic",
+    "art_style": "minimal product marketing card, lots of whitespace",
+    "color_palette": ["#FFFFFF", "#1456F0", "#0B1B3A"]
+  },
+  "compositional_deconstruction": {
+    "background": "Soft white-to-pale-blue gradient, very clean.",
+    "elements": [
+      {
+        "type": "text",
+        "bbox": [300, 150, 460, 850],
+        "text": "Start your free trial",
+        "desc": "Friendly bold sans-serif headline, dark navy, centered.",
+        "color_palette": ["#0B1B3A"]
+      },
+      {
+        "type": "obj",
+        "bbox": [560, 340, 680, 660],
+        "desc": "A rounded rectangular button with subtle shadow.",
+        "color_palette": ["#1456F0"]
+      },
+      {
+        "type": "text",
+        "bbox": [585, 360, 655, 640],
+        "text": "Get started free",
+        "desc": "Button label, medium-weight white sans-serif, centered on the button.",
+        "color_palette": ["#FFFFFF"]
+      }
+    ]
+  }
+}
+```
+
+Note the layered text-over-object: the button is an `obj`, its label is a separate `text` element
+with a tighter bbox sitting inside the button's bbox.
+
+---
+
+## 4. Quote / stat card (multi-line text + layout)
+
+**User:** "Stat card: big '94%' with 'of teams shipped faster' underneath."
+
+```json
+{
+  "high_level_description": "A minimal stat card with a giant '94%' figure and the supporting line 'of teams shipped faster' beneath it.",
+  "style_description": {
+    "aesthetics": "confident, minimal, data-forward",
+    "lighting": "flat even studio light",
+    "medium": "flat vector graphic design",
+    "art_style": "clean infographic card",
+    "color_palette": ["#0B0B1A", "#00E0C6", "#FFFFFF"]
+  },
+  "compositional_deconstruction": {
+    "background": "Solid deep navy with a faint radial glow behind the figure.",
+    "elements": [
+      {
+        "type": "text",
+        "bbox": [220, 250, 560, 750],
+        "text": "94%",
+        "desc": "Enormous bold sans-serif figure, bright cyan, centered.",
+        "color_palette": ["#00E0C6"]
+      },
+      {
+        "type": "text",
+        "bbox": [600, 200, 700, 800],
+        "text": "of teams shipped faster",
+        "desc": "Medium-weight white sans-serif subline, centered beneath the figure.",
+        "color_palette": ["#FFFFFF"]
+      }
+    ]
+  }
+}
+```
+
+---
+
+## 5. Photographic scene (when to use `photo`)
+
+**User:** "A photo of a modern office at golden hour for a background, no text."
+
+```json
+{
+  "high_level_description": "A warm, modern open-plan office bathed in golden-hour light, no text.",
+  "style_description": {
+    "aesthetics": "warm, aspirational, editorial",
+    "lighting": "golden hour sunlight streaming through floor-to-ceiling windows, long soft shadows",
+    "photo": "35mm, f/2.8, shallow depth of field, eye-level",
+    "medium": "photograph",
+    "color_palette": ["#F4C77E", "#3A2E25", "#D9C8B4"]
+  },
+  "compositional_deconstruction": {
+    "background": "Open-plan office with wood desks and plants, large windows with sun flare at the far end.",
+    "elements": [
+      {
+        "type": "obj",
+        "bbox": [350, 100, 800, 500],
+        "desc": "A wooden desk with an open laptop and a steaming coffee mug, foreground left.",
+        "color_palette": ["#6B4E2E", "#1B1B1B"]
+      },
+      {
+        "type": "obj",
+        "bbox": [300, 600, 750, 780],
+        "desc": "A leafy potted plant catching warm backlight.",
+        "color_palette": ["#3E5C2E"]
+      }
+    ]
+  }
+}
+```
+
+Note the key order flips for photos: `aesthetics → lighting → photo → medium → color_palette`.
+
+---
+
+## Good vs. bad at a glance
+
+| Bad (plain text) | Good (JSON caption) |
+|------------------|---------------------|
+| `"Title card saying AI Engineering Review"` | Example 1 — headline as a `text` element, bbox, brand palette |
+| Text described inside `desc` | Literal string in the `text` field of a `text` element |
+| `color: blue` | `"color_palette": ["#1456F0"]` (uppercase hex, per element) |
+| Paragraph of body copy in one text element | 1–3 word headline + short subline, each its own element |
+| Lowercase hex `#1456f0` | Uppercase `#1456F0` |

--- a/.claude/skills/ideogram4/prompting.md
+++ b/.claude/skills/ideogram4/prompting.md
@@ -1,0 +1,139 @@
+# Ideogram 4 — JSON Caption Prompting
+
+Ideogram 4 is trained **exclusively** on structured JSON captions where every element is named
+explicitly. This file is the reference for building those captions. The whole prompt-adherence and
+text-rendering advantage flows from following this schema precisely — including its quirks (strict
+key ordering, an unusual bbox axis order).
+
+## Top-Level Structure
+
+A caption is a JSON object with three top-level fields:
+
+| Field | Required | Purpose |
+|-------|----------|---------|
+| `high_level_description` | Optional but **strongly recommended** | 1–2 sentence summary of the whole image |
+| `style_description` | Optional object | Visual aesthetics, medium, global color palette |
+| `compositional_deconstruction` | **Required** object | Spatial layout: background + every element |
+
+## `style_description`
+
+Must contain **exactly one** of `photo` or `art_style`:
+- `photo` — for photographic images
+- `art_style` — for illustrations, paintings, 3D renders, vector/graphic design
+
+Required keys when the block is present: `aesthetics`, `lighting`, `medium`. Optional: `color_palette`.
+
+### Strict key ordering (this matters)
+
+> "The model was trained on JSON with a consistent key order, so maintaining it improves
+> generation quality." Deviating is *allowed* but samples outside the training distribution.
+
+- **Photos:** `aesthetics` → `lighting` → `photo` → `medium` → `color_palette`
+- **Non-photos:** `aesthetics` → `lighting` → `medium` → `art_style` → `color_palette`
+
+```json
+"style_description": {
+  "aesthetics": "bold, modern, high-contrast corporate",
+  "lighting": "flat even studio lighting, no harsh shadows",
+  "medium": "flat vector graphic design, clean geometric",
+  "art_style": "minimalist tech poster, generous negative space",
+  "color_palette": ["#0B0B1A", "#00E0C6", "#FFFFFF"]
+}
+```
+
+## `compositional_deconstruction`
+
+Two required fields:
+- `background` — string describing the environment / backdrop
+- `elements` — array of objects and text, each with a **fixed key order**
+
+### Element: object (`type: "obj"`)
+
+Key order: `type` → `bbox` → `desc` → `color_palette`
+
+```json
+{ "type": "obj", "bbox": [200, 100, 800, 450], "desc": "A sleek silver laptop, three-quarter view, screen glowing.", "color_palette": ["#C0C0C0", "#1B1B2F"] }
+```
+
+### Element: text (`type: "text"`)
+
+Key order: `type` → `bbox` → `text` → `desc` → `color_palette`
+
+The `text` field holds the **literal string to render**; `desc` describes how it looks
+(font weight, style, placement feel).
+
+```json
+{ "type": "text", "bbox": [120, 80, 300, 920], "text": "AI ENGINEERING REVIEW", "desc": "Bold heavy sans-serif headline, all caps, crisp white, centered.", "color_palette": ["#FFFFFF"] }
+```
+
+## Bounding Boxes (`bbox`)
+
+- Format: **`[y_min, x_min, y_max, x_max]`** — note the **y-first** axis order (row before column).
+- Coordinates are **normalized 0–1000**, where `0` is top/left and `1000` is bottom/right.
+- Optional per element. Omit when you don't care where something lands; include for precise layout.
+
+Quick mental map (full frame is 0–1000 on each axis):
+
+```
+x:   0 ............... 500 ............... 1000
+y=0   ┌───────────────────────────────────┐
+      │  top band  [0,0, 250,1000]         │   ← headline / title text here
+      │                                    │
+y=500 │  center    [350,150, 650,850]      │   ← hero subject
+      │                                    │
+y=1000│  bottom    [800,0, 1000,1000]      │   ← CTA / footer text
+      └───────────────────────────────────┘
+```
+
+So a centered headline across the top third is `[80, 100, 280, 900]`
+(`y_min=80, x_min=100, y_max=280, x_max=900`).
+
+## Color Palette Rules
+
+- Up to **16** colors in `style_description.color_palette`; up to **5** per element.
+- Must be **uppercase hex**: `#RRGGBB` (e.g. `#1B1B2F`, not `#1b1b2f` or `rgb(...)`).
+- Include both background and contrast/accent colors for controlled lighting.
+- Per-element palettes override/steer that element specifically — ideal for forcing exact brand
+  colors on a logo or headline.
+
+## Serialization Quirks
+
+When emitting the JSON string the model consumes:
+- Use compact separators: `separators=(",", ":")` (no spaces) — the `--json` path in the tool
+  handles this; if hand-passing, compact JSON is safest.
+- `ensure_ascii=False` so non-ASCII / multilingual text passes through literally.
+- Preserve key order exactly as above.
+
+## Magic Prompt vs. Claude
+
+Ideogram ships an LLM "magic prompt" that expands plain text → JSON. Three configs exist:
+`ideogram-4-v1` (free hosted default), `claude-opus-v1`, `claude-sonnet-v1` (both via OpenRouter).
+Their docs warn the shipped expander "is **not** the same used in production — results will differ."
+
+**Claude Code runs on Opus.** So the highest-quality path is: Claude builds the caption directly
+using this skill, rather than round-tripping through the weaker free expander or adding an
+OpenRouter dependency. Treat *yourself* as the magic-prompt LLM.
+
+## Prompting Principles
+
+1. **Name every element explicitly.** The model rewards exhaustive captions. Don't write "a busy
+   office" — list the desk, the monitor, the plant, the window light.
+2. **Put literal on-image text in a `text` element**, never bury it in a description. This is what
+   unlocks the legible-text advantage.
+3. **Keep rendered strings reasonable.** A headline + subhead + CTA is fine (its strength); a
+   paragraph of body copy still degrades.
+4. **Use bboxes for layout-critical images** (title cards, thumbnails). Skip them for loose scenes.
+5. **Use per-element palettes to pin brand colors** on logos/headlines; global palette for mood.
+6. **Match the style block to intent** — `photo` for realism, `art_style` for design/graphic work.
+   Most title cards and thumbnails are `art_style`.
+
+## Common Pitfalls
+
+| Pitfall | Fix |
+|---------|-----|
+| Plain-text prompt, generic result | Build the JSON caption — that's the whole point |
+| Text rendered garbled/misspelled | Put it in a `text` element with the literal string in `text`, keep it short |
+| Wrong colors | Uppercase hex, per-element `color_palette` on the headline/logo |
+| Text in wrong spot | Add a `bbox` (remember y-first: `[y_min,x_min,y_max,x_max]`, 0–1000) |
+| Mediocre adherence | Add `high_level_description`; name more elements; keep key order |
+| `lowercase hex` ignored | Always `#RRGGBB` uppercase |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,44 @@ modal deploy docker/modal-image-edit/app.py
 # See docs/modal-setup.md for full guide
 ```
 
+### AI Image Generation (FLUX.2 vs Ideogram 4)
+
+The toolkit has **two** text-to-image generators. They barely overlap — the deciding factor is
+**whether the image needs legible baked-in text**.
+
+```bash
+# FLUX.2 — text-FREE backgrounds + image editing (self-hosted, free, Apache-2.0/commercial-OK)
+python tools/flux2.py --preset title-bg --brand digital-samba   # background for Remotion text overlay
+python tools/flux2.py --prompt "Abstract tech background, no text"
+
+# Ideogram 4 — legible IN-IMAGE text + exact color/layout (hosted API, ~$0.03-0.09/img, commercial-OK)
+python3 tools/ideogram4.py --json caption.json --output title.png   # text baked into the image
+python3 tools/ideogram4.py --prompt "Thumbnail: 'SHIP FASTER' bold" --output thumb.png
+```
+
+**The key distinction — baked-in text vs. background-for-overlay:**
+
+- **FLUX.2 presets deliberately produce text-*free* backgrounds** (`title-bg`, `cta`, `thumbnail`
+  all end with "no text, no words, no letters"). The intended pattern is **FLUX background →
+  Remotion renders the text on top**, so the text stays editable, animatable per-letter, and
+  frame-accurate. This is the right default for sprint-review **title cards / lower-thirds**.
+- **Ideogram 4 bakes legible designed text *into* a flat PNG.** Pixel-perfect typography + exact
+  hex colors in one shot, but static. Reach for it when **the text *is* the design**: YouTube/social
+  thumbnails (static anyway), quote/stat cards, in-scene signage/logos, stylized text effects that
+  Remotion overlays can't easily do. It fills a real gap — FLUX and LTX-2 both garble in-image text.
+
+| Need | Use |
+|------|-----|
+| Animated/editable title text, lower-thirds, sprint-review title cards | **FLUX.2 bg + Remotion text** |
+| Atmospheric/abstract backgrounds, problem/solution illustrations, presenter backdrops | **FLUX.2** presets |
+| Finished graphic where typography is the design — thumbnails, quote cards, in-scene signage | **Ideogram 4** |
+| Edit an existing photo (clothing, reframe, style, background) | **image_edit** (neither generator edits) |
+
+Ideogram 4 chains with the processors like any generator: `ideogram4 → upscale.py` (crisp 4K),
+`ideogram4 → ltx2.py --input` (animate the still), or drop the PNG straight into Remotion `<Img>`.
+Ideogram 4 is generate-only here (no editing). See `.claude/skills/ideogram4/` for the JSON caption
+format — Claude authors the caption as the "magic prompt" expander; needs `IDEOGRAM_API_KEY` in `.env`.
+
 ### AI Image Editing
 
 ```bash

--- a/_internal/toolkit-registry.json
+++ b/_internal/toolkit-registry.json
@@ -90,7 +90,7 @@
       "status": "beta",
       "category": "image-generation",
       "backend": "ideogram-4 hosted v4 API (json_prompt)",
-      "note": "Skill (prompting) landed; tools/ideogram4.py pending — issue #25. Hosted paid API (commercial license, ~$0.03–0.09/img); not self-hosted. Needs IDEOGRAM_API_KEY.",
+      "note": "Skill teaches the JSON caption format; Claude is the magic-prompt expander. Tool: tools/ideogram4.py. Hosted paid API (commercial license, ~$0.03–0.09/img); not self-hosted. Needs IDEOGRAM_API_KEY.",
       "created": "2026-06-08",
       "updated": "2026-06-08"
     }
@@ -579,7 +579,7 @@
         ],
         "brand": true
       },
-      "note": "Commercial license via paid API. Skill `.claude/skills/ideogram4/` teaches the JSON caption format; Claude is the magic-prompt expander. Issue #25 — pending live test."
+      "note": "Commercial license via paid API. Skill `.claude/skills/ideogram4/` teaches the JSON caption format; Claude is the magic-prompt expander. Live-tested (json_prompt + text_prompt paths)."
     },
     "ltx2": {
       "path": "tools/ltx2.py",

--- a/_internal/toolkit-registry.json
+++ b/_internal/toolkit-registry.json
@@ -83,6 +83,16 @@
       "status": "beta",
       "created": "2026-04-08",
       "updated": "2026-04-08"
+    },
+    "ideogram4": {
+      "path": ".claude/skills/ideogram4/",
+      "description": "Prompting patterns for Ideogram 4 text-to-image — structured JSON captions for best-in-class in-image text, color-palette and bounding-box layout control (title cards, thumbnails, CTAs)",
+      "status": "beta",
+      "category": "image-generation",
+      "backend": "ideogram-4 hosted v4 API (json_prompt)",
+      "note": "Skill (prompting) landed; tools/ideogram4.py pending — issue #25. Hosted paid API (commercial license, ~$0.03–0.09/img); not self-hosted. Needs IDEOGRAM_API_KEY.",
+      "created": "2026-06-08",
+      "updated": "2026-06-08"
     }
   },
   "commands": {
@@ -548,6 +558,29 @@
       "created": "2026-03-14",
       "updated": "2026-03-15"
     },
+    "ideogram4": {
+      "path": "tools/ideogram4.py",
+      "description": "Ideogram 4 text-to-image via hosted v4 API — best-in-class in-image text rendering and exact color/layout control through structured JSON captions",
+      "usage": "python3 tools/ideogram4.py --json caption.json --output title.png",
+      "status": "beta",
+      "category": "image-generation",
+      "backend": "ideogram-4 hosted v4 API",
+      "requires": "IDEOGRAM_API_KEY (developer.ideogram.ai)",
+      "options": {
+        "modes": [
+          "json_prompt (--json)",
+          "text_prompt (--prompt)"
+        ],
+        "rendering_speed": [
+          "FLASH",
+          "TURBO",
+          "DEFAULT",
+          "QUALITY"
+        ],
+        "brand": true
+      },
+      "note": "Commercial license via paid API. Skill `.claude/skills/ideogram4/` teaches the JSON caption format; Claude is the magic-prompt expander. Issue #25 — pending live test."
+    },
     "ltx2": {
       "path": "tools/ltx2.py",
       "description": "AI video generation using LTX-2.3 22B - text-to-video, image-to-video clips with synchronized audio",
@@ -605,7 +638,10 @@
         ],
         "perScenePrompts": "--prompts-file scenes.json",
         "resume": "auto-skips existing clips",
-        "progress": ["json", "human"],
+        "progress": [
+          "json",
+          "human"
+        ],
         "prefix": "chain (default)"
       },
       "envVars": [

--- a/tools/config.py
+++ b/tools/config.py
@@ -65,6 +65,13 @@ def get_acemusic_api_key() -> str | None:
     return os.getenv("ACEMUSIC_API_KEY")
 
 
+def get_ideogram_api_key() -> str | None:
+    """Get Ideogram (hosted v4 API) key from environment."""
+    from dotenv import load_dotenv
+    load_dotenv()
+    return os.getenv("IDEOGRAM_API_KEY")
+
+
 def get_runpod_api_key() -> str | None:
     """Get RunPod API key from environment."""
     from dotenv import load_dotenv

--- a/tools/ideogram4.py
+++ b/tools/ideogram4.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""
+AI text-to-image generation using Ideogram 4 (hosted v4 API).
+
+Ideogram 4's strength is best-in-class *in-image text rendering* plus exact color and
+layout control — ideal for title cards, thumbnails, and CTAs with baked-in text. That
+advantage lives in the model's structured JSON caption format. See the `ideogram4` skill
+(.claude/skills/ideogram4/) for how to author captions; Claude is the recommended
+"magic prompt" expander.
+
+Backend: Ideogram's hosted v4 API (POST /v1/ideogram-v4/generate). Paid plans include a
+commercial license. Needs IDEOGRAM_API_KEY in .env (get a key at developer.ideogram.ai).
+
+Two prompt modes (mutually exclusive, mirroring the API's text_prompt vs json_prompt):
+  --json    Post a structured JSON caption as json_prompt (recommended for text/layout).
+            Claude authors the caption via the ideogram4 skill. Pass a file or '-' for stdin.
+  --prompt  Post plain text as text_prompt (Ideogram's server-side magic prompt expands it).
+
+Examples:
+  # Structured caption (recommended) — Claude writes caption.json via the skill
+  python3 tools/ideogram4.py --json caption.json --output title.png
+
+  # Caption from stdin
+  cat caption.json | python3 tools/ideogram4.py --json - --output title.png
+
+  # Plain prompt (server-side magic prompt)
+  python3 tools/ideogram4.py --prompt "Title card: 'AI ENGINEERING REVIEW' bold white on dark" --output title.png
+
+  # Inject brand palette into a JSON caption's style_description.color_palette
+  python3 tools/ideogram4.py --json caption.json --brand digital-samba --output cta.png
+
+  # Quality tier + resolution
+  python3 tools/ideogram4.py --json caption.json --speed QUALITY --resolution 2048x2048 --output slide.png
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+try:
+    import requests
+    from dotenv import load_dotenv
+except ImportError as e:
+    print(f"Missing dependency: {e}")
+    print("Install with: pip install requests python-dotenv")
+    sys.exit(1)
+
+load_dotenv()
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+API_URL = "https://api.ideogram.ai/v1/ideogram-v4/generate"
+RENDERING_SPEEDS = ["FLASH", "TURBO", "DEFAULT", "QUALITY"]
+# Rough per-image cost by tier (USD) for cost-awareness logging.
+SPEED_COST = {"FLASH": 0.02, "TURBO": 0.03, "DEFAULT": 0.06, "QUALITY": 0.09}
+
+
+def log(msg: str, level: str = "info"):
+    """Print formatted log message."""
+    colors = {
+        "info": "\033[94m",
+        "success": "\033[92m",
+        "error": "\033[91m",
+        "warn": "\033[93m",
+        "dim": "\033[90m",
+    }
+    reset = "\033[0m"
+    prefix = {"info": "->", "success": "OK", "error": "!!", "warn": "??", "dim": "  "}
+    color = colors.get(level, "")
+    print(f"{color}{prefix.get(level, '->')} {msg}{reset}", file=sys.stderr)
+
+
+def load_brand_palette(brand_name: str) -> list[str]:
+    """Load brand.json and return its colors as uppercase #RRGGBB hex strings."""
+    workspace = Path(__file__).parent.parent
+    brand_path = workspace / "brands" / brand_name / "brand.json"
+    if not brand_path.exists():
+        log(f"Brand not found: {brand_path}", "warn")
+        return []
+    try:
+        brand = json.loads(brand_path.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        log(f"Error reading brand: {e}", "warn")
+        return []
+
+    palette: list[str] = []
+    for value in (brand.get("colors") or {}).values():
+        if isinstance(value, str) and value.startswith("#") and len(value) in (4, 7):
+            hx = value.upper()
+            if hx not in palette:
+                palette.append(hx)
+    return palette[:16]  # API caps style palette at 16
+
+
+def read_caption(source: str) -> dict:
+    """Read a JSON caption from a file path or '-' for stdin. Returns the parsed object."""
+    raw = sys.stdin.read() if source == "-" else Path(source).read_text()
+    caption = json.loads(raw)
+    if not isinstance(caption, dict):
+        raise ValueError("JSON caption must be an object (got a non-object top level)")
+    return caption
+
+
+def inject_brand_palette(caption: dict, palette: list[str]) -> dict:
+    """Merge brand hex colors into the caption's style_description.color_palette.
+
+    Brand colors are prepended (they take priority) and de-duplicated; existing palette
+    colors are preserved after them. Capped at the API's 16-color limit.
+    """
+    if not palette:
+        return caption
+    style = caption.setdefault("style_description", {})
+    existing = style.get("color_palette") or []
+    merged = palette + [c for c in existing if c.upper() not in {p.upper() for p in palette}]
+    style["color_palette"] = merged[:16]
+    return caption
+
+
+def generate(
+    api_key: str,
+    *,
+    text_prompt: Optional[str] = None,
+    json_prompt: Optional[dict] = None,
+    output_path: str,
+    rendering_speed: str = "DEFAULT",
+    resolution: Optional[str] = None,
+    copyright_detection: bool = False,
+    timeout: int = 300,
+) -> Optional[str]:
+    """Call the Ideogram v4 generate endpoint and download the result.
+
+    Exactly one of text_prompt / json_prompt must be provided. Returns the output path
+    on success, None on failure.
+    """
+    if (text_prompt is None) == (json_prompt is None):
+        log("Provide exactly one of text_prompt / json_prompt.", "error")
+        return None
+
+    # Multipart/form-data: send each field as (None, value). json_prompt is serialized
+    # compactly with non-ASCII preserved, per the model's caption format.
+    fields: dict[str, tuple] = {"rendering_speed": (None, rendering_speed)}
+    if text_prompt is not None:
+        fields["text_prompt"] = (None, text_prompt)
+        log(f"text_prompt: {text_prompt}", "info")
+    else:
+        caption_str = json.dumps(json_prompt, separators=(",", ":"), ensure_ascii=False)
+        fields["json_prompt"] = (None, caption_str)
+        hld = json_prompt.get("high_level_description", "")
+        log(f"json_prompt: {hld or '(structured caption)'}", "info")
+    if resolution:
+        fields["resolution"] = (None, resolution)
+    if copyright_detection:
+        fields["enable_copyright_detection"] = (None, "true")
+
+    cost = SPEED_COST.get(rendering_speed, 0.06)
+    log(f"Speed: {rendering_speed} (~${cost:.2f}/image)  Resolution: {resolution or 'API default'}", "dim")
+
+    try:
+        response = requests.post(
+            API_URL,
+            headers={"Api-Key": api_key},
+            files=fields,
+            timeout=timeout,
+        )
+    except requests.exceptions.Timeout:
+        log(f"Request timed out ({timeout}s)", "error")
+        return None
+    except requests.exceptions.RequestException as e:
+        log(f"Request failed: {e}", "error")
+        return None
+
+    if response.status_code != 200:
+        log(f"API returned HTTP {response.status_code}: {response.text[:500]}", "error")
+        return None
+
+    try:
+        result = response.json()
+    except json.JSONDecodeError:
+        log("Invalid JSON response from API", "error")
+        return None
+
+    images = result.get("data") or []
+    urls = [img.get("url") for img in images if isinstance(img, dict) and img.get("url")]
+    if not urls:
+        log(f"No image URL in response: {json.dumps(result)[:500]}", "error")
+        return None
+
+    # Download. If multiple images came back, suffix _2, _3, ...
+    out = Path(output_path)
+    saved: list[str] = []
+    for i, url in enumerate(urls):
+        target = out if i == 0 else out.with_name(f"{out.stem}_{i + 1}{out.suffix}")
+        try:
+            img_resp = requests.get(url, timeout=timeout)
+            img_resp.raise_for_status()
+            target.write_bytes(img_resp.content)
+        except requests.exceptions.RequestException as e:
+            log(f"Download failed for {url}: {e}", "error")
+            continue
+        saved.append(str(target))
+        meta = images[i]
+        log(
+            f"Saved: {target} ({len(img_resp.content) // 1024} KB)"
+            f"{'  seed=' + str(meta.get('seed')) if meta.get('seed') is not None else ''}"
+            f"{'  safe=' + str(meta.get('is_image_safe')) if 'is_image_safe' in meta else ''}",
+            "success",
+        )
+
+    if not saved:
+        return None
+
+    if sys.platform == "darwin":
+        import subprocess
+        subprocess.run(["open", saved[0]], check=False)
+
+    return saved[0]
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Ideogram 4 text-to-image (hosted v4 API) — best-in-class in-image text.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --json caption.json --output title.png
+  cat caption.json | %(prog)s --json - --output title.png
+  %(prog)s --prompt "Title card: 'SHIP FASTER' bold" --output thumb.png
+  %(prog)s --json caption.json --brand digital-samba --speed QUALITY --output cta.png
+
+Authoring captions: see the `ideogram4` skill (.claude/skills/ideogram4/). The --json path
+posts the caption as the API's json_prompt (no server-side magic prompt — Claude is the expander).
+        """,
+    )
+
+    prompt_group = parser.add_mutually_exclusive_group(required=True)
+    prompt_group.add_argument(
+        "--json", dest="json_src", metavar="FILE",
+        help="Structured JSON caption file (or '-' for stdin) — posted as json_prompt",
+    )
+    prompt_group.add_argument(
+        "--prompt", "-p",
+        help="Plain text prompt — posted as text_prompt (server-side magic prompt expands it)",
+    )
+
+    parser.add_argument("--output", "-o", required=True, help="Output PNG path")
+    parser.add_argument("--brand", help="Brand name — inject brands/<name>/brand.json colors into the caption palette (JSON mode)")
+    parser.add_argument("--speed", choices=RENDERING_SPEEDS, default="DEFAULT",
+                        help="Rendering speed / quality tier (default: DEFAULT)")
+    parser.add_argument("--resolution", help="Resolution e.g. 2048x2048 (omit for API default; see Ideogram docs for valid values)")
+    parser.add_argument("--copyright-detection", action="store_true",
+                        help="Enable Ideogram's copyright detection")
+    parser.add_argument("--timeout", type=int, default=300, help="Request timeout seconds (default: 300)")
+    parser.add_argument("--json-out", action="store_true", help="Emit a machine-readable result line to stdout")
+
+    args = parser.parse_args()
+
+    from config import get_ideogram_api_key
+    api_key = get_ideogram_api_key()
+    if not api_key:
+        log("IDEOGRAM_API_KEY not set.", "error")
+        log("Get a key at https://developer.ideogram.ai/ then: echo 'IDEOGRAM_API_KEY=your_key' >> .env", "info")
+        sys.exit(1)
+
+    text_prompt = None
+    json_prompt = None
+    if args.json_src is not None:
+        try:
+            json_prompt = read_caption(args.json_src)
+        except (json.JSONDecodeError, OSError, ValueError) as e:
+            log(f"Could not read JSON caption: {e}", "error")
+            sys.exit(1)
+        if args.brand:
+            palette = load_brand_palette(args.brand)
+            if palette:
+                json_prompt = inject_brand_palette(json_prompt, palette)
+                log(f"Brand palette: {', '.join(palette)}", "dim")
+    else:
+        text_prompt = args.prompt
+        if args.brand:
+            log("--brand only applies in --json mode (no palette field in plain text). Ignoring.", "warn")
+
+    print(file=sys.stderr)
+    log("Ideogram 4 (hosted v4 API)", "info")
+
+    result = generate(
+        api_key,
+        text_prompt=text_prompt,
+        json_prompt=json_prompt,
+        output_path=args.output,
+        rendering_speed=args.speed,
+        resolution=args.resolution,
+        copyright_detection=args.copyright_detection,
+        timeout=args.timeout,
+    )
+
+    if args.json_out:
+        print(json.dumps({"success": result is not None, "output": result}))
+
+    sys.exit(0 if result else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds **Ideogram 4** as a second text-to-image generator, specialised for **legible in-image text** — title cards, thumbnails, CTAs, quote/stat cards, in-scene signage — plus exact hex color palettes and bounding-box layout. This fills a real gap: FLUX.2 and LTX-2 both garble baked-in text.

Closes #25.

## What's included

- **`tools/ideogram4.py`** — thin multipart wrapper over the hosted v4 API (`POST /v1/ideogram-v4/generate`, `Api-Key` header). Mutually-exclusive `--json` (structured `json_prompt`, the quality path) and `--prompt` (`text_prompt`, server-side magic prompt). `--brand` injects `brand.json` hex colors into the caption palette; `--speed FLASH/TURBO/DEFAULT/QUALITY`; `--resolution`; stdin via `--json -`.
- **`ideogram4` skill** (`.claude/skills/ideogram4/`) — teaches the structured JSON caption format (SKILL.md + prompting.md + examples.md). Claude acts as the magic-prompt expander, which beats the weaker free hosted one.
- **`get_ideogram_api_key()`** in `tools/config.py`; registry entries for skill + tool.
- **CLAUDE.md** — FLUX.2-vs-Ideogram-4 decision guidance (baked-in text vs. background-for-Remotion-overlay).

## Why the hosted API (not self-hosting)

The v4 weights are **non-commercial**-licensed; the toolkit does commercial work. The paid API includes a commercial license, and crucially its `json_prompt` field preserves the *entire* prompting-skill value (~$0.03–0.09/image). It also avoids baking a ~9GB image and the RunPod worker-slot ceiling.

## How it fits the existing tools

Only FLUX.2 and Ideogram 4 generate from scratch; the rest edit/upscale/process. The split:
- **FLUX.2** → text-free backgrounds for Remotion to overlay animated text on (sprint-review title cards), abstract/illustration visuals. Free, self-hosted.
- **Ideogram 4** → finished graphics where typography *is* the design (thumbnails, quote cards, signage).

Chains like any generator: `ideogram4 → upscale.py`, `ideogram4 → ltx2.py --input`, or straight into Remotion `<Img>`.

## Testing

Tested live against the real API:
- `--json` title card → crisp legible "AI ENGINEERING REVIEW", exact layout/colors/accent rule
- `--prompt` thumbnail → renders correctly
- `resolution=2048x2048` accepted; response `data[].url`/`seed`/`is_image_safe` parsed correctly

Local checks (no key): syntax, `--help`, arg mutual-exclusion, no-key error path, brand palette de-dup/prepend, compact key-order-preserving serialization.

> Note: requires `IDEOGRAM_API_KEY` in `.env` (key from developer.ideogram.ai). The full valid `resolution` enum beyond `2048x2048` isn't yet enumerated — the tool passes the value through and surfaces API errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)