### PR TITLE
Add TTS pacing QC: per-take wpm reporting + --max-wpm auto-clamp

### DIFF
--- a/.claude/commands/voice-clone.md
+++ b/.claude/commands/voice-clone.md
@@ -45,14 +45,15 @@ If the selected brand already has a clone profile, show the existing config and 
 
 ## Step 3: Record or Provide Reference Audio
 
-Present a reference script for the user to read aloud. The script should be ~10-15 seconds and include varied intonation:
+Present a reference script for the user to read aloud. The script should be ~15-20 seconds and include varied intonation:
 
 ```
-Suggested script to read aloud (~12 seconds):
+Suggested script to read aloud (~15 seconds):
 
   "Welcome to this video walkthrough. Today we'll explore some exciting
    new features — including improved performance, better accessibility,
-   and a redesigned dashboard. Let's get started!"
+   and a redesigned dashboard. There's a lot to cover, so let's take it
+   step by step and get started!"
 
 Options:
   1. I'll record this script (provide the file path when ready)
@@ -60,10 +61,26 @@ Options:
   3. Use an existing file (enter path)
 ```
 
+**Read it at the pace you want the clone to narrate at.** The clone inherits
+its speaking rate from the reference, and temperature/regeneration cannot
+correct pace afterwards — a short, snappy reference reliably produces rushed
+(170-210 wpm) narration on every take.
+
 Once the user provides the audio file:
 1. Verify the file exists and is a supported format (wav, mp3, m4a, flac, ogg)
-2. Copy it to `brands/{name}/assets/voice-reference.{ext}`
-3. Confirm the copy
+2. **Validate the reference** before accepting it:
+   ```bash
+   ffprobe -v error -show_entries format=duration -of csv=p=0 REFERENCE_FILE
+   ```
+   - Duration **< 8s**: warn strongly — too little prosody to anchor pace or
+     tone; the clone will sound rushed and flat. Recommend re-recording.
+   - Duration **8-12s**: usable, but suggest a longer take if convenient.
+   - Duration **12-25s**: ideal.
+   - Also sanity-check content: fewer than ~25 words of varied, full-sentence
+     speech (e.g. a repeated short phrase like "Thank you. Thank you.") gives
+     the model no narration pacing to copy — warn and offer to proceed anyway.
+3. Copy it to `brands/{name}/assets/voice-reference.{ext}`
+4. Confirm the copy
 
 ## Step 4: Transcript
 
@@ -182,8 +199,9 @@ automatically whenever you use --brand {name} with --provider qwen3.
 Share these with the user:
 
 - **Recording quality matters** — use a quiet room, consistent mic distance
-- **10-15 seconds** of reference audio is ideal (too short = poor quality, too long = diminishing returns)
-- **Varied intonation** helps — include questions, emphasis, and natural pauses
+- **12-25 seconds** of reference audio is ideal (too short = poor quality + rushed pace, too long = diminishing returns)
+- **The clone copies your pace** — read the reference at narration speed; rushed or punchy references produce rushed clones, and no generation setting fixes it afterwards (use `--max-wpm 165` on voiceover.py/qwen3_tts.py as a deterministic safety net)
+- **Varied intonation** helps — include questions, emphasis, and natural pauses; avoid repeating one short phrase
 - **Transcript accuracy** is critical — must match the audio exactly
 - **Supported formats:** wav, mp3, m4a, flac, ogg (wav or m4a preferred)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -465,6 +465,12 @@ TTS engines do NOT consistently produce 150 WPM output. In practice:
 | Demo too fast for narration | Viewer can't follow | Decrease `playbackRate` or cut narration |
 | Demo too slow for narration | Waiting for demo to catch up | Increase `playbackRate` (1.5-2x typical) |
 | Pauses lost in TTS | Script felt spacious, audio feels rushed | Add explicit `<break time="1s"/>` in SSML or extend scene padding |
