### PR TITLE
Add Edge-TTS as a third voiceover provider (free, no API key, incl. Vietnamese)

### DIFF
--- a/.claude/commands/generate-voiceover.md
+++ b/.claude/commands/generate-voiceover.md
@@ -152,7 +152,7 @@ Before gathering configuration, check if we're in a project context:
    Note: Per-scene tone overrides are supported with built-in speakers. Add `[tone: excited]` or `[instruct: Whisper gently]` as the first line of any scene `.txt` file. These are ignored when using a cloned voice.
 
    *If Edge-TTS selected:*
-   - Voice (default: `vi-VN-HoaiMyNeural`, female). Options: `vi-VN-HoaiMyNeural` (female), `vi-VN-NamMinhNeural` (male), or run `python tools/edgetts.py --list-voices --language vi` to see more (drop `--language vi` for other languages).
+   - Voice (default: `en-US-AriaNeural`). Vietnamese options: `vi-VN-HoaiMyNeural` (female), `vi-VN-NamMinhNeural` (male), or run `python tools/edgetts.py --list-voices --language vi` to see more (drop `--language vi` for other languages, or omit `--language` entirely to browse all ~300 voices).
    - Rate adjustment (optional, default: `+0%`). E.g. `+10%` for faster, `-15%` for slower.
 
    Edge-TTS has no tone presets or voice cloning — those are Qwen3-TTS-only features.

--- a/.claude/commands/generate-voiceover.md
+++ b/.claude/commands/generate-voiceover.md
@@ -4,7 +4,7 @@ description: Generate AI voiceover from script
 
 # Generate Voiceover
 
-Help me generate a voiceover for a Remotion video project using ElevenLabs or Qwen3-TTS.
+Help me generate a voiceover for a Remotion video project using ElevenLabs, Qwen3-TTS, or Edge-TTS.
 
 ## Project Integration
 
@@ -93,6 +93,7 @@ Before gathering configuration, check if we're in a project context:
    Options:
    - ElevenLabs (default) — high quality, paid API
    - Qwen3-TTS — self-hosted via RunPod, free/cheap, voice cloning
+   - Edge-TTS — free, no API key or account needed, includes Vietnamese voices
 
    If Qwen3-TTS is selected, check the project brand (from `project.json`) for a clone profile:
    1. Load `brands/{brand}/voice.json`
@@ -149,6 +150,12 @@ Before gathering configuration, check if we're in a project context:
      9. Custom instruction (type your own)
 
    Note: Per-scene tone overrides are supported with built-in speakers. Add `[tone: excited]` or `[instruct: Whisper gently]` as the first line of any scene `.txt` file. These are ignored when using a cloned voice.
+
+   *If Edge-TTS selected:*
+   - Voice (default: `vi-VN-HoaiMyNeural`, female). Options: `vi-VN-HoaiMyNeural` (female), `vi-VN-NamMinhNeural` (male), or run `python tools/edgetts.py --list-voices --language vi` to see more (drop `--language vi` for other languages).
+   - Rate adjustment (optional, default: `+0%`). E.g. `+10%` for faster, `-15%` for slower.
+
+   Edge-TTS has no tone presets or voice cloning — those are Qwen3-TTS-only features.
 
 3. **Execute Voiceover Generation**
 
