### PR TITLE
FIX: classify YouTube 403s by API reason (config/forbidden vs quota)

### DIFF
--- a/.claude/commands/publish.md
+++ b/.claude/commands/publish.md
@@ -151,7 +151,9 @@ run a dry-run before the real upload.
 |-----------------------|----------|
 | `auth` | Run `python3 tools/youtube_upload.py --auth` once; if the refresh token expired (7-day Testing limit), re-run `--auth`. |
 | `validation` | Fix the flagged field (missing video/title, bad `--publish-at`). |
+| `config` | YouTube Data API v3 isn't enabled on the Cloud project (or just enabled, still propagating). Enable it, wait 1–2 min, retry. See `docs/youtube-upload.md`. |
 | `quota` | Daily quota exhausted — wait, or request more in Google Cloud. |
+| `forbidden` | Permission denied (e.g. the authorized account lacks rights to the target channel). Check the account / `--account`. |
 | `upload` / `http` | Transient network/server issue; the tool already retried — try again later. |
 | Video uploaded but stuck `private` | Unverified OAuth app lock — verify the app, or publish manually. |
 

--- a/docs/youtube-upload.md
+++ b/docs/youtube-upload.md
@@ -149,9 +149,12 @@ Success:
 ```
 Failure:
 ```json
-{"success": false, "error": "...", "errorType": "auth", "videoId": null}
+{"success": false, "error": "...", "errorType": "config", "errorReason": "accessNotConfigured", "videoId": null}
 ```
-`errorType` ∈ `auth | quota | validation | upload | http | thumbnail | captions`.
+`errorType` ∈ `auth | quota | config | forbidden | validation | upload | http | thumbnail | captions`.
+For HTTP errors, `errorReason` carries YouTube's machine reason (e.g. `accessNotConfigured`,
+`quotaExceeded`, `forbidden`) so a disabled API (`config`) is distinguishable from a real quota
+wall (`quota`) or a permission denial (`forbidden`) — all three are HTTP 403.
 Compare `requestedPrivacy` vs `privacyStatus` to detect the unverified-app force-to-private case.
 
 ---

--- a/tools/youtube_upload.py
+++ b/tools/youtube_upload.py
@@ -303,6 +303,58 @@ def build_request_body(args, description: str, tags: list[str]) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Error classification
+# ---------------------------------------------------------------------------
+# YouTube returns a machine-readable reason in the error body (e.g. "quotaExceeded",
+# "accessNotConfigured", "forbidden"). A bare HTTP status is ambiguous — 403 covers
+# a genuine quota wall, a disabled API, and a plain permission denial alike — so we
+# read the reason to give the caller an accurate errorType instead of calling every
+# 403 "quota".
+_QUOTA_REASONS = {
+    "quotaExceeded",
+    "dailyLimitExceeded",
+    "rateLimitExceeded",
+    "userRateLimitExceeded",
+}
+
+
+def extract_api_reason(e: "HttpError") -> Optional[str]:
+    """Pull the YouTube error 'reason' (e.g. 'accessNotConfigured') from an HttpError body."""
+    content = getattr(e, "content", None)
+    if content is None:
+        return None
+    try:
+        if isinstance(content, (bytes, bytearray)):
+            content = content.decode("utf-8", "replace")
+        error = json.loads(content).get("error", {})
+        errors = error.get("errors") or []
+        if errors and errors[0].get("reason"):
+            return errors[0]["reason"]
+        return error.get("status")  # e.g. "PERMISSION_DENIED"
+    except (ValueError, AttributeError, TypeError):
+        return None
+
+
+def classify_http_error(e: "HttpError") -> tuple[str, Optional[str]]:
+    """Map an HttpError to (errorType, apiReason).
+
+    errorType ∈ quota | config | forbidden | auth | http. The reason disambiguates
+    same-status failures; we fall back to the status code when no reason is present.
+    """
+    status = getattr(e.resp, "status", None)
+    reason = extract_api_reason(e)
+    if reason in _QUOTA_REASONS:
+        return "quota", reason
+    if reason == "accessNotConfigured":
+        return "config", reason
+    if status == 401:
+        return "auth", reason
+    if status == 403:
+        return "forbidden", reason
+    return "http", reason
+
+
+# ---------------------------------------------------------------------------
 # Upload
 # ---------------------------------------------------------------------------
 def resumable_upload(request) -> dict:
@@ -609,11 +661,23 @@ def main():
         response = resumable_upload(request)
     except HttpError as e:
         status = getattr(e.resp, "status", None)
-        etype = "quota" if status == 403 else "http"
+        etype, reason = classify_http_error(e)
         msg = f"HTTP {status}: {e}"
         log(msg, "error")
+        if etype == "config":
+            log(
+                "The YouTube Data API v3 isn't enabled on this Cloud project (or was just "
+                "enabled and is still propagating). Enable it, wait 1-2 min, and retry — "
+                "see docs/youtube-upload.md.",
+                "warn",
+            )
+        elif etype == "quota":
+            log("Daily API quota exhausted (~6 uploads/day on the default quota). Wait or request more.", "warn")
         if args.json_out:
-            emit_json({"success": False, "error": msg, "errorType": etype, "videoId": None})
+            emit_json({
+                "success": False, "error": msg,
+                "errorType": etype, "errorReason": reason, "videoId": None,
+            })
         sys.exit(1)
     except UploadError as e:
         log(str(e), "error")


### PR DESCRIPTION
## What

Follow-up to #29. The upload handler mapped **every** HTTP 403 to `errorType: "quota"`, but YouTube returns 403 for several distinct reasons:
- `accessNotConfigured` — the Data API isn't enabled on the project (**this hit us on the first real upload**)
- `quotaExceeded` / `dailyLimitExceeded` / rate limits — actual quota
- `forbidden` / `PERMISSION_DENIED` — the account lacks rights to the channel

Labeling all of them "quota" sent users chasing the wrong fix.

## Change

- `extract_api_reason()` reads YouTube's machine `reason` from the error body (with safe fallbacks for missing/malformed bodies).
- `classify_http_error()` maps to accurate types: **`quota | config | forbidden | auth | http`**.
- New **`errorReason`** field in `--json-out` carries the raw reason for programmatic use.
- The `config` case prints an actionable hint ("enable the API, wait 1–2 min — see docs/youtube-upload.md"); `quota` explains the ~6/day ceiling.

## Testing

Unit-tested `classify_http_error` across 9 synthetic cases — each 403 reason, a 401, a 500, a malformed body, and the `error.status` fallback — all pass. Tool still compiles and `--dry-run` works.

Docs (`docs/youtube-upload.md` errorType enum + failure JSON) and the `/publish` error table updated with the new types.

Code + docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)