### PR TITLE
Add MiniMax hosted video generation tool

### DIFF
--- a/.claude/skills/minimax-video/SKILL.md
+++ b/.claude/skills/minimax-video/SKILL.md
@@ -34,6 +34,7 @@ python3 tools/minimax_video.py \
 # Fast image-to-video model
 python3 tools/minimax_video.py \
   --model MiniMax-Hailuo-2.3-Fast \
+  --resolution 768P \
   --input first-frame.png \
   --prompt "The subject turns toward the camera" \
   --output fast.mp4
@@ -43,8 +44,8 @@ python3 tools/minimax_video.py \
 
 | Mode | Required input | Recommended model |
 |------|----------------|-------------------|
-| Text-to-video | `--prompt` | `MiniMax-Hailuo-2.3` |
-| Image-to-video | `--prompt` and `--input` | `MiniMax-Hailuo-2.3` |
+| Text-to-video | `--prompt` | `MiniMax-H3` |
+| Image-to-video | `--prompt` and `--input` | `MiniMax-H3` |
 | Fast image-to-video | `--prompt` and `--input` | `MiniMax-Hailuo-2.3-Fast` |
 
 `--input` accepts a local JPG, PNG, or WebP under 20 MB, a public image URL, or an
@@ -66,17 +67,20 @@ Keep the region consistent with the account that issued `MINIMAX_API_KEY`.
 | `--prompt` | required | Video content and motion description |
 | `--input` | none | First-frame image for image-to-video |
 | `--output` | required | Output MP4 path |
-| `--model` | `MiniMax-Hailuo-2.3` | Video generation model |
-| `--duration` | `6` | `6` or `10` seconds |
-| `--resolution` | `768P` | `512P`, `768P`, or `1080P`, subject to model limits |
+| `--model` | `MiniMax-H3` | Video generation model |
+| `--duration` | `6` | `4` to `15` seconds for `MiniMax-H3` |
+| `--resolution` | `2K` | `2K` for `MiniMax-H3`; legacy models use `512P`, `768P`, or `1080P` |
+| `--ratio` | `adaptive` | `adaptive`, `21:9`, `16:9`, `4:3`, `1:1`, `3:4`, or `9:16` for `MiniMax-H3` |
 | `--region` | `global_en` | `global_en` or `cn_zh` |
-| `--no-prompt-optimizer` | off | Disable server-side prompt optimization |
-| `--fast-pretreatment` | off | Reduce prompt optimization time on supported models |
+| `--no-prompt-optimizer` | off | Disable server-side prompt optimization on legacy models |
+| `--fast-pretreatment` | off | Reduce prompt optimization time on supported legacy models |
 | `--generation-timeout` | `900` | Overall async generation timeout in seconds |
 | `--poll-interval` | `10` | Task status polling interval in seconds |
 | `--json-out` | off | Print a machine-readable result line |
 
-Ten-second generation uses `768P`. The fast model is image-to-video only.
+`MiniMax-H3` uses the v2 video generation endpoint and returns a downloadable URL
+from the task query response. Legacy Hailuo models use the v1 endpoint and file
+retrieval flow. The fast legacy model is image-to-video only.
 
 ## Prompting
 
@@ -122,7 +126,8 @@ if the local polling process stops.
 
 ### Unsupported duration or resolution
 
-Use `6` seconds for `1080P`, or switch to `768P` for `10` seconds.
+Use `2K` with `MiniMax-H3` and keep the duration between 4 and 15 seconds. For
+legacy models, use `6` seconds for `1080P`, or switch to `768P` for `10` seconds.
 
 ### Image rejected
 

--- a/.claude/skills/minimax-video/SKILL.md
+++ b/.claude/skills/minimax-video/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: minimax-video
+description: Generate text-to-video and image-to-video clips with the MiniMax hosted video API. Use for cinematic b-roll, animated stills, product shots, social clips, camera-controlled motion, and cloud video generation without deploying a GPU endpoint.
+---
+
+# MiniMax Video Generation
+
+Generate video clips through the hosted MiniMax video API with `tools/minimax_video.py`.
+The tool creates an asynchronous task, polls its status, retrieves the generated file,
+and saves the final MP4.
+
+Set `MINIMAX_API_KEY` in `.env` before running the tool.
+
+## Quick Reference
+
+```bash
+# Text-to-video in the global region
+python3 tools/minimax_video.py \
+  --prompt "A cinematic aerial shot over a coastal city at golden hour" \
+  --output coast.mp4
+
+# Image-to-video from a local first frame
+python3 tools/minimax_video.py \
+  --prompt "Slow camera push-in, natural wind moving the trees" \
+  --input first-frame.png \
+  --output animated.mp4
+
+# China region
+python3 tools/minimax_video.py \
+  --region cn_zh \
+  --prompt "A clean studio product reveal with soft reflections" \
+  --output reveal.mp4
+
+# Fast image-to-video model
+python3 tools/minimax_video.py \
+  --model MiniMax-Hailuo-2.3-Fast \
+  --input first-frame.png \
+  --prompt "The subject turns toward the camera" \
+  --output fast.mp4
+```
+
+## Modes
+
+| Mode | Required input | Recommended model |
+|------|----------------|-------------------|
+| Text-to-video | `--prompt` | `MiniMax-Hailuo-2.3` |
+| Image-to-video | `--prompt` and `--input` | `MiniMax-Hailuo-2.3` |
+| Fast image-to-video | `--prompt` and `--input` | `MiniMax-Hailuo-2.3-Fast` |
+
+`--input` accepts a local JPG, PNG, or WebP under 20 MB, a public image URL, or an
+image data URL. Local images are encoded as data URLs before submission.
+
+## Regions
+
+| Flag | API region |
+|------|------------|
+| `--region global_en` | Global English API, default |
+| `--region cn_zh` | China API |
+
+Keep the region consistent with the account that issued `MINIMAX_API_KEY`.
+
+## Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `--prompt` | required | Video content and motion description |
+| `--input` | none | First-frame image for image-to-video |
+| `--output` | required | Output MP4 path |
+| `--model` | `MiniMax-Hailuo-2.3` | Video generation model |
+| `--duration` | `6` | `6` or `10` seconds |
+| `--resolution` | `768P` | `512P`, `768P`, or `1080P`, subject to model limits |
+| `--region` | `global_en` | `global_en` or `cn_zh` |
+| `--no-prompt-optimizer` | off | Disable server-side prompt optimization |
+| `--fast-pretreatment` | off | Reduce prompt optimization time on supported models |
+| `--generation-timeout` | `900` | Overall async generation timeout in seconds |
+| `--poll-interval` | `10` | Task status polling interval in seconds |
+| `--json-out` | off | Print a machine-readable result line |
+
+Ten-second generation uses `768P`. The fast model is image-to-video only.
+
+## Prompting
+
+Describe the scene, subject motion, camera motion, lighting, and visual style in that
+order. Keep the action achievable within the requested duration.
+
+```text
+A ceramic perfume bottle on black stone, mist drifting across the surface,
+[Push in], soft rim lighting, premium product commercial, shallow depth of field.
+```
+
+Supported camera instructions can be placed in square brackets, including:
+
+- `[Truck left]` or `[Truck right]`
+- `[Pan left]` or `[Pan right]`
+- `[Push in]` or `[Pull out]`
+- `[Pedestal up]` or `[Pedestal down]`
+- `[Tilt up]` or `[Tilt down]`
+- `[Zoom in]` or `[Zoom out]`
+- `[Shake]`, `[Tracking shot]`, or `[Static shot]`
+
+Use no more than three simultaneous camera instructions. For sequential moves, place
+the instructions in the prompt in the order they should occur.
+
+## Image-to-Video Guidance
+
+- Use a sharp first frame with a clear subject and intentional composition.
+- Describe motion that follows naturally from the still image.
+- Specify camera movement separately from subject movement.
+- Avoid asking for major identity, wardrobe, or scene changes in a short clip.
+- Use `--no-prompt-optimizer` when precise camera instructions must remain unchanged.
+
+## Troubleshooting
+
+### API key error
+
+Confirm `MINIMAX_API_KEY` is present in `.env` and that `--region` matches the account.
+
+### Generation timeout
+
+Increase `--generation-timeout`. The task remains associated with the API account even
+if the local polling process stops.
+
+### Unsupported duration or resolution
+
+Use `6` seconds for `1080P`, or switch to `768P` for `10` seconds.
+
+### Image rejected
+
+Use JPG, PNG, or WebP under 20 MB. The short edge must be greater than 300 pixels and
+the aspect ratio must stay between 2:5 and 5:2.

