### PR TITLE
feat: add Atlas Cloud image generation tool

### DIFF
--- a/_internal/toolkit-registry.json
+++ b/_internal/toolkit-registry.json
@@ -592,6 +592,25 @@
       },
       "note": "Commercial license via paid API. Skill `.claude/skills/ideogram4/` teaches the JSON caption format; Claude is the magic-prompt expander. Live-tested (json_prompt + text_prompt paths)."
     },
+    "atlascloud": {
+      "path": "tools/atlascloud.py",
+      "description": "Asynchronous text-to-image generation through Atlas Cloud with task polling and local result download",
+      "usage": "python3 tools/atlascloud.py --prompt \"Editorial title card, no text\" --output title.jpg",
+      "status": "beta",
+      "category": "image-generation",
+      "backend": "Atlas Cloud media generation API",
+      "requires": "ATLASCLOUD_API_KEY (atlascloud.ai)",
+      "options": {
+        "defaultModel": "bytedance/seedream-v5.0-lite",
+        "customModel": true,
+        "customParams": true,
+        "outputFormats": [
+          "jpeg",
+          "png"
+        ]
+      },
+      "note": "Uses Atlas Cloud's asynchronous generateImage and prediction endpoints. The default model and request contract were live-tested."
+    },
     "ltx2": {
       "path": "tools/ltx2.py",
       "description": "AI video generation using LTX-2.3 22B - text-to-video, image-to-video clips with synchronized audio",

--- a/tests/test_atlascloud.py
+++ b/tests/test_atlascloud.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+
+import atlascloud
+
+
+class FakeResponse:
+    def __init__(self, payload=None, *, content=b"", status_code=200):
+        self.payload = payload
+        self.content = content
+        self.status_code = status_code
+
+    def json(self):
+        return self.payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise atlascloud.requests.HTTPError(f"HTTP {self.status_code}")
+
+
+class FakeHTTP:
+    def __init__(self, post_response, get_responses):
+        self.post_response = post_response
+        self.get_responses = list(get_responses)
+        self.post_calls = []
+        self.get_calls = []
+
+    def post(self, url, **kwargs):
+        self.post_calls.append((url, kwargs))
+        return self.post_response
+
+    def get(self, url, **kwargs):
+        self.get_calls.append((url, kwargs))
+        return self.get_responses.pop(0)
+
+
+class GenerateImageTests(unittest.TestCase):
+    @patch("atlascloud.time.sleep", return_value=None)
+    def test_submits_polls_and_downloads(self, _sleep):
+        http = FakeHTTP(
+            FakeResponse(
+                {
+                    "code": 200,
+                    "data": {
+                        "id": "prediction-123",
+                        "status": "processing",
+                        "urls": {"get": "https://api.example/prediction-123"},
+                    },
+                }
+            ),
+            [
+                FakeResponse(
+                    {
+                        "code": 200,
+                        "data": {
+                            "status": "completed",
+                            "outputs": ["https://cdn.example/image.jpg"],
+                        },
+                    }
+                ),
+                FakeResponse(content=b"image-bytes"),
+            ],
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output = Path(temp_dir) / "nested" / "image.jpg"
+            result = atlascloud.generate_image(
+                "secret",
+                prompt="A clean title background",
+                output_path=str(output),
+                extra_params={"seed": 7, "prompt": "ignored"},
+                poll_interval=0,
+                http=http,
+            )
+
+            self.assertEqual(output.read_bytes(), b"image-bytes")
+            self.assertEqual(result["prediction_id"], "prediction-123")
+
+        submit_url, submit_kwargs = http.post_calls[0]
+        self.assertTrue(submit_url.endswith("/model/generateImage"))
+        self.assertEqual(submit_kwargs["json"]["prompt"], "A clean title background")
+        self.assertEqual(submit_kwargs["json"]["seed"], 7)
+        self.assertNotIn("size", submit_kwargs["json"])
+        self.assertNotIn("output_format", submit_kwargs["json"])
+        self.assertEqual(http.get_calls[0][0], "https://api.example/prediction-123")
+
+    @patch("atlascloud.time.sleep", return_value=None)
+    def test_reports_failed_prediction_without_downloading(self, _sleep):
+        http = FakeHTTP(
+            FakeResponse(
+                {"code": 200, "data": {"id": "failed-123", "status": "processing"}}
+            ),
+            [
+                FakeResponse(
+                    {"code": 200, "data": {"status": "failed", "error": "bad prompt"}}
+                )
+            ],
+        )
+
+        result = atlascloud.generate_image(
+            "secret",
+            prompt="A prompt",
+            output_path="unused.jpg",
+            poll_interval=0,
+            http=http,
+        )
+
+        self.assertIsNone(result)
+        self.assertEqual(len(http.get_calls), 1)
+
+
+class ExtraParamsTests(unittest.TestCase):
+    def test_requires_json_object(self):
+        with self.assertRaises(TypeError):
+            atlascloud._extra_params('["not", "an", "object"]')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/atlascloud.py
+++ b/tools/atlascloud.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Generate and download images with Atlas Cloud's asynchronous media API.
+
+Examples:
+  python3 tools/atlascloud.py --prompt "Editorial title card, no text" --output title.jpg
+  python3 tools/atlascloud.py --prompt "Square poster" --size "2048*2048" \
+      --output poster.png --output-format png
+  python3 tools/atlascloud.py --model bytedance/seedream-v5.0-lite \
+      --prompt "Product backdrop" --output backdrop.jpg
+
+Set ATLASCLOUD_API_KEY in the environment or a local .env file before running.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+try:
+    import requests
+    from dotenv import load_dotenv
+except ImportError as error:
+    print(f"Missing dependency: {error}", file=sys.stderr)
+    print("Install with: pip install requests python-dotenv", file=sys.stderr)
+    sys.exit(1)
+
+load_dotenv()
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+API_BASE_URL = "https://api.atlascloud.ai/api/v1"
+DEFAULT_MODEL = "bytedance/seedream-v5.0-lite"
+SUCCESS_STATUSES = {"completed", "succeeded"}
+FAILURE_STATUSES = {"failed", "canceled", "cancelled"}
+
+
+def log(message: str, level: str = "info") -> None:
+    """Write a compact status message to stderr."""
+    prefix = {"info": "->", "success": "OK", "error": "!!", "dim": "  "}
+    print(f"{prefix.get(level, '->')} {message}", file=sys.stderr)
+
+
+def _response_data(response: Any, action: str) -> dict[str, Any]:
+    """Validate an Atlas Cloud response and return its data object."""
+    response.raise_for_status()
+    try:
+        payload = response.json()
+    except ValueError as error:
+        raise RuntimeError(f"{action} returned invalid JSON") from error
+
+    if not isinstance(payload, dict):
+        raise TypeError(f"{action} returned an invalid response object")
+    if payload.get("code") not in (None, 200):
+        message = payload.get("message") or "unknown API error"
+        raise RuntimeError(f"{action} failed: {message}")
+
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        raise TypeError(f"{action} returned no data object")
+    return data
+
+
+def _output_urls(data: dict[str, Any]) -> list[str]:
+    """Extract generated asset URLs from a completed prediction."""
+    outputs = data.get("outputs") or data.get("output") or []
+    if isinstance(outputs, str):
+        outputs = [outputs]
+    if not isinstance(outputs, list):
+        return []
+
+    urls: list[str] = []
+    for output in outputs:
+        if isinstance(output, str) and output.startswith(("https://", "http://")):
+            urls.append(output)
+        elif isinstance(output, dict):
+            url = output.get("url")
+            if isinstance(url, str) and url.startswith(("https://", "http://")):
+                urls.append(url)
+    return urls
+
+
+def generate_image(
+    api_key: str,
+    *,
+    prompt: str,
+    output_path: str,
+    model: str = DEFAULT_MODEL,
+    size: str | None = None,
+    output_format: str | None = None,
+    extra_params: dict[str, Any] | None = None,
+    poll_interval: float = 3,
+    timeout: float = 300,
+    request_timeout: float = 60,
+    http: Any = requests,
+) -> dict[str, Any] | None:
+    """Submit, poll, and download one Atlas Cloud image generation."""
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    payload: dict[str, Any] = dict(extra_params or {})
+    payload.update({"model": model, "prompt": prompt})
+    if size:
+        payload["size"] = size
+    if output_format:
+        payload["output_format"] = output_format
+    if model == DEFAULT_MODEL:
+        payload["enable_base64_output"] = False
+
+    try:
+        submit = http.post(
+            f"{API_BASE_URL}/model/generateImage",
+            headers=headers,
+            json=payload,
+            timeout=request_timeout,
+        )
+        data = _response_data(submit, "Image submission")
+        prediction_id = data.get("id")
+        if not isinstance(prediction_id, str) or not prediction_id:
+            raise RuntimeError("Image submission returned no prediction ID")
+
+        urls = data.get("urls")
+        poll_url = urls.get("get") if isinstance(urls, dict) else None
+        if not isinstance(poll_url, str) or not poll_url:
+            poll_url = f"{API_BASE_URL}/model/prediction/{prediction_id}"
+
+        log(f"Prediction: {prediction_id}", "dim")
+        deadline = time.monotonic() + timeout
+        status = str(data.get("status") or "created").lower()
+
+        while status not in SUCCESS_STATUSES:
+            if status in FAILURE_STATUSES:
+                error = data.get("error") or data.get("message") or status
+                raise RuntimeError(f"Generation {status}: {error}")
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"Generation did not finish within {timeout:g}s")
+
+            time.sleep(poll_interval)
+            poll = http.get(poll_url, headers=headers, timeout=request_timeout)
+            data = _response_data(poll, "Prediction polling")
+            status = str(data.get("status") or "processing").lower()
+            log(f"Status: {status}", "dim")
+
+        output_urls = _output_urls(data)
+        if not output_urls:
+            raise RuntimeError("Completed prediction returned no output URL")
+
+        download = http.get(output_urls[0], timeout=request_timeout)
+        download.raise_for_status()
+        destination = Path(output_path)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(download.content)
+        log(f"Saved: {destination} ({len(download.content) // 1024} KB)", "success")
+        return {
+            "prediction_id": prediction_id,
+            "model": model,
+            "output": str(destination),
+            "source_url": output_urls[0],
+        }
+    except (
+        requests.RequestException,
+        RuntimeError,
+        TypeError,
+        TimeoutError,
+        OSError,
+    ) as error:
+        log(str(error), "error")
+        return None
+
+
+def _extra_params(value: str | None) -> dict[str, Any]:
+    """Parse optional model-specific parameters from a JSON object."""
+    if not value:
+        return {}
+    parsed = json.loads(value)
+    if not isinstance(parsed, dict):
+        raise TypeError("--extra-params must be a JSON object")
+    return parsed
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate and download an image with Atlas Cloud.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --prompt "Editorial title card, no text" --output title.jpg
+  %(prog)s --prompt "Square poster" --size "2048*2048" \
+      --output poster.png --output-format png
+  %(prog)s --model bytedance/seedream-v5.0-lite \
+      --prompt "Product backdrop" --output backdrop.jpg
+        """,
+    )
+    parser.add_argument("--prompt", "-p", required=True, help="Image description")
+    parser.add_argument("--output", "-o", required=True, help="Downloaded image path")
+    parser.add_argument(
+        "--model",
+        default=DEFAULT_MODEL,
+        help=f"Atlas Cloud model ID (default: {DEFAULT_MODEL})",
+    )
+    parser.add_argument("--size", help="Model-specific image size, e.g. 2048*2048")
+    parser.add_argument(
+        "--output-format",
+        choices=("jpeg", "png"),
+        help="Requested model output format",
+    )
+    parser.add_argument(
+        "--extra-params", help="Additional model parameters as a JSON object"
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=float,
+        default=3,
+        help="Polling interval in seconds (default: 3)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=300,
+        help="Overall generation timeout in seconds (default: 300)",
+    )
+    parser.add_argument(
+        "--json-out",
+        action="store_true",
+        help="Emit one machine-readable result line",
+    )
+    args = parser.parse_args()
+
+    try:
+        extra_params = _extra_params(args.extra_params)
+    except (json.JSONDecodeError, TypeError) as error:
+        parser.error(str(error))
+
+    from config import get_atlascloud_api_key
+
+    api_key = get_atlascloud_api_key()
+    if not api_key:
+        log("ATLASCLOUD_API_KEY not set.", "error")
+        log(
+            "Create a key at https://www.atlascloud.ai/console/api-keys "
+            "and add it to .env.",
+            "info",
+        )
+        sys.exit(1)
+
+    result = generate_image(
+        api_key,
+        prompt=args.prompt,
+        output_path=args.output,
+        model=args.model,
+        size=args.size,
+        output_format=args.output_format,
+        extra_params=extra_params,
+        poll_interval=args.poll_interval,
+        timeout=args.timeout,
+    )
+    if args.json_out:
+        print(json.dumps({"success": result is not None, **(result or {})}))
+    sys.exit(0 if result else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/config.py
+++ b/tools/config.py
@@ -5,6 +5,7 @@ import json
 import os
 from pathlib import Path
 
+
 # Find workspace root (where _internal/ lives)
 def find_workspace_root() -> Path:
     """Find the workspace root by looking for _internal directory."""
@@ -70,6 +71,13 @@ def get_ideogram_api_key() -> str | None:
     from dotenv import load_dotenv
     load_dotenv()
     return os.getenv("IDEOGRAM_API_KEY")
+
+
+def get_atlascloud_api_key() -> str | None:
+    """Get Atlas Cloud API key from environment."""
+    from dotenv import load_dotenv
+    load_dotenv()
+    return os.getenv("ATLASCLOUD_API_KEY")
 
 
 def get_youtube_client_secrets_file() -> str | None:


### PR DESCRIPTION
## Summary

- add an Atlas Cloud text-to-image CLI with asynchronous prediction polling and local download
- support the current Seedream v5 Lite default plus explicit model-specific parameters
- register the tool and load `ATLASCLOUD_API_KEY` through shared configuration

## Testing

- `python3 -m unittest -v tests/test_atlascloud.py`
- `python3 -m compileall -q tools/atlascloud.py tools/config.py tests/test_atlascloud.py`
- `uvx ruff check tools/atlascloud.py tools/config.py tests/test_atlascloud.py`
- `uvx ruff format --check tools/atlascloud.py tests/test_atlascloud.py`
- `python3 -m json.tool _internal/toolkit-registry.json`
- live Atlas Cloud generation completed and downloaded a 2048x2048 JPEG