+| Cloned voice rushes | Scenes land >170 wpm; retakes also fast (temperature doesn't help) | Pace is inherited from the reference audio. Use `--max-wpm 165` (pitch-preserving atempo clamp, both voiceover.py and qwen3_tts.py), and record clone references as 12-25s of varied sentences *at narration pace* |
+
+**Pacing QC:** voiceover.py and qwen3_tts.py report `wpm` and a `pacing` label
+(fast/slow/ok) per generated file — check these before composition. Comfortable
+narration is 140-160 wpm; flag anything over ~170. `--max-wpm` turns the check
+into an automatic fix.
 
 ### Fixing Mismatches
 - **Voiceover too long**: Speed up demos, trim pauses, cut content

--- a/_internal/toolkit-registry.json
+++ b/_internal/toolkit-registry.json
@@ -195,7 +195,10 @@
       "usage": "python tools/voiceover.py --script SCRIPT.md --output out.mp3",
       "status": "stable",
       "created": "2025-12-08",
-      "updated": "2026-02-19"
+      "updated": "2026-06-09",
+      "options": {
+        "pacingQC": "results include wpm + pacing label (fast/slow/ok); --max-wpm clamps fast takes with pitch-preserving atempo (floor 0.85x)"
+      }
     },
     "music": {
       "path": "tools/music.py",
@@ -487,7 +490,8 @@
         "formats": [
           "mp3",
           "wav"
-        ]
+        ],
+        "pacingQC": "results include wpm + pacing label (fast/slow/ok); --max-wpm clamps fast takes with pitch-preserving atempo (floor 0.85x)"
       },
       "envVars": [
         "RUNPOD_API_KEY",
@@ -495,7 +499,7 @@
       ],
       "estimatedCost": "$0.005-0.10 per generation",
       "created": "2026-02-19",