--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,12 @@
 # ELEVENLABS_VOICE_ID=your_voice_id_here
 
 
+# --- MiniMax hosted video generation ---
+# Used by tools/minimax_video.py for text-to-video and image-to-video.
+# The tool supports both global and China API regions through --region.
+# MINIMAX_API_KEY=your_api_key_here
+
+
 # --- YouTube upload (tools/youtube_upload.py) ---
 # YouTube uploads use OAuth 2.0 (acting on behalf of a channel), NOT an API key.
 # One-time setup (see docs/youtube-upload.md for the full walkthrough):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ If you're using this repo from Codex, run the migration script once to install t
 python3 scripts/migrate_to_codex.py --force
 ```
 
-That installs 25 entries (11 toolkit skills + 13 command wrappers + 1 overview). The script can also sync the full `CLAUDE.md` content into a generated block at the end of this file — re-run `--force` after editing `CLAUDE.md` to keep the synced block fresh. Manual content above the generated block (i.e. everything you're reading now) is preserved.
+That installs 28 entries (13 toolkit skills + 14 command wrappers + 1 overview). The script can also sync the full `CLAUDE.md` content into a generated block at the end of this file — re-run `--force` after editing `CLAUDE.md` to keep the synced block fresh. Manual content above the generated block (i.e. everything you're reading now) is preserved.
 
 To uninstall:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,7 @@ This is especially critical for background commands where the working directory 
 | **Project tools** | voiceover, music, music_gen, sfx, sync_timing | During video creation workflow |
 | **Utility tools** | redub, addmusic, notebooklm_brand, locate_watermark | Quick transformations on existing videos |
 | **Cloud GPU** | image_edit, upscale, dewatermark, sadtalker, qwen3_tts, music_gen, flux2 | AI processing via RunPod or Modal (`--cloud runpod\|modal`) |
+| **Hosted API** | minimax_video | Text-to-video and image-to-video through regional API endpoints |
 | **Publishing** | youtube_upload | Upload a finished render to YouTube (use `/publish` for the guided workflow) |
 
 Utility tools work on any video file without requiring a project structure.
@@ -185,6 +186,34 @@ modal deploy docker/modal-upscale/app.py        # Then save URL to .env
 modal deploy docker/modal-image-edit/app.py
 # See docs/modal-setup.md for full guide
 ```
+
+### MiniMax Video Generation
+
+`tools/minimax_video.py` generates video through the hosted MiniMax API. It supports
+text-to-video, image-to-video, global and China regions, asynchronous task polling,
+and automatic MP4 download. Set `MINIMAX_API_KEY` in `.env` first.
+
+```bash
+# Text-to-video
+python3 tools/minimax_video.py \
+  --prompt "A cinematic aerial shot over a coastal city" \
+  --output coast.mp4
+
+# Image-to-video
+python3 tools/minimax_video.py \
+  --input first-frame.png \
+  --prompt "Slow camera push-in, natural wind in the trees" \
+  --output animated.mp4
+
+# China region
+python3 tools/minimax_video.py \
+  --region cn_zh \
+  --prompt "A clean studio product reveal" \
+  --output reveal.mp4
+```
+
+Use `.claude/skills/minimax-video/` for model limits, camera-control syntax, and
+prompting guidance.
 
 ### AI Image Generation (FLUX.2 vs Ideogram 4)
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Claude Code has deep knowledge in:
 | **ideogram4** | AI image generation with best-in-class in-image text — title cards, thumbnails, exact brand colors |
 | **acestep** | AI music generation — prompts, lyrics, scene presets, video integration |
 | **ltx2** | AI video generation — text-to-video, image-to-video clips, prompting guide |
+| **minimax-video** | Hosted video generation — text-to-video, image-to-video, regional endpoints |
 | **moviepy** | Python video composition — overlay text on LTX-2/SadTalker output, build.py-style projects |
 | **runpod** | Cloud GPU — setup, Docker images, endpoint management, costs |
 
@@ -204,6 +205,9 @@ python tools/image_edit.py --input photo.jpg --prompt "Add sunglasses" --cloud m
 # AI video generation (LTX-2.3 — text-to-video, image-to-video)
 python tools/ltx2.py --prompt "A sunset over the ocean, cinematic" --cloud modal
 
