### PR TITLE
DEPS: make YouTube google-* deps opt-in in requirements.txt

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -14,14 +14,16 @@ Pillow>=10.0
 moviepy>=2.0
 matplotlib>=3.7
 
-# YouTube upload (tools/youtube_upload.py) — OAuth 2.0 + Data API v3 resumable upload.
-# NOTE: pip package names differ from their import names, e.g.
+# Optional — YouTube upload (tools/youtube_upload.py) — OAuth 2.0 + Data API v3
+# resumable upload. Only needed if you publish to YouTube. Uncomment to enable
+# (the tool prints an install hint if they're missing). NOTE: pip package names
+# differ from their import names, e.g.
 #   google-api-python-client -> import googleapiclient
 #   google-auth-oauthlib     -> import google_auth_oauthlib
 #   google-auth-httplib2     -> (transport glue, pulled in transitively)
-google-api-python-client>=2.100.0
-google-auth-oauthlib>=1.2.0
-google-auth-httplib2>=0.2.0
+# google-api-python-client>=2.100.0
+# google-auth-oauthlib>=1.2.0
+# google-auth-httplib2>=0.2.0
 
 # Optional — burned karaoke captions in templates/concept-explainer-short
 # (word-level timing; heavy install, pulls in torch). Uncomment to enable:


### PR DESCRIPTION
## What

Follow-up tidy to #29. The three YouTube publishing deps (`google-api-python-client`, `google-auth-oauthlib`, `google-auth-httplib2`) landed **uncommented** in `tools/requirements.txt`, so every `pip install -r tools/requirements.txt` installed them — even for users who never touch `/publish`.

This comments them out under an "uncomment to enable" header, matching how `openai-whisper` is already handled, so base installs stay lean. `youtube_upload.py` already prints an actionable install hint when the deps are missing (`pip install google-api-python-client ...`), so the opt-in path is self-documenting.

## Why opt-in (not default)

Consistency with the existing optional-deps convention (`openai-whisper`). Publishing is one workflow among many; people rendering videos shouldn't carry the Google API client stack unless they're uploading.

No code changes — `requirements.txt` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)