-      "updated": "2026-02-19"
+      "updated": "2026-06-09"
     },
     "sync_timing": {
       "path": "tools/sync_timing.py",

--- a/tools/pacing.py
+++ b/tools/pacing.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Delivery-pace QC for TTS output.
+
+TTS engines drift in speaking rate — and cloned voices inherit pace from
+their reference audio in a way temperature cannot correct (a short, snappy
+reference reliably produces 170-210 wpm narration, retake after retake).
+Sampling more takes doesn't fix pace; measuring it and correcting
+deterministically does.
+
+This module provides the two halves of that fix:
+
+  * measure_wpm()/pace_label() — words-per-minute from script text + audio
+    duration, with "fast"/"slow"/"ok" labels for QC gates
+  * clamp_pace() — pitch-preserving ffmpeg `atempo` slow-down applied when
+    a take exceeds a target wpm (floor 0.85x so it never sounds processed)
+
+Used by voiceover.py and qwen3_tts.py (`--max-wpm`). Comfortable narration
+is ~140-160 wpm; see CLAUDE.md "Speaking Rate Tiers".
+"""
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Warn outside this band (only when the clip has enough words to measure).
+WARN_FAST_WPM = 170
+WARN_SLOW_WPM = 110
+
+# Below this many words a wpm figure is mostly noise — don't label it.
+MIN_WORDS_FOR_LABEL = 6
+
+# Never stretch harder than this; beyond it artifacts become audible.
+MIN_ATEMPO = 0.85
+
+_MARKUP = re.compile(
+    r"\[pause[^\]]*\]"          # [pause 1.0s] script markers
+    r"|<break[^>]*/?>"          # SSML <break time="1s"/>
+    r"|^\[(tone|instruct):[^\]]*\]\s*",  # per-scene header line
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def count_words(text: str) -> int:
+    """Spoken-word count: ignores pause markers, SSML breaks, tone headers."""
+    return len(_MARKUP.sub(" ", text).split())
+
+
+def measure_wpm(text: str, duration_seconds: float | None) -> float | None:
+    """Words per minute, or None if it can't be measured."""
+    if not duration_seconds or duration_seconds <= 0:
+        return None
+    words = count_words(text)
+    if words == 0:
+        return None
+    return round(words / duration_seconds * 60, 1)
+
+
+def pace_label(text: str, duration_seconds: float | None) -> tuple[float | None, str | None]:
+    """Return (wpm, label) where label is 'fast' | 'slow' | 'ok' | None.
+
+    None label means "not enough signal" (short clip or missing duration).
+    Note: pause markers stretch duration without adding words, so scripts
+    with long scripted pauses read slightly slow — treat 'slow' as a hint.
+    """
+    wpm = measure_wpm(text, duration_seconds)
+    if wpm is None or count_words(text) < MIN_WORDS_FOR_LABEL:
+        return wpm, None
+    if wpm > WARN_FAST_WPM:
+        return wpm, "fast"
+    if wpm < WARN_SLOW_WPM:
+        return wpm, "slow"
+    return wpm, "ok"
+
+
+def _probe_duration(path: str) -> float | None:
+    try:
+        out = subprocess.run(
+            ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+             "-of", "csv=p=0", str(path)],
+            capture_output=True, text=True, timeout=30,
+        )
+        return float(out.stdout.strip())
+    except (OSError, ValueError, subprocess.TimeoutExpired):
+        return None
+
+
+def clamp_pace(
+    audio_path: str,
+    text: str,
+    max_wpm: float,
+    min_atempo: float = MIN_ATEMPO,
+    verbose: bool = True,
+) -> dict:
+    """Slow `audio_path` in place (pitch-preserving) if it exceeds max_wpm.
+
+    Returns {applied, wpm, atempo?, duration_seconds?, error?}:
+      * applied=False, no error — pace was already within target
+      * applied=True — file replaced; duration_seconds is the new duration
+      * error set — ffmpeg/ffprobe problem; original file left untouched
+    """
+    duration = _probe_duration(audio_path)
+    wpm = measure_wpm(text, duration)
+    if wpm is None:
+        return {"applied": False, "wpm": None, "error": "could not measure wpm"}
+    if wpm <= max_wpm:
+        return {"applied": False, "wpm": wpm}
+
+    atempo = max(max_wpm / wpm, min_atempo)
+    suffix = Path(audio_path).suffix or ".mp3"
+    codec_args = ["-b:a", "192k"] if suffix.lower() == ".mp3" else []
+    tmp = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
+    tmp.close()
+    try:
+        r = subprocess.run(
+            ["ffmpeg", "-y", "-v", "error", "-i", str(audio_path),
+             "-filter:a", f"atempo={atempo:.4f}", *codec_args, tmp.name],
+            capture_output=True, text=True, timeout=120,
+        )
+        if r.returncode != 0:
+            return {"applied": False, "wpm": wpm,
+                    "error": f"ffmpeg atempo failed: {r.stderr.strip()[-200:]}"}
+        shutil.move(tmp.name, str(audio_path))
+    except (OSError, subprocess.TimeoutExpired) as e:
+        return {"applied": False, "wpm": wpm, "error": f"ffmpeg atempo failed: {e}"}
+    finally:
+        Path(tmp.name).unlink(missing_ok=True)
+
+    new_duration = _probe_duration(audio_path)
+    new_wpm = measure_wpm(text, new_duration)
+    if verbose:
+        print(
+            f"  Pace clamp: {wpm:.0f} wpm > {max_wpm:.0f} target — "
+            f"stretched x{1/atempo:.2f} → {new_wpm:.0f} wpm",
+            file=sys.stderr,
+        )
+    return {
+        "applied": True,
+        "wpm": new_wpm,
+        "original_wpm": wpm,
+        "atempo": round(atempo, 4),
+        "duration_seconds": round(new_duration, 2) if new_duration else None,
+    }

--- a/tools/qwen3_tts.py
+++ b/tools/qwen3_tts.py
@@ -153,6 +153,7 @@ def generate_audio(
     top_p: float | None = None,
     cloud: str = "modal",
     progress=None,
+    max_wpm: float | None = None,
 ) -> dict:
     """Generate audio using Qwen3-TTS via cloud GPU.
 
@@ -165,8 +166,14 @@ def generate_audio(
     matching list. The handler reuses a single voice_clone_prompt across
     all utterances for consistent voice (proper Qwen3-TTS pattern).
 
+    Pacing QC: every result includes `wpm` (words per minute) and a `pacing`
+    label ('fast'/'slow'/'ok'/None). If `max_wpm` is set, takes that exceed
+    it are slowed in place with pitch-preserving ffmpeg atempo (floor 0.85x)
+    — cloned voices inherit pace from their reference and resist temperature,
+    so deterministic correction beats regenerating. See tools/pacing.py.
+
     Returns dict with:
-      single call: {success, output, duration_seconds, duration_frames_30fps}
+      single call: {success, output, duration_seconds, duration_frames_30fps, wpm, pacing}
       batch call:  {success, outputs: [{output, duration_seconds, ...}, ...]}
     """
     start_time = time.time()