+# Hosted AI video generation (text-to-video or image-to-video)
+python3 tools/minimax_video.py --prompt "A cinematic ocean sunrise" --output sunrise.mp4
+
 # Talking head from a portrait + audio (SadTalker)
 python tools/sadtalker.py --image portrait.png --audio voiceover.mp3 --output talking.mp4 --cloud modal
 ```
@@ -264,6 +268,10 @@ python tools/flux2.py --list-presets
 python tools/ltx2.py --prompt "A sunset over the ocean, cinematic" --cloud modal
 python tools/ltx2.py --prompt "Gentle camera drift" --input photo.jpg --cloud modal
 
+# Hosted AI video generation (global or China region)
+python3 tools/minimax_video.py --prompt "A cinematic ocean sunrise" --output sunrise.mp4
+python3 tools/minimax_video.py --input photo.jpg --prompt "Slow camera push-in" --output animated.mp4
+
 # Publish a finished render to YouTube (OAuth 2.0 + Data API v3) — contributed by @dascope (#29)
 python tools/youtube_upload.py --auth                                   # one-time browser login
 python tools/youtube_upload.py --video out/video.mp4 --title "My video" --privacy private --json-out
@@ -278,6 +286,7 @@ python tools/youtube_upload.py --video out/video.mp4 --title "My video" --privac
 | **Project** | voiceover, music, music_gen, sfx | Used during video creation workflow |
 | **Utility** | redub, addmusic, notebooklm_brand, locate_watermark | Quick transformations, no project needed |
 | **Cloud GPU** | image_edit, upscale, dewatermark, sadtalker, qwen3_tts, flux2, music_gen, ltx2 | AI processing via Modal or RunPod |
+| **Hosted API** | minimax_video | Text-to-video and image-to-video without a GPU deployment |
 | **Publishing** | youtube_upload | Upload a finished render to YouTube (or use `/publish`) |
 
 ### Cloud GPU (Modal + RunPod)

--- a/_internal/toolkit-registry.json
+++ b/_internal/toolkit-registry.json
@@ -77,6 +77,15 @@
       "created": "2026-03-25",
       "updated": "2026-04-08"
     },
+    "minimax-video": {
+      "path": ".claude/skills/minimax-video/",
+      "description": "Hosted text-to-video and image-to-video generation with regional API support, async task polling, and camera-control prompting",
+      "status": "beta",
+      "category": "video-generation",
+      "backend": "MiniMax video generation API",
+      "created": "2026-07-08",
+      "updated": "2026-07-08"
+    },
     "moviepy": {
       "path": ".claude/skills/moviepy/",
       "description": "Python video composition with moviepy 2.x — overlaying text on LTX-2/SadTalker output, single-file build.py video projects",
@@ -633,6 +642,44 @@
       "estimatedCost": "$0.20-0.25 per 5s clip",
       "created": "2026-03-25",
       "updated": "2026-04-21"
+    },
+    "minimax_video": {
+      "path": "tools/minimax_video.py",
+      "description": "Hosted text-to-video and image-to-video generation with async polling and download",
+      "usage": "python3 tools/minimax_video.py --prompt \"A cinematic ocean sunrise\" --output sunrise.mp4",
+      "status": "beta",
+      "category": "video-generation",
+      "backend": "MiniMax video generation API",
+      "requires": "MINIMAX_API_KEY",
+      "options": {
+        "modes": [
+          "text-to-video",
+          "image-to-video"
+        ],
+        "models": [
+          "MiniMax-Hailuo-2.3",
+          "MiniMax-Hailuo-2.3-Fast",
+          "MiniMax-Hailuo-02"
+        ],
+        "regions": [
+          "global_en",
+          "cn_zh"
+        ],
+        "duration": [
+          6,
+          10
+        ],
+        "resolution": [
+          "512P",
+          "768P",
+          "1080P"
+        ]
+      },
+      "envVars": [
+        "MINIMAX_API_KEY"
+      ],
+      "created": "2026-07-08",
+      "updated": "2026-07-08"
     },
     "chain_video": {
       "path": "tools/chain_video.py",

--- a/_internal/toolkit-registry.json
+++ b/_internal/toolkit-registry.json
@@ -657,22 +657,38 @@
           "image-to-video"
         ],
         "models": [
+          "MiniMax-H3",
           "MiniMax-Hailuo-2.3",
           "MiniMax-Hailuo-2.3-Fast",
-          "MiniMax-Hailuo-02"
+          "MiniMax-Hailuo-02",
+          "T2V-01-Director",
+          "T2V-01",
+          "I2V-01-Director",
+          "I2V-01-live",
+          "I2V-01"
         ],
         "regions": [
           "global_en",
           "cn_zh"
         ],
         "duration": [
-          6,
-          10
+          "MiniMax-H3: 4-15 seconds",
+          "legacy: 6 or 10 seconds"
         ],
         "resolution": [
+          "2K",
           "512P",
           "768P",
           "1080P"
+        ],
+        "ratio": [
+          "adaptive",
+          "21:9",
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16"
         ]
       },
       "envVars": [

--- a/tests/test_minimax_video.py
+++ b/tests/test_minimax_video.py
@@ -39,16 +39,30 @@ class MiniMaxVideoTests(unittest.TestCase):
             prompt="A city skyline at dusk",
             model=minimax_video.DEFAULT_MODEL,
             duration=6,
-            resolution="1080P",
-            prompt_optimizer=False,
-            fast_pretreatment=True,
+            resolution="2K",
+            ratio="16:9",
         )
 
         self.assertEqual(payload["model"], minimax_video.DEFAULT_MODEL)
-        self.assertEqual(payload["prompt"], "A city skyline at dusk")
-        self.assertFalse(payload["prompt_optimizer"])
-        self.assertTrue(payload["fast_pretreatment"])
+        self.assertEqual(payload["content"], [{"type": "text", "text": "A city skyline at dusk"}])
+        self.assertEqual(payload["resolution"], "2K")
+        self.assertEqual(payload["ratio"], "16:9")
         self.assertNotIn("first_frame_image", payload)
+
+    def test_builds_v2_image_to_video_payload(self):
+        payload = minimax_video.build_payload(
+            prompt="A moving camera",
+            model=minimax_video.DEFAULT_MODEL,
+            duration=8,
+            resolution="2K",
+            first_frame_image="https://example.com/frame.png",
+        )
+
+        self.assertEqual(payload["content"][1], {
+            "type": "image_url",
+            "image_url": "https://example.com/frame.png",
+            "role": "first_frame",
+        })
 
     def test_encodes_local_image_as_data_url(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -72,6 +86,15 @@ class MiniMaxVideoTests(unittest.TestCase):
                 resolution="768P",
             )
 
+    def test_v1_model_rejects_v2_resolution(self):
+        with self.assertRaisesRegex(ValueError, "does not support 2K"):
+            minimax_video.build_payload(
+                prompt="A moving camera",
+                model=minimax_video.HAILUO_23_MODEL,
+                duration=6,
+                resolution="2K",
+            )
+
     def test_512p_hailuo_02_requires_image_input(self):
         with self.assertRaisesRegex(ValueError, "only for image-to-video"):
             minimax_video.build_payload(
@@ -81,14 +104,14 @@ class MiniMaxVideoTests(unittest.TestCase):
                 resolution="512P",
             )
 
-    def test_create_task_uses_cn_endpoint(self):
+    def test_create_task_uses_v2_cn_endpoint(self):
         session = FakeSession([
             FakeResponse({"task_id": "task-1", "base_resp": {"status_code": 0}}),
         ])
 
         task_id = minimax_video.create_video_task(
             "test-key",
-            {"model": minimax_video.DEFAULT_MODEL, "prompt": "Test"},
+            {"model": minimax_video.DEFAULT_MODEL, "content": [{"type": "text", "text": "Test"}]},
             region="cn_zh",
             request_timeout=30,
             session=session,
@@ -97,8 +120,51 @@ class MiniMaxVideoTests(unittest.TestCase):
         self.assertEqual(task_id, "task-1")
         method, url, kwargs = session.calls[0]
         self.assertEqual(method, "POST")
-        self.assertEqual(url, "https://api.minimaxi.com/v1/video_generation")
+        self.assertEqual(url, "https://api.minimaxi.com/v2/video_generation")
         self.assertEqual(kwargs["headers"]["Authorization"], "Bearer test-key")
+
+    def test_create_task_uses_v1_endpoint_for_hailuo_model(self):
+        session = FakeSession([
+            FakeResponse({"task_id": "task-1", "base_resp": {"status_code": 0}}),
+        ])
+
+        minimax_video.create_video_task(
+            "test-key",
+            {"model": minimax_video.HAILUO_23_MODEL, "prompt": "Test"},
+            region="global_en",
+            request_timeout=30,
+            session=session,
+        )
+
+        self.assertEqual(session.calls[0][1], "https://api.minimax.io/v1/video_generation")
+
+    def test_poll_v2_returns_content_url_after_processing(self):
+        session = FakeSession([
+            FakeResponse({"task": {"status": "Processing"}, "base_resp": {"status_code": 0}}),
+            FakeResponse({
+                "task": {
+                    "status": "Success",
+                    "content": {"url": "https://download.example/video.mp4"},
+                },
+                "base_resp": {"status_code": 0},
+            }),
+        ])
+        clock = iter([0.0, 0.0, 1.0])
+
+        url = minimax_video.poll_video_task_v2(
+            "test-key",
+            "task-1",
+            region="global_en",
+            request_timeout=30,
+            generation_timeout=60,
+            poll_interval=10,
+            session=session,
+            sleep=lambda _: None,
+            monotonic=lambda: next(clock),
+        )
+
+        self.assertEqual(url, "https://download.example/video.mp4")
+        self.assertEqual(session.calls[0][1], "https://api.minimax.io/v2/query/video_generation/task-1")
 
     def test_poll_returns_file_id_after_processing(self):
         session = FakeSession([
@@ -130,7 +196,7 @@ class MiniMaxVideoTests(unittest.TestCase):
         with self.assertRaisesRegex(minimax_video.MiniMaxVideoError, "authentication failed"):
             minimax_video.create_video_task(
                 "test-key",
-                {"model": minimax_video.DEFAULT_MODEL, "prompt": "Test"},
+                {"model": minimax_video.DEFAULT_MODEL, "content": [{"type": "text", "text": "Test"}]},
                 region="global_en",
                 request_timeout=30,
                 session=session,

--- a/tests/test_minimax_video.py
+++ b/tests/test_minimax_video.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools import minimax_video
+
+
+class FakeResponse:
+    def __init__(self, payload=None, content=b"video"):
+        self.payload = payload
+        self.content = content
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self.payload
+
+    def iter_content(self, chunk_size):
+        del chunk_size
+        yield self.content
+
+
+class FakeSession:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def request(self, method, url, **kwargs):
+        self.calls.append((method, url, kwargs))
+        return self.responses.pop(0)
+
+
+class MiniMaxVideoTests(unittest.TestCase):
+    def test_builds_text_to_video_payload(self):
+        payload = minimax_video.build_payload(
+            prompt="A city skyline at dusk",
+            model=minimax_video.DEFAULT_MODEL,
+            duration=6,
+            resolution="1080P",
+            prompt_optimizer=False,
+            fast_pretreatment=True,
+        )
+
+        self.assertEqual(payload["model"], minimax_video.DEFAULT_MODEL)
+        self.assertEqual(payload["prompt"], "A city skyline at dusk")
+        self.assertFalse(payload["prompt_optimizer"])
+        self.assertTrue(payload["fast_pretreatment"])
+        self.assertNotIn("first_frame_image", payload)
+
+    def test_encodes_local_image_as_data_url(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            image = Path(tmpdir) / "frame.png"
+            image.write_bytes(b"png-data")
+
+            source = minimax_video.image_source(str(image))
+
+        self.assertTrue(source.startswith("data:image/png;base64,"))
+
+    def test_rejects_unsupported_image_data_url(self):
+        with self.assertRaisesRegex(ValueError, "Unsupported image data URL type"):
+            minimax_video.image_source("data:image/gif;base64,AAAA")
+
+    def test_fast_model_requires_image_input(self):
+        with self.assertRaisesRegex(ValueError, "requires --input"):
+            minimax_video.build_payload(
+                prompt="A moving camera",
+                model=minimax_video.FAST_MODEL,
+                duration=6,
+                resolution="768P",
+            )
+
+    def test_512p_hailuo_02_requires_image_input(self):
+        with self.assertRaisesRegex(ValueError, "only for image-to-video"):
+            minimax_video.build_payload(
+                prompt="A moving camera",
+                model=minimax_video.HAILUO_02_MODEL,
+                duration=6,
+                resolution="512P",
+            )
+
+    def test_create_task_uses_cn_endpoint(self):
+        session = FakeSession([
+            FakeResponse({"task_id": "task-1", "base_resp": {"status_code": 0}}),
+        ])
+
+        task_id = minimax_video.create_video_task(
+            "test-key",
+            {"model": minimax_video.DEFAULT_MODEL, "prompt": "Test"},
+            region="cn_zh",
+            request_timeout=30,
+            session=session,
+        )
+
+        self.assertEqual(task_id, "task-1")
+        method, url, kwargs = session.calls[0]
+        self.assertEqual(method, "POST")
+        self.assertEqual(url, "https://api.minimaxi.com/v1/video_generation")
+        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer test-key")
+
+    def test_poll_returns_file_id_after_processing(self):
+        session = FakeSession([
+            FakeResponse({"status": "Processing", "base_resp": {"status_code": 0}}),
+            FakeResponse({"status": "Success", "file_id": "file-1", "base_resp": {"status_code": 0}}),
+        ])
+        clock = iter([0.0, 0.0, 1.0])
+
+        file_id = minimax_video.poll_video_task(
+            "test-key",
+            "task-1",
+            region="global_en",
+            request_timeout=30,
+            generation_timeout=60,
+            poll_interval=10,
+            session=session,
+            sleep=lambda _: None,
+            monotonic=lambda: next(clock),
+        )
+
+        self.assertEqual(file_id, "file-1")
+        self.assertEqual(session.calls[0][1], "https://api.minimax.io/v1/query/video_generation")
+
+    def test_api_error_is_raised(self):
+        session = FakeSession([
+            FakeResponse({"base_resp": {"status_code": 1004, "status_msg": "authentication failed"}}),
+        ])
+
+        with self.assertRaisesRegex(minimax_video.MiniMaxVideoError, "authentication failed"):
+            minimax_video.create_video_task(
+                "test-key",
+                {"model": minimax_video.DEFAULT_MODEL, "prompt": "Test"},
+                region="global_en",
+                request_timeout=30,
+                session=session,
+            )
+
+    def test_download_writes_video(self):
+        session = FakeSession([FakeResponse(content=b"mp4-bytes")])
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = Path(tmpdir) / "out.mp4"
+
+            result = minimax_video.download_video(
+                "https://download.example/video.mp4",
+                str(output),
+                request_timeout=30,
+                session=session,
+            )
+
+            self.assertEqual(result, str(output))
+            self.assertEqual(output.read_bytes(), b"mp4-bytes")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/config.py
+++ b/tools/config.py
@@ -72,6 +72,13 @@ def get_ideogram_api_key() -> str | None:
     return os.getenv("IDEOGRAM_API_KEY")
 
 
+def get_minimax_api_key() -> str | None:
+    """Get the MiniMax hosted API key from environment."""
+    from dotenv import load_dotenv
+    load_dotenv()
+    return os.getenv("MINIMAX_API_KEY")
+
+
 def get_youtube_client_secrets_file() -> str | None:
     """Path to the OAuth 2.0 'Desktop app' client_secret JSON used for YouTube uploads.
 

--- a/tools/minimax_video.py
+++ b/tools/minimax_video.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env python3
+"""Generate videos with the MiniMax hosted video API.
+
+Supports text-to-video and image-to-video generation in the global and China
+regions. Video generation is asynchronous: the tool creates a task, polls it,
+retrieves the generated file, and downloads the final MP4.
+
+Examples:
+  python3 tools/minimax_video.py \
+      --prompt "A cinematic aerial shot over a coastal city" \
+      --output coast.mp4
+
+  python3 tools/minimax_video.py \
+      --prompt "Slow camera push-in, natural wind in the trees" \
+      --input first-frame.png \
+      --output animated.mp4
+
+  python3 tools/minimax_video.py \
+      --region cn_zh \
+      --prompt "A product reveal with soft studio lighting" \
+      --output reveal.mp4
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import mimetypes
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+try:
+    import requests
+    from dotenv import load_dotenv
+except ImportError as e:
+    print(f"Missing dependency: {e}")
+    print("Install with: pip install requests python-dotenv")
+    sys.exit(1)
+
+load_dotenv()
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+API_BASES = {
+    "global_en": "https://api.minimax.io",
+    "cn_zh": "https://api.minimaxi.com",
+}
+DEFAULT_MODEL = "MiniMax-Hailuo-2.3"
+FAST_MODEL = "MiniMax-Hailuo-2.3-Fast"
+HAILUO_02_MODEL = "MiniMax-Hailuo-02"
+SUPPORTED_MODELS = [DEFAULT_MODEL, FAST_MODEL, HAILUO_02_MODEL]
+SUPPORTED_IMAGE_TYPES = {"image/jpeg", "image/png", "image/webp"}
+MAX_IMAGE_BYTES = 20 * 1024 * 1024
+
+
+class MiniMaxVideoError(RuntimeError):
+    """Raised when the video API returns an error or invalid response."""
+
+
+def log(message: str, level: str = "info") -> None:
+    """Print a formatted status message to stderr."""
+    colors = {
+        "info": "\033[94m",
+        "success": "\033[92m",
+        "error": "\033[91m",
+        "warn": "\033[93m",
+        "dim": "\033[90m",
+    }
+    reset = "\033[0m"
+    prefix = {"info": "->", "success": "OK", "error": "!!", "warn": "??", "dim": "  "}
+    print(f"{colors.get(level, '')}{prefix.get(level, '->')} {message}{reset}", file=sys.stderr)
+
+
+def api_url(region: str, path: str) -> str:
+    """Build an API URL for an official MiniMax region."""
+    try:
+        base = API_BASES[region]
+    except KeyError as e:
+        raise ValueError(f"Unknown region: {region}") from e
+    return f"{base}{path}"
+
+
+def image_source(source: str) -> str:
+    """Return a URL/data URL, encoding a local image as a data URL when needed."""
+    if source.startswith(("https://", "http://")):
+        return source
+    if source.startswith("data:image/"):
+        media_type = source.split(";", 1)[0].removeprefix("data:")
+        if media_type not in SUPPORTED_IMAGE_TYPES:
+            raise ValueError(f"Unsupported image data URL type: {media_type}")
+        return source
+
+    path = Path(source)
+    if not path.is_file():
+        raise ValueError(f"Input image not found: {source}")
+    if path.stat().st_size >= MAX_IMAGE_BYTES:
+        raise ValueError("Input image must be smaller than 20 MB")
+
+    media_type = mimetypes.guess_type(path.name)[0]
+    if media_type not in SUPPORTED_IMAGE_TYPES:
+        supported = ", ".join(sorted(SUPPORTED_IMAGE_TYPES))
+        raise ValueError(f"Unsupported image type: {media_type or 'unknown'} (use {supported})")
+
+    encoded = base64.b64encode(path.read_bytes()).decode("ascii")
+    return f"data:{media_type};base64,{encoded}"
+
+
+def build_payload(
+    *,
+    prompt: str,
+    model: str,
+    duration: int,
+    resolution: str,
+    first_frame_image: str | None = None,
+    prompt_optimizer: bool | None = None,
+    fast_pretreatment: bool = False,
+) -> dict[str, Any]:
+    """Build and validate a video generation request payload."""
+    if not prompt.strip():
+        raise ValueError("Prompt must not be empty")
+    if model not in SUPPORTED_MODELS:
+        raise ValueError(f"Unsupported model: {model}")
+    if model == FAST_MODEL and first_frame_image is None:
+        raise ValueError(f"{FAST_MODEL} requires --input for image-to-video generation")
+    if duration == 10 and resolution == "1080P":
+        raise ValueError("10-second generation supports 768P resolution")
+    if model in {DEFAULT_MODEL, FAST_MODEL} and resolution in {"512P", "720P"}:
+        raise ValueError(f"{model} supports 768P or 1080P resolution")
+    if model == HAILUO_02_MODEL and first_frame_image is None and resolution == "512P":
+        raise ValueError(f"{HAILUO_02_MODEL} supports 512P only for image-to-video generation")
+
+    payload: dict[str, Any] = {
+        "model": model,
+        "prompt": prompt,
+        "duration": duration,
+        "resolution": resolution,
+    }
+    if first_frame_image is not None:
+        payload["first_frame_image"] = first_frame_image
+    if prompt_optimizer is not None:
+        payload["prompt_optimizer"] = prompt_optimizer
+    if fast_pretreatment:
+        payload["fast_pretreatment"] = True
+    return payload
+
+
+def request_json(
+    session: Any,
+    method: str,
+    url: str,
+    *,
+    api_key: str,
+    timeout: int,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Send an authenticated request and validate the API response envelope."""
+    headers = dict(kwargs.pop("headers", {}))
+    headers["Authorization"] = f"Bearer {api_key}"
+    try:
+        response = session.request(method, url, headers=headers, timeout=timeout, **kwargs)
+        response.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        raise MiniMaxVideoError(f"Request failed: {e}") from e
+
+    try:
+        data = response.json()
+    except ValueError as e:
+        raise MiniMaxVideoError("API returned invalid JSON") from e
+    if not isinstance(data, dict):
+        raise MiniMaxVideoError("API returned a non-object response")
+
+    base_response = data.get("base_resp") or {}
+    status_code = base_response.get("status_code")
+    if status_code not in (None, 0):
+        message = base_response.get("status_msg") or "unknown API error"
+        raise MiniMaxVideoError(f"API error {status_code}: {message}")
+    return data
+
+
+def create_video_task(
+    api_key: str,
+    payload: dict[str, Any],
+    *,
+    region: str,
+    request_timeout: int,
+    session: Any = requests,
+) -> str:
+    """Create an asynchronous video task and return its ID."""
+    data = request_json(
+        session,
+        "POST",
+        api_url(region, "/v1/video_generation"),
+        api_key=api_key,
+        timeout=request_timeout,
+        headers={"Content-Type": "application/json"},
+        json=payload,
+    )
+    task_id = data.get("task_id")
+    if not task_id:
+        raise MiniMaxVideoError("Task creation response did not include task_id")
+    return str(task_id)
+
+
+def poll_video_task(
+    api_key: str,
+    task_id: str,
+    *,
+    region: str,
+    request_timeout: int,
+    generation_timeout: int,
+    poll_interval: float,
+    session: Any = requests,
+    sleep: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> str:
+    """Poll a video task until it succeeds, fails, or times out."""
+    deadline = monotonic() + generation_timeout
+    while True:
+        data = request_json(
+            session,
+            "GET",
+            api_url(region, "/v1/query/video_generation"),
+            api_key=api_key,
+            timeout=request_timeout,
+            params={"task_id": task_id},
+        )
+        status = data.get("status")
+        if status == "Success":
+            file_id = data.get("file_id")
+            if not file_id:
+                raise MiniMaxVideoError("Successful task did not include file_id")
+            return str(file_id)
+        if status == "Fail":
+            message = (data.get("base_resp") or {}).get("status_msg") or "unknown generation error"
+            raise MiniMaxVideoError(f"Video generation failed: {message}")
+
+        remaining = deadline - monotonic()
+        if remaining <= 0:
+            raise MiniMaxVideoError(f"Video generation timed out after {generation_timeout}s")
+        log(f"Task {task_id}: {status or 'unknown'}", "dim")
+        sleep(min(poll_interval, remaining))
+
+
+def retrieve_download_url(
+    api_key: str,
+    file_id: str,
+    *,
+    region: str,
+    request_timeout: int,
+    session: Any = requests,
+) -> str:
+    """Retrieve the temporary download URL for a generated video file."""
+    data = request_json(
+        session,
+        "GET",
+        api_url(region, "/v1/files/retrieve"),
+        api_key=api_key,
+        timeout=request_timeout,
+        params={"file_id": file_id},
+    )
+    download_url = (data.get("file") or {}).get("download_url")
+    if not download_url:
+        raise MiniMaxVideoError("File response did not include download_url")
+    return str(download_url)
+
+
+def download_video(
+    download_url: str,
+    output_path: str,
+    *,
+    request_timeout: int,
+    session: Any = requests,
+) -> str:
+    """Download a generated video to disk."""
+    try:
+        response = session.request("GET", download_url, timeout=request_timeout, stream=True)
+        response.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        raise MiniMaxVideoError(f"Video download failed: {e}") from e
+
+    output = Path(output_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("wb") as handle:
+        for chunk in response.iter_content(chunk_size=1024 * 1024):
+            if chunk:
+                handle.write(chunk)
+    return str(output)
+
+
+def generate_video(
+    api_key: str,
+    *,
+    prompt: str,
+    output_path: str,
+    input_image: str | None = None,
+    model: str = DEFAULT_MODEL,
+    duration: int = 6,
+    resolution: str = "768P",
+    region: str = "global_en",
+    prompt_optimizer: bool | None = None,
+    fast_pretreatment: bool = False,
+    request_timeout: int = 60,
+    generation_timeout: int = 900,
+    poll_interval: float = 10,
+    session: Any = requests,
+) -> dict[str, str]:
+    """Generate and download a video, returning task and file metadata."""
+    if request_timeout <= 0:
+        raise ValueError("Request timeout must be greater than zero")
+    if generation_timeout <= 0:
+        raise ValueError("Generation timeout must be greater than zero")
+    if poll_interval <= 0:
+        raise ValueError("Poll interval must be greater than zero")
+
+    first_frame = image_source(input_image) if input_image else None
+    payload = build_payload(
+        prompt=prompt,
+        model=model,
+        duration=duration,
+        resolution=resolution,
+        first_frame_image=first_frame,
+        prompt_optimizer=prompt_optimizer,
+        fast_pretreatment=fast_pretreatment,
+    )
+
+    mode = "image-to-video" if first_frame else "text-to-video"
+    log(f"Mode: {mode}  Model: {model}  Region: {region}", "info")
+    log(f"Duration: {duration}s  Resolution: {resolution}", "dim")
+
+    task_id = create_video_task(
+        api_key,
+        payload,
+        region=region,
+        request_timeout=request_timeout,
+        session=session,
+    )
+    log(f"Task submitted: {task_id}", "success")
+    file_id = poll_video_task(
+        api_key,
+        task_id,
+        region=region,
+        request_timeout=request_timeout,
+        generation_timeout=generation_timeout,
+        poll_interval=poll_interval,
+        session=session,
+    )
+    download_url = retrieve_download_url(
+        api_key,
+        file_id,
+        region=region,
+        request_timeout=request_timeout,
+        session=session,
+    )
+    output = download_video(
+        download_url,
+        output_path,
+        request_timeout=request_timeout,
+        session=session,
+    )
+    log(f"Saved: {output}", "success")
+    return {"output": output, "task_id": task_id, "file_id": file_id}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate text-to-video or image-to-video clips with the MiniMax hosted API.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --prompt "A cinematic ocean sunrise" --output sunrise.mp4
+  %(prog)s --prompt "Slow camera push-in" --input still.png --output animated.mp4
+  %(prog)s --region cn_zh --prompt "A studio product reveal" --output reveal.mp4
+        """,
+    )
+    parser.add_argument("--prompt", "-p", required=True, help="Video content and motion prompt")
+    parser.add_argument("--input", "-i", help="First-frame image path, public URL, or image data URL")
+    parser.add_argument("--output", "-o", required=True, help="Output MP4 path")
+    parser.add_argument("--model", choices=SUPPORTED_MODELS, default=DEFAULT_MODEL,
+                        help=f"Video model (default: {DEFAULT_MODEL})")
+    parser.add_argument("--duration", type=int, choices=[6, 10], default=6,
+                        help="Video duration in seconds (default: 6)")
+    parser.add_argument("--resolution", choices=["512P", "768P", "1080P"], default="768P",
+                        help="Output resolution (default: 768P)")
+    parser.add_argument("--region", choices=sorted(API_BASES), default="global_en",
+                        help="API region: global_en or cn_zh (default: global_en)")
+    parser.add_argument("--prompt-optimizer", action=argparse.BooleanOptionalAction, default=None,
+                        help="Enable or disable server-side prompt optimization")
+    parser.add_argument("--fast-pretreatment", action="store_true",
+                        help="Reduce prompt optimization time on supported models")
+    parser.add_argument("--request-timeout", type=int, default=60,
+                        help="Per-request timeout seconds (default: 60)")
+    parser.add_argument("--generation-timeout", type=int, default=900,
+                        help="Overall generation timeout seconds (default: 900)")
+    parser.add_argument("--poll-interval", type=float, default=10,
+                        help="Task polling interval seconds (default: 10)")
+    parser.add_argument("--no-open", action="store_true", help="Do not open the generated video")
+    parser.add_argument("--json-out", action="store_true", help="Emit a machine-readable result line")
+    args = parser.parse_args()
+
+    from config import get_minimax_api_key
+
+    api_key = get_minimax_api_key()
+    if not api_key:
+        log("MINIMAX_API_KEY not set.", "error")
+        log("Add MINIMAX_API_KEY to .env before using this tool.", "info")
+        sys.exit(1)
+
+    try:
+        result = generate_video(
+            api_key,
+            prompt=args.prompt,
+            output_path=args.output,
+            input_image=args.input,
+            model=args.model,
+            duration=args.duration,
+            resolution=args.resolution,
+            region=args.region,
+            prompt_optimizer=args.prompt_optimizer,
+            fast_pretreatment=args.fast_pretreatment,
+            request_timeout=args.request_timeout,
+            generation_timeout=args.generation_timeout,
+            poll_interval=args.poll_interval,
+        )
+    except (MiniMaxVideoError, OSError, ValueError) as e:
+        log(str(e), "error")
+        if args.json_out:
+            print(json.dumps({"success": False, "error": str(e)}))
+        sys.exit(1)
+
+    if args.json_out:
+        print(json.dumps({"success": True, **result}))
+    if not args.no_open and sys.platform == "darwin":
+        import subprocess
+        subprocess.run(["open", result["output"]], check=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/minimax_video.py
+++ b/tools/minimax_video.py
@@ -47,12 +47,25 @@ API_BASES = {
     "global_en": "https://api.minimax.io",
     "cn_zh": "https://api.minimaxi.com",
 }
-DEFAULT_MODEL = "MiniMax-Hailuo-2.3"
+DEFAULT_MODEL = "MiniMax-H3"
+V2_MODELS = {DEFAULT_MODEL}
+HAILUO_23_MODEL = "MiniMax-Hailuo-2.3"
 FAST_MODEL = "MiniMax-Hailuo-2.3-Fast"
 HAILUO_02_MODEL = "MiniMax-Hailuo-02"
-SUPPORTED_MODELS = [DEFAULT_MODEL, FAST_MODEL, HAILUO_02_MODEL]
+V1_MODELS = [
+    HAILUO_23_MODEL,
+    FAST_MODEL,
+    HAILUO_02_MODEL,
+    "T2V-01-Director",
+    "T2V-01",
+    "I2V-01-Director",
+    "I2V-01-live",
+    "I2V-01",
+]
+SUPPORTED_MODELS = [DEFAULT_MODEL, *V1_MODELS]
 SUPPORTED_IMAGE_TYPES = {"image/jpeg", "image/png", "image/webp"}
 MAX_IMAGE_BYTES = 20 * 1024 * 1024
+V2_RATIOS = ["adaptive", "21:9", "16:9", "4:3", "1:1", "3:4", "9:16"]
 
 
 class MiniMaxVideoError(RuntimeError):
@@ -116,17 +129,41 @@ def build_payload(
     first_frame_image: str | None = None,
     prompt_optimizer: bool | None = None,
     fast_pretreatment: bool = False,
+    ratio: str = "adaptive",
 ) -> dict[str, Any]:
     """Build and validate a video generation request payload."""
     if not prompt.strip():
         raise ValueError("Prompt must not be empty")
     if model not in SUPPORTED_MODELS:
         raise ValueError(f"Unsupported model: {model}")
+    if model in V2_MODELS:
+        if not 4 <= duration <= 15:
+            raise ValueError(f"{model} duration must be between 4 and 15 seconds")
+        if resolution != "2K":
+            raise ValueError(f"{model} supports 2K resolution")
+        if ratio not in V2_RATIOS:
+            raise ValueError(f"Unsupported ratio: {ratio}")
+
+        content: list[dict[str, str]] = [{"type": "text", "text": prompt}]
+        if first_frame_image is not None:
+            content.append({"type": "image_url", "image_url": first_frame_image, "role": "first_frame"})
+        payload: dict[str, Any] = {
+            "model": model,
+            "content": content,
+            "duration": duration,
+            "resolution": resolution,
+        }
+        if ratio != "adaptive":
+            payload["ratio"] = ratio
+        return payload
+
     if model == FAST_MODEL and first_frame_image is None:
         raise ValueError(f"{FAST_MODEL} requires --input for image-to-video generation")
+    if resolution == "2K":
+        raise ValueError(f"{model} does not support 2K resolution")
     if duration == 10 and resolution == "1080P":
         raise ValueError("10-second generation supports 768P resolution")
-    if model in {DEFAULT_MODEL, FAST_MODEL} and resolution in {"512P", "720P"}:
+    if model in {HAILUO_23_MODEL, FAST_MODEL} and resolution in {"512P", "720P"}:
         raise ValueError(f"{model} supports 768P or 1080P resolution")
     if model == HAILUO_02_MODEL and first_frame_image is None and resolution == "512P":
         raise ValueError(f"{HAILUO_02_MODEL} supports 512P only for image-to-video generation")
@@ -144,6 +181,15 @@ def build_payload(
     if fast_pretreatment:
         payload["fast_pretreatment"] = True
     return payload
+
+
+def api_version_for_model(model: str) -> str:
+    """Return the video API version required by a supported model."""
+    if model in V2_MODELS:
+        return "v2"
+    if model in V1_MODELS:
+        return "v1"
+    raise ValueError(f"Unsupported model: {model}")
 
 
 def request_json(
@@ -188,10 +234,12 @@ def create_video_task(
     session: Any = requests,
 ) -> str:
     """Create an asynchronous video task and return its ID."""
+    api_version = api_version_for_model(str(payload.get("model", "")))
+    path = "/v2/video_generation" if api_version == "v2" else "/v1/video_generation"
     data = request_json(
         session,
         "POST",
-        api_url(region, "/v1/video_generation"),
+        api_url(region, path),
         api_key=api_key,
         timeout=request_timeout,
         headers={"Content-Type": "application/json"},
@@ -235,6 +283,48 @@ def poll_video_task(
         if status == "Fail":
             message = (data.get("base_resp") or {}).get("status_msg") or "unknown generation error"
             raise MiniMaxVideoError(f"Video generation failed: {message}")
+
+        remaining = deadline - monotonic()
+        if remaining <= 0:
+            raise MiniMaxVideoError(f"Video generation timed out after {generation_timeout}s")
+        log(f"Task {task_id}: {status or 'unknown'}", "dim")
+        sleep(min(poll_interval, remaining))
+
+
+def poll_video_task_v2(
+    api_key: str,
+    task_id: str,
+    *,
+    region: str,
+    request_timeout: int,
+    generation_timeout: int,
+    poll_interval: float,
+    session: Any = requests,
+    sleep: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> str:
+    """Poll a v2 video task until it returns a downloadable content URL."""
+    deadline = monotonic() + generation_timeout
+    while True:
+        data = request_json(
+            session,
+            "GET",
+            api_url(region, f"/v2/query/video_generation/{task_id}"),
+            api_key=api_key,
+            timeout=request_timeout,
+        )
+        task = data.get("task") or {}
+        status = task.get("status")
+        content = task.get("content") or {}
+        if status in {"Success", "Succeeded", "Completed", "success", "succeeded", "completed"}:
+            url = content.get("url")
+            if not url:
+                raise MiniMaxVideoError("Successful task did not include task.content.url")
+            return str(url)
+        if status in {"Fail", "Failed", "Error", "fail", "failed", "error"}:
+            error = task.get("error") or {}
+            message = error.get("message") if isinstance(error, dict) else error
+            raise MiniMaxVideoError(f"Video generation failed: {message or 'unknown generation error'}")
 
         remaining = deadline - monotonic()
         if remaining <= 0:
@@ -297,10 +387,11 @@ def generate_video(
     input_image: str | None = None,
     model: str = DEFAULT_MODEL,
     duration: int = 6,
-    resolution: str = "768P",
+    resolution: str = "2K",
     region: str = "global_en",
     prompt_optimizer: bool | None = None,
     fast_pretreatment: bool = False,
+    ratio: str = "adaptive",
     request_timeout: int = 60,
     generation_timeout: int = 900,
     poll_interval: float = 10,
@@ -323,6 +414,7 @@ def generate_video(
         first_frame_image=first_frame,
         prompt_optimizer=prompt_optimizer,
         fast_pretreatment=fast_pretreatment,
+        ratio=ratio,
     )
 
     mode = "image-to-video" if first_frame else "text-to-video"
@@ -337,22 +429,35 @@ def generate_video(
         session=session,
     )
     log(f"Task submitted: {task_id}", "success")
-    file_id = poll_video_task(
-        api_key,
-        task_id,
-        region=region,
-        request_timeout=request_timeout,
-        generation_timeout=generation_timeout,
-        poll_interval=poll_interval,
-        session=session,
-    )
-    download_url = retrieve_download_url(
-        api_key,
-        file_id,
-        region=region,
-        request_timeout=request_timeout,
-        session=session,
-    )
+    api_version = api_version_for_model(model)
+    if api_version == "v2":
+        download_url = poll_video_task_v2(
+            api_key,
+            task_id,
+            region=region,
+            request_timeout=request_timeout,
+            generation_timeout=generation_timeout,
+            poll_interval=poll_interval,
+            session=session,
+        )
+        file_id = ""
+    else:
+        file_id = poll_video_task(
+            api_key,
+            task_id,
+            region=region,
+            request_timeout=request_timeout,
+            generation_timeout=generation_timeout,
+            poll_interval=poll_interval,
+            session=session,
+        )
+        download_url = retrieve_download_url(
+            api_key,
+            file_id,
+            region=region,
+            request_timeout=request_timeout,
+            session=session,
+        )
     output = download_video(
         download_url,
         output_path,
@@ -379,12 +484,14 @@ Examples:
     parser.add_argument("--output", "-o", required=True, help="Output MP4 path")
     parser.add_argument("--model", choices=SUPPORTED_MODELS, default=DEFAULT_MODEL,
                         help=f"Video model (default: {DEFAULT_MODEL})")
-    parser.add_argument("--duration", type=int, choices=[6, 10], default=6,
+    parser.add_argument("--duration", type=int, default=6,
                         help="Video duration in seconds (default: 6)")
-    parser.add_argument("--resolution", choices=["512P", "768P", "1080P"], default="768P",
-                        help="Output resolution (default: 768P)")
+    parser.add_argument("--resolution", choices=["2K", "512P", "768P", "1080P"], default="2K",
+                        help="Output resolution (default: 2K)")
     parser.add_argument("--region", choices=sorted(API_BASES), default="global_en",
                         help="API region: global_en or cn_zh (default: global_en)")
+    parser.add_argument("--ratio", choices=V2_RATIOS, default="adaptive",
+                        help="Aspect ratio for MiniMax-H3 (default: adaptive)")
     parser.add_argument("--prompt-optimizer", action=argparse.BooleanOptionalAction, default=None,
                         help="Enable or disable server-side prompt optimization")
     parser.add_argument("--fast-pretreatment", action="store_true",
@@ -419,6 +526,7 @@ Examples:
             region=args.region,
             prompt_optimizer=args.prompt_optimizer,
             fast_pretreatment=args.fast_pretreatment,
+            ratio=args.ratio,
             request_timeout=args.request_timeout,
             generation_timeout=args.generation_timeout,
             poll_interval=args.poll_interval,


### PR DESCRIPTION
Reason: add target video capability using existing tool/provider pattern

## Summary
- add a hosted text-to-video and image-to-video CLI with global_en and cn_zh API regions
- add asynchronous task polling, local image data URL support, request validation, and MP4 download
- register and document the tool and skill, including environment setup and Codex migration coverage
- add mocked unit coverage for payloads, regional endpoints, polling, API errors, and downloads

## Checks
- `.venv/bin/python -m pip check`
- `.venv/bin/python -m compileall -q tools/minimax_video.py tests/test_minimax_video.py`
- `.venv/bin/python -m unittest discover -s tests -p 'test_minimax_video.py'`
- `.venv/bin/python tools/minimax_video.py --help`
- `.venv/bin/python -m json.tool _internal/toolkit-registry.json`
- `.venv/bin/python scripts/migrate_to_codex.py --repo-root . --dry-run`
- `git diff --check`