@@ -231,6 +238,36 @@ Before gathering configuration, check if we're in a project context:
      --json
    ```
 
+   **Edge-TTS — Per-scene mode:**
+   ```bash
+   cd REPO_ROOT/PROJECT_DIR
+   python ../tools/voiceover.py \
+     --provider edge-tts \
+     --scene-dir public/audio/scenes \
+     --json
+   ```
+
+   **Edge-TTS — With voice + rate adjustment:**
+   ```bash
+   cd REPO_ROOT/PROJECT_DIR
+   python ../tools/voiceover.py \
+     --provider edge-tts \
+     --speaker vi-VN-NamMinhNeural \
+     --rate +10% \
+     --scene-dir public/audio/scenes \
+     --json
+   ```
+
+   **Edge-TTS — Single-file mode:**
+   ```bash
+   cd REPO_ROOT/PROJECT_DIR
+   python ../tools/voiceover.py \
+     --provider edge-tts \
+     --script "SCRIPT_PATH" \
+     --output "public/audio/voiceover.mp3" \
+     --json
+   ```
+
 4. **Report Results**
 
    **Per-scene results:**
@@ -266,8 +303,9 @@ Before gathering configuration, check if we're in a project context:
 
 - Voiceover tool: `tools/voiceover.py` (run from the toolkit root, or use `../tools/voiceover.py` from a project directory)
 - Qwen3-TTS tool: `tools/qwen3_tts.py`
+- Edge-TTS tool: `tools/edgetts.py` (also used to discover voices: `--list-voices --language vi`)
 - Config: `_internal/toolkit-registry.json` (voice ID)
-- API Key: `.env` file (`ELEVENLABS_API_KEY` for ElevenLabs, `RUNPOD_API_KEY` + `RUNPOD_QWEN3_TTS_ENDPOINT_ID` for Qwen3)
+- API Key: `.env` file (`ELEVENLABS_API_KEY` for ElevenLabs, `RUNPOD_API_KEY` + `RUNPOD_QWEN3_TTS_ENDPOINT_ID` for Qwen3). Edge-TTS needs no API key or account — just `pip install edge-tts`.
 
 ## Voice Settings Reference
 
@@ -319,7 +357,11 @@ Share these tips with the user:
 - If `RUNPOD_API_KEY` is missing, tell user to add it to `.env`
 - If `RUNPOD_QWEN3_TTS_ENDPOINT_ID` is missing, tell user to run `python tools/qwen3_tts.py --setup`
 
-**Both:**
+**Edge-TTS:**
+- If the `edge-tts` package is missing, tell user to run `pip install edge-tts` (no API key or account needed)
+- If unsure which voice to use, run `python tools/edgetts.py --list-voices --language vi` to list Vietnamese voices
+
+**All providers:**
 - If script file not found, offer to create a template
 - If scene directory empty, prompt to create scene scripts first
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,8 @@ python tools/voiceover.py --scene-dir public/audio/scenes --json
 # Using Qwen3-TTS (self-hosted, free alternative to ElevenLabs)
 python tools/voiceover.py --provider qwen3 --tone warm --scene-dir public/audio/scenes --json
 
-# Using Edge TTS (free, no API key — Vietnamese voices: vi-VN-HoaiMyNeural, vi-VN-NamMinhNeural)
+# Using Edge TTS (free, no API key — defaults to en-US-AriaNeural; also has
+# Vietnamese voices: vi-VN-HoaiMyNeural, vi-VN-NamMinhNeural)
 python tools/voiceover.py --provider edge-tts --scene-dir public/audio/scenes --json
 python tools/voiceover.py --provider edge-tts --speaker vi-VN-NamMinhNeural --rate +10% --script SCRIPT.md --output out.mp3
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 **Key capabilities:**
 - Programmatic video creation with Remotion (React-based)
-- AI voiceover generation with ElevenLabs or Qwen3-TTS
+- AI voiceover generation with ElevenLabs, Qwen3-TTS, or Edge TTS (free, incl. Vietnamese)
 - AI music generation with ACE-Step 1.5 (text-to-music, vocals, covers, stems)
 - Browser demo recording with Playwright
 - Asset processing with FFmpeg
@@ -139,6 +139,10 @@ python tools/voiceover.py --scene-dir public/audio/scenes --json
 
 # Using Qwen3-TTS (self-hosted, free alternative to ElevenLabs)
 python tools/voiceover.py --provider qwen3 --tone warm --scene-dir public/audio/scenes --json
+
+# Using Edge TTS (free, no API key — Vietnamese voices: vi-VN-HoaiMyNeural, vi-VN-NamMinhNeural)
+python tools/voiceover.py --provider edge-tts --scene-dir public/audio/scenes --json
+python tools/voiceover.py --provider edge-tts --speaker vi-VN-NamMinhNeural --rate +10% --script SCRIPT.md --output out.mp3
 
 # Single file (legacy)
 python tools/voiceover.py --script SCRIPT.md --output out.mp3

--- a/_internal/toolkit-registry.json
+++ b/_internal/toolkit-registry.json
@@ -133,10 +133,10 @@
     },
     "generate-voiceover": {
       "path": ".claude/commands/generate-voiceover.md",
-      "description": "Generate TTS voiceover using ElevenLabs or Qwen3-TTS",
+      "description": "Generate TTS voiceover using ElevenLabs, Qwen3-TTS, or Edge-TTS",
       "status": "stable",
       "created": "2025-12-08",
-      "updated": "2026-02-19"
+      "updated": "2026-07-14"
     },
     "contribute": {
       "path": ".claude/commands/contribute.md",
@@ -206,6 +206,25 @@
       "options": {
         "pacingQC": "results include wpm + pacing label (fast/slow/ok); --max-wpm clamps fast takes with pitch-preserving atempo (floor 0.85x)"
       }
+    },
+    "edgetts": {
+      "path": "tools/edgetts.py",
+      "description": "Generate speech using Microsoft Edge TTS - free, no API key, ~300 voices incl. Vietnamese; also used as a voiceover.py --provider edge-tts backend",
+      "usage": "python tools/edgetts.py --text \"Hello\" --voice en-US-AriaNeural --output hello.mp3",
+      "status": "stable",
+      "category": "audio-generation",
+      "backend": "edge-tts",
+      "requires": "pip install edge-tts (no API key or account)",
+      "options": {
+        "voice": "Any edge-tts voice name (default: en-US-AriaNeural); 'python tools/edgetts.py --list-voices' to browse ~300 options",
+        "vietnameseVoices": ["vi-VN-HoaiMyNeural (female)", "vi-VN-NamMinhNeural (male)"],
+        "rate": "Speech rate delta, e.g. +10% or -15% (default: +0%)",
+        "pitch": "Pitch delta, e.g. +5Hz or -10Hz (default: +0Hz)",
+        "volume": "Volume delta, e.g. +10% or -20% (default: +0%)",
+        "max-wpm": "Pace clamp: slows takes exceeding this WPM with pitch-preserving atempo"
+      },
+      "created": "2026-07-13",
+      "updated": "2026-07-14"
     },
     "music": {
       "path": "tools/music.py",

--- a/_internal/toolkit-registry.json
+++ b/_internal/toolkit-registry.json
@@ -198,11 +198,11 @@
   "tools": {
     "voiceover": {
       "path": "tools/voiceover.py",
-      "description": "Generate TTS voiceovers using ElevenLabs or Qwen3-TTS",
+      "description": "Generate TTS voiceovers using ElevenLabs, Qwen3-TTS, or Edge TTS (free, incl. Vietnamese)",
       "usage": "python tools/voiceover.py --script SCRIPT.md --output out.mp3",
       "status": "stable",
       "created": "2025-12-08",
-      "updated": "2026-06-09",
+      "updated": "2026-07-13",
       "options": {
         "pacingQC": "results include wpm + pacing label (fast/slow/ok); --max-wpm clamps fast takes with pitch-preserving atempo (floor 0.85x)"
       }

--- a/brands/default/voice.json
+++ b/brands/default/voice.json
@@ -16,7 +16,7 @@
     "clone": null
   },
   "edgeTts": {
-    "voice": "vi-VN-HoaiMyNeural",
+    "voice": "en-US-AriaNeural",
     "rate": "+0%",
     "pitch": "+0Hz",
     "volume": "+0%"

--- a/brands/default/voice.json
+++ b/brands/default/voice.json
@@ -14,5 +14,11 @@
     "tone": "",
     "instruct": "",
     "clone": null
+  },
+  "edgeTts": {
+    "voice": "vi-VN-HoaiMyNeural",
+    "rate": "+0%",
+    "pitch": "+0Hz",
+    "volume": "+0%"
   }
 }

--- a/tools/edgetts.py
+++ b/tools/edgetts.py
@@ -28,6 +28,7 @@ import argparse
 import asyncio
 import json
 import sys
+import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
@@ -89,6 +90,54 @@ async def _synthesize(text: str, output_path: str, voice: str, rate: str, pitch:
     await communicate.save(output_path)
 
 
+def _synthesize_with_retries(
+    text: str, output_path: str, voice: str, rate: str, pitch: str, volume: str,
+    retries: int, verbose: bool,
+) -> str | None:
+    """Synthesize, retrying transient backend failures. Returns None on success,
+    or an error string once the attempts are exhausted.
+
+    Microsoft's Edge TTS backend intermittently returns no audio for an
+    otherwise valid request ("No audio was received"); a retry usually clears
+    it. Left unretried, a single flaky scene silently drops out of a multi-scene
+    voiceover run.
+
+    On unrecoverable failure the output file is removed: a failed save can leave
+    a ZERO-BYTE .mp3 behind, and an empty file in a scene directory is worse than
+    no file — ffprobe reports no duration, Remotion renders silence rather than
+    erroring, and the file's mere presence reads as success.
+
+    Bad parameters (unknown voice, malformed rate/pitch/volume) surface as
+    ValueError from edge-tts's client-side validation, before any network call.
+    Those are deterministic, so they fail immediately rather than burning retries.
+    """
+    last_error: object = None
+    for attempt in range(1, retries + 1):
+        try:
+            asyncio.run(_synthesize(text, output_path, voice, rate, pitch, volume))
+        except ValueError as e:
+            Path(output_path).unlink(missing_ok=True)
+            return f"edge-tts rejected the request: {e}"
+        except Exception as e:
+            last_error = e
+        else:
+            out = Path(output_path)
+            if out.exists() and out.stat().st_size > 0:
+                return None
+            last_error = "edge-tts reported success but wrote no audio"
+
+        if attempt < retries:
+            if verbose:
+                print(
+                    f"  Attempt {attempt}/{retries} failed ({last_error}) — retrying...",
+                    file=sys.stderr,
+                )
+            time.sleep(attempt)  # 1s, then 2s
+
+    Path(output_path).unlink(missing_ok=True)
+    return f"edge-tts synthesis failed after {retries} attempts: {last_error}"
+
+
 def generate_audio(
     text: str,
     output_path: str,
@@ -98,6 +147,7 @@ def generate_audio(
     volume: str = "+0%",
     max_wpm: float | None = None,
     verbose: bool = True,
+    retries: int = 3,
 ) -> dict:
     """Generate one audio file using Microsoft Edge TTS.
 
@@ -105,6 +155,9 @@ def generate_audio(
     label ('fast'/'slow'/'ok'/None). If `max_wpm` is set, takes that exceed
     it are slowed in place with pitch-preserving ffmpeg atempo (floor 0.85x).
     See tools/pacing.py.
+
+    Transient backend failures are retried (see _synthesize_with_retries); a
+    run that ultimately fails leaves no file behind.
 
     Returns: {success, output, duration_seconds, duration_frames_30fps,
     script_chars, wpm, pacing} or {success: False, error} on failure.
@@ -120,10 +173,11 @@ def generate_audio(
     if verbose:
         print(f"Generating speech with Edge TTS (voice={voice})...", file=sys.stderr)
 
-    try:
-        asyncio.run(_synthesize(text, output_path, voice, rate, pitch, volume))
-    except Exception as e:
-        return {"success": False, "error": f"edge-tts synthesis failed: {e}"}
+    error = _synthesize_with_retries(
+        text, output_path, voice, rate, pitch, volume, retries, verbose
+    )
+    if error:
+        return {"success": False, "error": error}
 
     duration = get_audio_duration(output_path)
     result = {

--- a/tools/edgetts.py
+++ b/tools/edgetts.py
@@ -2,9 +2,10 @@
 """
 Generate speech using Microsoft Edge TTS (free, no API key, no cloud GPU).
 
-Includes high-quality Vietnamese neural voices (vi-VN-HoaiMyNeural,
-vi-VN-NamMinhNeural) alongside ~300 other voices across languages. Used as
-a `voiceover.py --provider edge-tts` backend; also usable standalone.
+Defaults to an English voice; also includes high-quality Vietnamese neural
+voices (vi-VN-HoaiMyNeural, vi-VN-NamMinhNeural) alongside ~300 other voices
+across languages — pass --voice/--speaker to pick one. Used as a
+`voiceover.py --provider edge-tts` backend; also usable standalone.
 
 Usage:
     # Single utterance
@@ -41,7 +42,7 @@ VIETNAMESE_VOICES = {
     "vi-VN-NamMinhNeural": "Male",
 }
 
-DEFAULT_VOICE = "vi-VN-HoaiMyNeural"
+DEFAULT_VOICE = "en-US-AriaNeural"
 
 
 def _get_edge_tts_import():
@@ -284,7 +285,7 @@ def main():
         for v in voices:
             print(f"{v['ShortName']:<28} {v['Gender']:<8} {v['Locale']}")
         print()
-        print("Vietnamese defaults: " + ", ".join(f"{k} ({g})" for k, g in VIETNAMESE_VOICES.items()))
+        print("Vietnamese voices: " + ", ".join(f"{k} ({g})" for k, g in VIETNAMESE_VOICES.items()))
         return
 
     if not args.text:

--- a/tools/edgetts.py
+++ b/tools/edgetts.py
@@ -185,7 +185,7 @@ def parse_args():
         epilog="""
 Examples:
   python tools/edgetts.py --text "Xin chao" --voice vi-VN-HoaiMyNeural --output hello.mp3
-  python tools/edgetts.py --text "Hello" --voice en-US-AriaNeural --rate +10%% --output out.mp3
+  python tools/edgetts.py --text "Hello" --voice en-US-AriaNeural --rate +10% --output out.mp3
   python tools/edgetts.py --list-voices --language vi
         """,
     )

--- a/tools/edgetts.py
+++ b/tools/edgetts.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""
+Generate speech using Microsoft Edge TTS (free, no API key, no cloud GPU).
+
+Includes high-quality Vietnamese neural voices (vi-VN-HoaiMyNeural,
+vi-VN-NamMinhNeural) alongside ~300 other voices across languages. Used as
+a `voiceover.py --provider edge-tts` backend; also usable standalone.
+
+Usage:
+    # Single utterance
+    python tools/edgetts.py --text "Xin chao" --voice vi-VN-HoaiMyNeural --output hello.mp3
+
+    # Adjust rate/pitch/volume
+    python tools/edgetts.py --text "Hello" --voice en-US-AriaNeural --rate +10% --pitch -5Hz --output out.mp3
+
+    # List Vietnamese voices
+    python tools/edgetts.py --list-voices --language vi
+
+    # List all voices
+    python tools/edgetts.py --list-voices
+
+Setup:
+    pip install edge-tts
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+# Curated reference — NOT an exhaustive or enforced list. --voice/--speaker
+# accepts any edge-tts voice name; these are just the toolkit's Vietnamese
+# defaults, surfaced by --list-voices for convenience.
+VIETNAMESE_VOICES = {
+    "vi-VN-HoaiMyNeural": "Female",
+    "vi-VN-NamMinhNeural": "Male",
+}
+
+DEFAULT_VOICE = "vi-VN-HoaiMyNeural"
+
+
+def _get_edge_tts_import():
+    """Lazy import the edge-tts package. Returns the module, or None (and
+    prints an install hint) if it isn't installed."""
+    try:
+        import edge_tts
+        return edge_tts
+    except ImportError:
+        print(
+            "Error: edge-tts Python package not installed.\n"
+            "\n"
+            "  pip install edge-tts\n"
+            "\n"
+            "Edge TTS is free and needs no API key or account — it's a wrapper\n"
+            "around Microsoft Edge's built-in read-aloud voices.",
+            file=sys.stderr,
+        )
+        return None
+
+
+def get_audio_duration(file_path: str) -> float | None:
+    """Get audio duration in seconds using ffprobe."""
+    import subprocess
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe", "-v", "error",
+                "-show_entries", "format=duration",
+                "-of", "csv=p=0",
+                file_path,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return float(result.stdout.strip())
+    except (FileNotFoundError, ValueError):
+        pass
+    return None
+
+
+async def _synthesize(text: str, output_path: str, voice: str, rate: str, pitch: str, volume: str) -> None:
+    import edge_tts
+    communicate = edge_tts.Communicate(text, voice, rate=rate, pitch=pitch, volume=volume)
+    await communicate.save(output_path)
+
+
+def generate_audio(
+    text: str,
+    output_path: str,
+    voice: str = DEFAULT_VOICE,
+    rate: str = "+0%",
+    pitch: str = "+0Hz",
+    volume: str = "+0%",
+    max_wpm: float | None = None,
+    verbose: bool = True,
+) -> dict:
+    """Generate one audio file using Microsoft Edge TTS.
+
+    Pacing QC: every result includes `wpm` (words per minute) and a `pacing`
+    label ('fast'/'slow'/'ok'/None). If `max_wpm` is set, takes that exceed
+    it are slowed in place with pitch-preserving ffmpeg atempo (floor 0.85x).
+    See tools/pacing.py.
+
+    Returns: {success, output, duration_seconds, duration_frames_30fps,
+    script_chars, wpm, pacing} or {success: False, error} on failure.
+    """
+    if _get_edge_tts_import() is None:
+        return {"success": False, "error": "edge-tts package not installed (pip install edge-tts)"}
+
+    if not text:
+        return {"success": False, "error": "text must be non-empty"}
+
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+
+    if verbose:
+        print(f"Generating speech with Edge TTS (voice={voice})...", file=sys.stderr)
+
+    try:
+        asyncio.run(_synthesize(text, output_path, voice, rate, pitch, volume))
+    except Exception as e:
+        return {"success": False, "error": f"edge-tts synthesis failed: {e}"}
+
+    duration = get_audio_duration(output_path)
+    result = {
+        "success": True,
+        "output": output_path,
+        "duration_seconds": round(duration, 2) if duration else None,
+        "duration_frames_30fps": int(duration * 30) if duration else None,
+        "script_chars": len(text),
+    }
+
+    from pacing import clamp_pace, pace_label
+    if max_wpm:
+        clamp = clamp_pace(output_path, text, max_wpm, verbose=verbose)
+        if clamp.get("applied"):
+            new_dur = clamp["duration_seconds"]
+            result["duration_seconds"] = new_dur
+            result["duration_frames_30fps"] = int(new_dur * 30) if new_dur else None
+            result["pace_adjusted"] = {
+                "original_wpm": clamp["original_wpm"],
+                "atempo": clamp["atempo"],
+            }
+        elif clamp.get("error") and verbose:
+            print(f"  Pace clamp skipped: {clamp['error']}", file=sys.stderr)
+    wpm, label = pace_label(text, result["duration_seconds"])
+    result["wpm"] = wpm
+    result["pacing"] = label
+    if verbose and label in ("fast", "slow"):
+        print(
+            f"  Pacing warning: {Path(output_path).name} is {wpm:.0f} wpm "
+            f"({label}; comfortable narration is 140-160). "
+            "Consider --max-wpm to auto-correct, or adjust --rate.",
+            file=sys.stderr,
+        )
+
+    return result
+
+
+async def _list_voices_async(language: str | None) -> list[dict]:
+    import edge_tts
+    voices = await edge_tts.list_voices()
+    if language:
+        prefix = language.lower() + "-"
+        voices = [v for v in voices if v["Locale"].lower().startswith(prefix)]
+    return voices
+
+
+def list_voices(language: str | None = None) -> list[dict]:
+    """Fetch the live edge-tts voice catalogue, optionally filtered by locale
+    prefix (e.g. language="vi" matches vi-VN-*)."""
+    if _get_edge_tts_import() is None:
+        return []
+    return asyncio.run(_list_voices_async(language))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Generate speech using Microsoft Edge TTS (free, no API key)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python tools/edgetts.py --text "Xin chao" --voice vi-VN-HoaiMyNeural --output hello.mp3
+  python tools/edgetts.py --text "Hello" --voice en-US-AriaNeural --rate +10%% --output out.mp3
+  python tools/edgetts.py --list-voices --language vi
+        """,
+    )
+    parser.add_argument("--text", "-t", type=str, help="Text to synthesize")
+    parser.add_argument("--output", "-o", type=str, help="Output audio file path (.mp3)")
+    parser.add_argument(
+        "--voice", "-v",
+        type=str,
+        default=DEFAULT_VOICE,
+        help=f"Edge-TTS voice name (default: {DEFAULT_VOICE}). Use --list-voices to see options.",
+    )
+    parser.add_argument("--rate", type=str, default="+0%", help="Speech rate delta, e.g. '+10%%' or '-15%%' (default: +0%%)")
+    parser.add_argument("--pitch", type=str, default="+0Hz", help="Pitch delta, e.g. '+5Hz' or '-10Hz' (default: +0Hz)")
+    parser.add_argument("--volume", type=str, default="+0%", help="Volume delta, e.g. '+10%%' or '-20%%' (default: +0%%)")
+    parser.add_argument(
+        "--max-wpm",
+        type=float,
+        default=None,
+        help="Pace clamp: if the take exceeds this words-per-minute, slow it "
+             "with pitch-preserving atempo (floor 0.85x). Try 165.",
+    )
+    parser.add_argument("--list-voices", action="store_true", help="List voices and exit")
+    parser.add_argument("--language", type=str, help="Filter --list-voices by locale prefix, e.g. 'vi', 'en'")
+    parser.add_argument("--json", action="store_true", help="Output result as JSON")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    verbose = not args.json
+
+    if args.list_voices:
+        voices = list_voices(args.language)
+        if args.json:
+            print(json.dumps(voices, indent=2))
+            return
+        if not voices:
+            print("No voices found (or edge-tts not installed / network unavailable).")
+            sys.exit(1)
+        print(f"{'Voice':<28} {'Gender':<8} {'Locale'}")
+        print(f"{'-'*28} {'-'*8} {'-'*8}")
+        for v in voices:
+            print(f"{v['ShortName']:<28} {v['Gender']:<8} {v['Locale']}")
+        print()
+        print("Vietnamese defaults: " + ", ".join(f"{k} ({g})" for k, g in VIETNAMESE_VOICES.items()))
+        return
+
+    if not args.text:
+        print("Error: --text is required", file=sys.stderr)
+        sys.exit(1)
+    if not args.output:
+        print("Error: --output is required", file=sys.stderr)
+        sys.exit(1)
+
+    result = generate_audio(
+        text=args.text,
+        output_path=args.output,
+        voice=args.voice,
+        rate=args.rate,
+        pitch=args.pitch,
+        volume=args.volume,
+        max_wpm=args.max_wpm,
+        verbose=verbose,
+    )
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    elif result.get("success"):
+        print(f"Saved to: {result['output']}", file=sys.stderr)
+        if result.get("duration_seconds"):
+            print(
+                f"Duration: {result['duration_seconds']:.2f}s "
+                f"({result['duration_frames_30fps']} frames @ 30fps, {result.get('wpm', '?')} wpm)",
+                file=sys.stderr,
+            )
+    else:
+        print(f"Error: {result.get('error', 'Unknown error')}", file=sys.stderr)
+
+    if not result.get("success"):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,5 +1,6 @@
 # Video Toolkit Python Dependencies
 elevenlabs>=1.0.0
+edge-tts>=6.1.0  # Free Microsoft Edge TTS voices (incl. Vietnamese) — no API key needed
 python-dotenv>=1.0.0
 requests>=2.28.0
 boto3>=1.28.0  # For Cloudflare R2 (S3-compatible)

--- a/tools/voiceover.py
+++ b/tools/voiceover.py
@@ -670,8 +670,11 @@ def process_scene_directory(
             total_duration += result["duration_seconds"]
 
         if not json_output:
-            duration_str = f" ({result.get('duration_seconds', '?')}s{_pace_note(result)})"
-            print(f"  {s['mp3_file'].name}{duration_str}", file=sys.stderr)
+            if result.get("success"):
+                duration_str = f" ({result.get('duration_seconds', '?')}s{_pace_note(result)})"
+                print(f"  {s['mp3_file'].name}{duration_str}", file=sys.stderr)
+            else:
+                print(f"  {s['mp3_file'].name}  [FAILED: {result.get('error')}]", file=sys.stderr)
 
     return results, total_duration, total_chars
 
@@ -1005,9 +1008,12 @@ def main():
             max_wpm=args.max_wpm,
         )
 
-        # Build final result
+        # Build final result. A per-scene run is only a success if every scene
+        # produced audio — a partial run that reports success silently ships a
+        # video with a missing scene.
+        failed = [r for r in results if not r.get("success")]
         result = {
-            "success": True,
+            "success": not failed,
             "mode": "per_scene",
             "provider": provider,
             "scene_dir": str(scene_dir),
@@ -1016,6 +1022,8 @@ def main():
             "total_duration_frames_30fps": int(total_duration * 30),
             "scenes": results,
         }
+        if failed:
+            result["failed_scenes"] = len(failed)
         if provider == "elevenlabs":
             result["voice_id"] = voice_id
             result["model"] = args.model
@@ -1038,9 +1046,17 @@ def main():
         if args.json:
             print(json.dumps(result, indent=2))
         else:
-            print(f"\nPer-scene audio generated:", file=sys.stderr)
+            if failed:
+                print(
+                    f"\n{len(failed)} of {len(results)} scenes FAILED — no audio written for those scenes.",
+                    file=sys.stderr,
+                )
+            else:
+                print(f"\nPer-scene audio generated:", file=sys.stderr)
             print(f"  Total: {total_duration:.1f}s ({int(total_duration * 30)} frames @ 30fps)", file=sys.stderr)
             print(f"  Characters: {total_chars}", file=sys.stderr)
+        if failed:
+            sys.exit(1)
         return
 
     # Single-file mode (original behavior)

--- a/tools/voiceover.py
+++ b/tools/voiceover.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Generate voiceover audio using ElevenLabs or Qwen3-TTS.
+Generate voiceover audio using ElevenLabs, Qwen3-TTS, or Edge-TTS.
 
 Usage:
     # From script file (ElevenLabs, default)
@@ -25,6 +25,11 @@ Usage:
     python tools/voiceover.py --provider qwen3 --speaker Ryan --scene-dir public/audio/scenes --json
     python tools/voiceover.py --provider qwen3 --tone warm --scene-dir public/audio/scenes --json
     python tools/voiceover.py --provider qwen3 --instruct "Speak warmly" --script script.txt --output out.mp3
+
+    # Using Edge-TTS provider (free, no API key — good Vietnamese voices)
+    python tools/voiceover.py --provider edge-tts --scene-dir public/audio/scenes --json
+    python tools/voiceover.py --provider edge-tts --speaker vi-VN-NamMinhNeural --script script.txt --output out.mp3
+    python tools/voiceover.py --provider edge-tts --rate +10% --script script.txt --output out.mp3
 """
 from __future__ import annotations
 
@@ -69,7 +74,7 @@ def _get_elevenlabs_imports():
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description="Generate voiceover using ElevenLabs or Qwen3-TTS",
+        description="Generate voiceover using ElevenLabs, Qwen3-TTS, or Edge-TTS",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
@@ -81,6 +86,10 @@ Examples:
   python tools/voiceover.py --provider qwen3 --speaker Ryan --scene-dir public/audio/scenes --json
   python tools/voiceover.py --provider qwen3 --tone warm --scene-dir public/audio/scenes --json
   python tools/voiceover.py --provider qwen3 --instruct "Speak warmly" --script script.txt --output out.mp3
+
+  # Edge-TTS (free, no API key, good Vietnamese voices)
+  python tools/voiceover.py --provider edge-tts --scene-dir public/audio/scenes --json
+  python tools/voiceover.py --provider edge-tts --speaker vi-VN-NamMinhNeural --rate +10% --script script.txt --output out.mp3
         """,
     )
     parser.add_argument(
@@ -111,7 +120,7 @@ Examples:
         "--provider",
         type=str,
         default="elevenlabs",
-        choices=["elevenlabs", "qwen3"],
+        choices=["elevenlabs", "qwen3", "edge-tts"],
         help="TTS provider (default: elevenlabs)",
     )
 
@@ -160,7 +169,10 @@ Examples:
         "--speaker",
         type=str,
         default="Ryan",
-        help="Qwen3-TTS speaker name (default: Ryan). Use 'python tools/qwen3_tts.py --list-voices' to see options.",
+        help="Speaker/voice name. For Qwen3-TTS: built-in speaker (default: Ryan; "
+             "'python tools/qwen3_tts.py --list-voices' to see options). For Edge-TTS: "
+             "a voice name like 'vi-VN-HoaiMyNeural' (defaults to that voice when unset; "
+             "'python tools/edgetts.py --list-voices' to see options).",
     )
     parser.add_argument(
         "--language",
@@ -198,6 +210,26 @@ Examples:
         "--top-p",
         type=float,
         help="Qwen3-TTS nucleus sampling (default: model default ~0.8, range: 0.1-1.0)",
+    )
+
+    # Edge-TTS-specific options
+    parser.add_argument(
+        "--rate",
+        type=str,
+        default="+0%",
+        help="Edge-TTS speech rate delta, e.g. '+10%%' or '-15%%' (default: +0%%).",
+    )
+    parser.add_argument(
+        "--pitch",
+        type=str,
+        default="+0Hz",
+        help="Edge-TTS pitch delta, e.g. '+5Hz' or '-10Hz' (default: +0Hz).",
+    )
+    parser.add_argument(
+        "--volume",
+        type=str,
+        default="+0%",
+        help="Edge-TTS volume delta, e.g. '+10%%' or '-20%%' (default: +0%%).",
     )
 
     # Cloud GPU provider (for Qwen3-TTS)
@@ -428,6 +460,32 @@ def generate_batch_audio_qwen3(
     ]
 
 
+def generate_single_audio_edge_tts(
+    script: str,
+    output_path: Path,
+    voice: str = "vi-VN-HoaiMyNeural",
+    rate: str = "+0%",
+    pitch: str = "+0Hz",
+    volume: str = "+0%",
+    max_wpm: float | None = None,
+) -> dict:
+    """Generate a single audio file from script text using Edge TTS. Returns result dict."""
+    from edgetts import generate_audio
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    return generate_audio(
+        text=script,
+        output_path=str(output_path),
+        voice=voice,
+        rate=rate,
+        pitch=pitch,
+        volume=volume,
+        verbose=False,
+        max_wpm=max_wpm,
+    )
+
+
 def process_scene_directory(
     scene_dir: Path,
     dry_run: bool = False,
@@ -451,6 +509,10 @@ def process_scene_directory(
     temperature: float | None = None,
     top_p: float | None = None,
     cloud: str = "runpod",
+    # Edge-TTS params (speaker doubles as the voice name)
+    rate: str = "+0%",
+    pitch: str = "+0Hz",
+    volume: str = "+0%",
     max_wpm: float | None = None,
 ) -> list[dict]:
     """Process all .txt files in directory, generate .mp3 for each."""
@@ -572,6 +634,16 @@ def process_scene_directory(
                 temperature=temperature,
                 top_p=top_p,
                 cloud=cloud,
+                max_wpm=max_wpm,
+            )
+        elif provider == "edge-tts":
+            result = generate_single_audio_edge_tts(
+                script=s["script"],
+                output_path=s["mp3_file"],
+                voice=speaker,
+                rate=rate,
+                pitch=pitch,
+                volume=volume,
                 max_wpm=max_wpm,
             )
         else:
@@ -752,10 +824,24 @@ def main():
                 args.instruct = qwen3_cfg["instruct"]
             if qwen3_cfg.get("tone") and not args.tone and not args.instruct:
                 args.tone = qwen3_cfg["tone"]
+        elif provider == "edge-tts":
+            edge_cfg = voice_config.get("edgeTts", {})
+            if edge_cfg.get("voice") and args.speaker == "Ryan":
+                args.speaker = edge_cfg["voice"]
+            if edge_cfg.get("rate") and args.rate == "+0%":
+                args.rate = edge_cfg["rate"]
+            if edge_cfg.get("pitch") and args.pitch == "+0Hz":
+                args.pitch = edge_cfg["pitch"]
+            if edge_cfg.get("volume") and args.volume == "+0%":
+                args.volume = edge_cfg["volume"]
         elif provider == "elevenlabs":
             # Apply voice ID from brand if not explicitly provided
             if not args.voice_id and voice_config.get("voiceId") and voice_config["voiceId"] != "YOUR_VOICE_ID_HERE":
                 args.voice_id = voice_config["voiceId"]
+
+    # Default voice for Edge-TTS when none given (CLI or brand)
+    if provider == "edge-tts" and args.speaker == "Ryan":
+        args.speaker = "vi-VN-HoaiMyNeural"
 
     # Resolve tone preset → instruct text for Qwen3
     if provider == "qwen3" and (args.tone or args.instruct):
@@ -817,7 +903,7 @@ def main():
 
         if not args.json:
             txt_count = len(list(scene_dir.glob("*.txt")))
-            provider_label = "Qwen3-TTS" if provider == "qwen3" else "ElevenLabs"
+            provider_label = {"qwen3": "Qwen3-TTS", "edge-tts": "Edge-TTS"}.get(provider, "ElevenLabs")
             print(f"Processing {txt_count} scene scripts in {scene_dir} ({provider_label})...", file=sys.stderr)
 
         if args.dry_run:
@@ -843,6 +929,9 @@ def main():
                 temperature=args.temperature,
                 top_p=args.top_p,
                 cloud=args.cloud,
+                rate=args.rate,
+                pitch=args.pitch,
+                volume=args.volume,
             )
             result = {
                 "dry_run": True,
@@ -861,6 +950,11 @@ def main():
                     "style": args.style,
                     "speed": args.speed,
                 }
+            elif provider == "edge-tts":
+                result["voice"] = args.speaker
+                result["rate"] = args.rate
+                result["pitch"] = args.pitch
+                result["volume"] = args.volume
             else:
                 result["speaker"] = args.speaker
                 result["language"] = args.language
@@ -897,6 +991,9 @@ def main():
             temperature=args.temperature,
             top_p=args.top_p,
             cloud=args.cloud,
+            rate=args.rate,
+            pitch=args.pitch,
+            volume=args.volume,
             max_wpm=args.max_wpm,
         )
 
@@ -914,6 +1011,11 @@ def main():
         if provider == "elevenlabs":
             result["voice_id"] = voice_id
             result["model"] = args.model
+        elif provider == "edge-tts":
+            result["voice"] = args.speaker
+            result["rate"] = args.rate
+            result["pitch"] = args.pitch
+            result["volume"] = args.volume
 
         # Concat if requested
         if args.concat:
@@ -960,6 +1062,11 @@ def main():
                 "style": args.style,
                 "speed": args.speed,
             }
+        elif provider == "edge-tts":
+            result["voice"] = args.speaker
+            result["rate"] = args.rate
+            result["pitch"] = args.pitch
+            result["volume"] = args.volume
         else:
             result["speaker"] = args.speaker
             result["language"] = args.language
@@ -976,6 +1083,9 @@ def main():
             if provider == "elevenlabs":
                 print(f"  Voice ID: {voice_id}")
                 print(f"  Model: {args.model}")
+            elif provider == "edge-tts":
+                print(f"  Voice: {args.speaker}")
+                print(f"  Rate: {args.rate}, Pitch: {args.pitch}, Volume: {args.volume}")
             else:
                 print(f"  Speaker: {args.speaker}")
                 print(f"  Language: {args.language}")
@@ -985,7 +1095,7 @@ def main():
 
     # Generate voiceover
     if not args.json:
-        provider_label = "Qwen3-TTS" if provider == "qwen3" else "ElevenLabs"
+        provider_label = {"qwen3": "Qwen3-TTS", "edge-tts": "Edge-TTS"}.get(provider, "ElevenLabs")
         print(f"Generating voiceover ({len(script)} chars, {provider_label})...", file=sys.stderr)
 
     if provider == "qwen3":
@@ -1000,6 +1110,16 @@ def main():
             temperature=args.temperature,
             top_p=args.top_p,
             cloud=args.cloud,
+            max_wpm=args.max_wpm,
+        )
+    elif provider == "edge-tts":
+        result = generate_single_audio_edge_tts(
+            script=script,
+            output_path=output_path,
+            voice=args.speaker,
+            rate=args.rate,
+            pitch=args.pitch,
+            volume=args.volume,
             max_wpm=args.max_wpm,
         )
     else:
@@ -1021,6 +1141,11 @@ def main():
     if provider == "elevenlabs":
         result["voice_id"] = voice_id
         result["model"] = args.model
+    elif provider == "edge-tts":
+        result["voice"] = args.speaker
+        result["rate"] = args.rate
+        result["pitch"] = args.pitch
+        result["volume"] = args.volume
 
     if args.json:
         print(json.dumps(result, indent=2))

--- a/tools/voiceover.py
+++ b/tools/voiceover.py
@@ -56,16 +56,20 @@ def _get_elevenlabs_imports():
         print(
             "Error: ElevenLabs Python package not installed.\n"
             "\n"
-            "You have 3 options:\n"
+            "You have 4 options:\n"
             "\n"
             "  1. Install ElevenLabs:\n"
             "     pip install elevenlabs\n"
             "\n"
-            "  2. Use Qwen3-TTS instead (free, self-hosted):\n"
+            "  2. Use Edge-TTS instead (free, no API key or account needed):\n"
+            "     python3 tools/voiceover.py --provider edge-tts --scene-dir public/audio/scenes --json\n"
+            "     (Install with: pip install edge-tts. Includes Vietnamese voices.)\n"
+            "\n"
+            "  3. Use Qwen3-TTS instead (free, self-hosted):\n"
             "     python3 tools/voiceover.py --provider qwen3 --speaker Ryan --scene-dir public/audio/scenes --json\n"
             "     (Requires RunPod account — run: python3 tools/qwen3_tts.py --setup)\n"
             "\n"
-            "  3. Skip voiceover entirely:\n"
+            "  4. Skip voiceover entirely:\n"
             "     Videos render fine without audio. Add voiceover later when ready.",
             file=sys.stderr,
         )
@@ -868,16 +872,20 @@ def main():
             print(
                 "Error: No ElevenLabs API key found.\n"
                 "\n"
-                "You have 3 options:\n"
+                "You have 4 options:\n"
                 "\n"
                 "  1. Add an ElevenLabs key:\n"
                 "     echo \"ELEVENLABS_API_KEY=your_key\" >> .env\n"
                 "\n"
-                "  2. Use Qwen3-TTS instead (free, self-hosted):\n"
+                "  2. Use Edge-TTS instead (free, no API key or account needed):\n"
+                "     python3 tools/voiceover.py --provider edge-tts --scene-dir public/audio/scenes --json\n"
+                "     (Install with: pip install edge-tts. Includes Vietnamese voices.)\n"
+                "\n"
+                "  3. Use Qwen3-TTS instead (free, self-hosted):\n"
                 "     python3 tools/voiceover.py --provider qwen3 --speaker Ryan --scene-dir public/audio/scenes --json\n"
                 "     (Requires RunPod account — run: python3 tools/qwen3_tts.py --setup)\n"
                 "\n"
-                "  3. Skip voiceover entirely:\n"
+                "  4. Skip voiceover entirely:\n"
                 "     Videos render fine without audio. Add voiceover later when ready.",
                 file=sys.stderr,
             )

--- a/tools/voiceover.py
+++ b/tools/voiceover.py
@@ -175,7 +175,8 @@ Examples:
         default="Ryan",
         help="Speaker/voice name. For Qwen3-TTS: built-in speaker (default: Ryan; "
              "'python tools/qwen3_tts.py --list-voices' to see options). For Edge-TTS: "
-             "a voice name like 'vi-VN-HoaiMyNeural' (defaults to that voice when unset; "
+             "a voice name like 'en-US-AriaNeural' or 'vi-VN-HoaiMyNeural' "
+             "(defaults to en-US-AriaNeural when unset; "
              "'python tools/edgetts.py --list-voices' to see options).",
     )
     parser.add_argument(
@@ -467,7 +468,7 @@ def generate_batch_audio_qwen3(
 def generate_single_audio_edge_tts(
     script: str,
     output_path: Path,
-    voice: str = "vi-VN-HoaiMyNeural",
+    voice: str = "en-US-AriaNeural",
     rate: str = "+0%",
     pitch: str = "+0Hz",
     volume: str = "+0%",
@@ -848,7 +849,7 @@ def main():
 
     # Default voice for Edge-TTS when none given (CLI or brand)
     if provider == "edge-tts" and args.speaker == "Ryan":
-        args.speaker = "vi-VN-HoaiMyNeural"
+        args.speaker = "en-US-AriaNeural"
 
     # Resolve tone preset → instruct text for Qwen3
     if provider == "qwen3" and (args.tone or args.instruct):


### PR DESCRIPTION
## Summary
Adds Microsoft Edge TTS as a third `voiceover.py` backend alongside ElevenLabs and
Qwen3-TTS — free, no API key or account, ~300 voices including Vietnamese
(vi-VN-HoaiMyNeural, vi-VN-NamMinhNeural). Defaults to en-US-AriaNeural.

## Changes
- tools/edgetts.py — new module (single-utterance + list-voices), retries transient
  backend failures, distinguishes client-side param errors (fail fast) from
  transient ones (retry with backoff), never leaves a zero-byte file on failure
- tools/voiceover.py — wires edge-tts into the existing per-scene / single-file
  dispatch, `--rate`/`--pitch`/`--volume` flags, honest per-scene failure
  reporting (exit 1 + `[FAILED: ...]` on any scene that didn't produce audio)
- brands/default/voice.json — edgeTts config block
- CLAUDE.md, .claude/commands/generate-voiceover.md, _internal/toolkit-registry.json
  — docs and registry entries

## Testing
- Verified live against the real edge-tts backend: default voice (English),
  explicit Vietnamese voice, malformed --rate (fails fast, no retry burned),
  valid-but-nonexistent voice (retries 3x then cleans up), per-scene batch run
  with a forced failure (exits 1, reports which scene failed, no stray files)