@@ -334,12 +341,42 @@ def generate_audio(
             return {"success": False, "error": f"No audio in output[{i}]: {list(item.keys())}"}
 
         duration = get_audio_duration(dest_path)
-        downloaded_items.append({
+        item_result = {
             "output": dest_path,
             "duration_seconds": round(duration, 2) if duration else None,
             "duration_frames_30fps": int(duration * 30) if duration else None,
             "script_chars": len(texts[i]),
-        })
+        }
+
+        # Pacing QC (voice_design seed sentences are auditions, not narration)
+        if mode != "voice_design":
+            from pacing import clamp_pace, pace_label
+            if max_wpm:
+                clamp = clamp_pace(dest_path, texts[i], max_wpm, verbose=verbose)
+                if clamp.get("applied"):
+                    new_dur = clamp["duration_seconds"]
+                    item_result["duration_seconds"] = new_dur
+                    item_result["duration_frames_30fps"] = (
+                        int(new_dur * 30) if new_dur else None
+                    )
+                    item_result["pace_adjusted"] = {
+                        "original_wpm": clamp["original_wpm"],
+                        "atempo": clamp["atempo"],
+                    }
+                elif clamp.get("error") and verbose:
+                    print(f"  Pace clamp skipped: {clamp['error']}", file=sys.stderr)
+            wpm, label = pace_label(texts[i], item_result["duration_seconds"])
+            item_result["wpm"] = wpm
+            item_result["pacing"] = label
+            if verbose and label in ("fast", "slow"):
+                print(
+                    f"  Pacing warning: {Path(dest_path).name} is {wpm:.0f} wpm "
+                    f"({label}; comfortable narration is 140-160). "
+                    "Consider --max-wpm to auto-correct.",
+                    file=sys.stderr,
+                )
+
+        downloaded_items.append(item_result)
 
     # Cleanup R2 objects
     for key in r2_keys_to_cleanup:
@@ -354,10 +391,7 @@ def generate_audio(
     else:
         return {
             "success": True,
-            "output": downloaded_items[0]["output"],
-            "duration_seconds": downloaded_items[0]["duration_seconds"],
-            "duration_frames_30fps": downloaded_items[0]["duration_frames_30fps"],
-            "script_chars": downloaded_items[0]["script_chars"],
+            **downloaded_items[0],
             "mode": mode,
         }
 
@@ -937,6 +971,14 @@ Examples:
 
     # Cloud GPU options
     parser.add_argument(
+        "--max-wpm",
+        type=float,
+        default=None,
+        help="Pace clamp: if the take exceeds this words-per-minute, slow it "
+             "with pitch-preserving atempo (floor 0.85x). Try 165. Cloned "
+             "voices inherit pace from the reference and resist temperature.",
+    )
+    parser.add_argument(
         "--cloud",
         type=str,
         default="modal",
@@ -1101,6 +1143,7 @@ def main():
         top_p=args.top_p,
         cloud=args.cloud,
         progress=reporter,
+        max_wpm=args.max_wpm,
     )
 
     if not result.get("success"):
@@ -1116,7 +1159,8 @@ def main():
         duration = result.get("duration_seconds", 0)
         print(f"Generated: {result['output']}")
         if duration:
-            print(f"  Duration: {duration:.1f}s ({int(duration * 30)} frames @ 30fps)")
+            wpm_note = f", {result['wpm']:.0f} wpm" if result.get("wpm") else ""
+            print(f"  Duration: {duration:.1f}s ({int(duration * 30)} frames @ 30fps{wpm_note})")
 
 
 if __name__ == "__main__":

--- a/tools/voiceover.py
+++ b/tools/voiceover.py
@@ -218,6 +218,14 @@ Examples:
 
     # Common options
     parser.add_argument(
+        "--max-wpm",
+        type=float,
+        default=None,
+        help="Pace clamp (any provider): takes exceeding this words-per-minute "
+             "are slowed with pitch-preserving atempo (floor 0.85x). Try 165. "
+             "Results always include wpm + a pacing label for QC.",
+    )
+    parser.add_argument(
         "--json",
         action="store_true",
         help="Output result as JSON (for machine parsing)",
@@ -277,6 +285,7 @@ def generate_single_audio(
     similarity: float,
     style: float,
     speed: float,
+    max_wpm: float | None = None,
 ) -> dict:
     """Generate a single audio file from script text using ElevenLabs. Returns result dict."""
     _, VoiceSettings, save = _get_elevenlabs_imports()
@@ -308,7 +317,29 @@ def generate_single_audio(
         result["duration_seconds"] = round(duration, 2)
         result["duration_frames_30fps"] = int(duration * 30)
 
+    _apply_pacing_qc(result, script, max_wpm)
     return result
+
+
+def _apply_pacing_qc(result: dict, script: str, max_wpm: float | None) -> None:
+    """Add wpm/pacing fields to a result; clamp pace in place if max_wpm set."""
+    from pacing import clamp_pace, pace_label
+
+    if not result.get("success") or not result.get("output"):
+        return
+    if max_wpm:
+        clamp = clamp_pace(result["output"], script, max_wpm, verbose=False)
+        if clamp.get("applied"):
+            new_dur = clamp["duration_seconds"]
+            result["duration_seconds"] = new_dur
+            result["duration_frames_30fps"] = int(new_dur * 30) if new_dur else None
+            result["pace_adjusted"] = {
+                "original_wpm": clamp["original_wpm"],
+                "atempo": clamp["atempo"],
+            }
+    wpm, label = pace_label(script, result.get("duration_seconds"))
+    result["wpm"] = wpm
+    result["pacing"] = label
 
 
 def generate_single_audio_qwen3(
@@ -322,6 +353,7 @@ def generate_single_audio_qwen3(
     temperature: float | None = None,
     top_p: float | None = None,
     cloud: str = "runpod",
+    max_wpm: float | None = None,
 ) -> dict:
     """Generate a single audio file from script text using Qwen3-TTS. Returns result dict."""
     from qwen3_tts import generate_audio
@@ -340,6 +372,7 @@ def generate_single_audio_qwen3(
         temperature=temperature,
         top_p=top_p,
         cloud=cloud,
+        max_wpm=max_wpm,
     )
 
 
@@ -354,6 +387,7 @@ def generate_batch_audio_qwen3(
     top_p: float | None = None,
     cloud: str = "runpod",
     timeout_per_scene: int = 120,
+    max_wpm: float | None = None,
 ) -> list[dict]:
     """Generate multiple audio files in a single Qwen3-TTS call.
 
@@ -380,6 +414,7 @@ def generate_batch_audio_qwen3(
         top_p=top_p,
         cloud=cloud,
         timeout=timeout_per_scene,
+        max_wpm=max_wpm,
     )
 
     if not result.get("success"):
@@ -416,6 +451,7 @@ def process_scene_directory(
     temperature: float | None = None,
     top_p: float | None = None,
     cloud: str = "runpod",
+    max_wpm: float | None = None,
 ) -> list[dict]:
     """Process all .txt files in directory, generate .mp3 for each."""
     txt_files = sorted(scene_dir.glob("*.txt"))
@@ -503,6 +539,7 @@ def process_scene_directory(
             temperature=temperature,
             top_p=top_p,
             cloud=cloud,
+            max_wpm=max_wpm,
         )
 
         for s, r in zip(scenes, batch_results):
@@ -512,7 +549,7 @@ def process_scene_directory(
                 total_duration += r["duration_seconds"]
             if not json_output:
                 if r.get("success"):
-                    dur = f" ({r.get('duration_seconds', '?')}s)"
+                    dur = f" ({r.get('duration_seconds', '?')}s{_pace_note(r)})"
                     print(f"  {s['mp3_file'].name}{dur}", file=sys.stderr)
                 else:
                     print(f"  {s['mp3_file'].name}  [FAILED: {r.get('error')}]", file=sys.stderr)
@@ -535,6 +572,7 @@ def process_scene_directory(
                 temperature=temperature,
                 top_p=top_p,
                 cloud=cloud,
+                max_wpm=max_wpm,
             )
         else:
             result = generate_single_audio(
@@ -547,6 +585,7 @@ def process_scene_directory(
                 similarity=similarity,
                 style=style,
                 speed=speed,
+                max_wpm=max_wpm,
             )
         result["script"] = str(s["txt_file"])
         results.append(result)
@@ -555,10 +594,23 @@ def process_scene_directory(
             total_duration += result["duration_seconds"]
 
         if not json_output:
-            duration_str = f" ({result.get('duration_seconds', '?')}s)"
+            duration_str = f" ({result.get('duration_seconds', '?')}s{_pace_note(result)})"
             print(f"  {s['mp3_file'].name}{duration_str}", file=sys.stderr)
 
     return results, total_duration, total_chars
+
+
+def _pace_note(result: dict) -> str:
+    """Human-mode pacing annotation for a per-scene result line."""
+    wpm = result.get("wpm")
+    if not wpm:
+        return ""
+    note = f", {wpm:.0f} wpm"
+    if result.get("pace_adjusted"):
+        note += f" [clamped from {result['pace_adjusted']['original_wpm']:.0f}]"
+    elif result.get("pacing") in ("fast", "slow"):
+        note += f" [{result['pacing'].upper()} — try --max-wpm 165]"
+    return note
 
 
 def concat_audio_files(mp3_files: list[Path], output_path: Path) -> dict:
@@ -845,6 +897,7 @@ def main():
             temperature=args.temperature,
             top_p=args.top_p,
             cloud=args.cloud,
+            max_wpm=args.max_wpm,
         )
 
         # Build final result
@@ -947,6 +1000,7 @@ def main():
             temperature=args.temperature,
             top_p=args.top_p,
             cloud=args.cloud,
+            max_wpm=args.max_wpm,
         )
     else:
         result = generate_single_audio(
@@ -959,6 +1013,7 @@ def main():
             similarity=args.similarity,
             style=args.style,
             speed=args.speed,
+            max_wpm=args.max_wpm,
         )
 
     result["mode"] = "single"
@@ -975,7 +1030,7 @@ def main():
             duration = result.get("duration_seconds")
             if duration:
                 print(
-                    f"Duration: {duration:.2f}s ({int(duration * 30)} frames @ 30fps)",
+                    f"Duration: {duration:.2f}s ({int(duration * 30)} frames @ 30fps{_pace_note(result)})",
                     file=sys.stderr,
                 )
         else:


### PR DESCRIPTION
## Why

While producing a cloned-voice explainer short, per-scene narration came out anywhere between 118 and 208 wpm. The root cause is that **voice clones inherit speaking pace from their reference audio** — and regeneration cannot fix it: 11 consecutive retakes at `--temperature 0.45` all landed 168–194 wpm because the reference (a brisk "Thank you ×3") gave the model no narration pacing to copy.

The fix that works is deterministic: measure words-per-minute, and slow rushed takes with pitch-preserving `atempo`.

## What

- **`tools/pacing.py`** — shared module: spoken-word counting (ignores `[pause]` markers, SSML breaks, `[tone:]` headers), wpm measurement, `fast`/`slow`/`ok` labels (>170 / <110, only when ≥6 words), and `clamp_pace()` — ffmpeg `atempo` slow-down with a 0.85× floor so stretching never becomes audible.
- **`voiceover.py` + `qwen3_tts.py`** — every result now includes `wpm` and `pacing`; human mode prints per-scene pace notes (`14.2s, 208 wpm [FAST — try --max-wpm 165]`). New `--max-wpm` flag on both tools (works for ElevenLabs and Qwen3, single/batch/scene-dir) slows offending takes in place and reports `pace_adjusted` in JSON.
- **`/voice-clone`** — validates reference audio before saving (ffprobe duration gates: <8s strong warn, 12–25s ideal; ~25-word minimum of varied speech) and explains the pace-inheritance behavior.
- **CLAUDE.md** — new row in the TTS drift table + pacing QC note; registry entries updated.

## Testing

- `py_compile` on all three tools; `--help` and `--dry-run --json` smoke tests pass.
- Unit-tested markup stripping, labels, clamp, floor behavior, and no-op path on real project audio.
- End-to-end on Modal: clone take generated at 192.7 wpm → clamped to 164.1, JSON reports `pace_adjusted: {original_wpm: 192.7, atempo: 0.85}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)