### PR TITLE
FIX: wire up LTX-2 config, repair Modal app detection, document Windo…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,9 @@
 # MODAL_MUSIC_GEN_ENDPOINT_URL=https://yourname--video-toolkit-music-gen-....modal.run
 # MODAL_SADTALKER_ENDPOINT_URL=https://yourname--video-toolkit-sadtalker-....modal.run
 # MODAL_DEWATERMARK_ENDPOINT_URL=https://yourname--video-toolkit-dewatermark-....modal.run
+# LTX-2 also needs a Modal secret named `huggingface-token` (gated weights) and an
+# A100-80GB, which requires a payment method on your Modal account.
+# MODAL_LTX2_ENDPOINT_URL=https://yourname--video-toolkit-ltx2-....modal.run
 
 
 # --- Cloud GPU: RunPod (alternative) ---

--- a/docs/modal-setup.md
+++ b/docs/modal-setup.md
@@ -19,6 +19,41 @@ python3 -m modal setup    # Opens browser to authenticate, saves token to ~/.mod
 modal app list             # Verify it works
 ```
 
+### Windows prerequisites
+
+Two Windows-specific issues will otherwise make the commands in this guide fail in ways
+that look like toolkit bugs.
+
+**Set `PYTHONIOENCODING=utf-8` before deploying.** Modal's progress output contains
+characters the default `cp1252` console codec can't encode, so `modal deploy` aborts
+mid-build with `'charmap' codec can't encode characters in position ...`. The build
+itself is fine — only the printing fails. Make it permanent:
+
+```powershell
+[Environment]::SetEnvironmentVariable('PYTHONIOENCODING','utf-8','User')
+```
+
+Reopen your terminal afterwards so new processes inherit it.
+
+**Make sure `python3` isn't the Microsoft Store stub.** A default Windows install puts
+`C:\Users\<you>\AppData\Local\Microsoft\WindowsApps` ahead of your real Python on
+`PATH`. That directory holds zero-byte App Execution Aliases which fail with
+`Permission denied` — and since this toolkit's docs and commands all invoke
+`python3 tools/...`, everything breaks. Check what resolves:
+
+```powershell
+(Get-Command python3).Source
+```
+
+If it points into `WindowsApps`, either turn off the `python.exe` / `python3.exe`
+aliases in *Settings → Apps → App execution aliases*, or move your Python directory
+ahead of `WindowsApps` in your user `PATH`.
+
+**FFmpeg** is not bundled on Windows and several tools need it. If `winget install
+Gyan.FFmpeg` fails with a corrupted-source error, download
+`ffmpeg-release-essentials.zip` from https://www.gyan.dev/ffmpeg/builds/, extract it,
+and add its `bin\` directory to `PATH`.
+
 ## Deploy Tools
 
 Each AI tool has its own Modal app. Deploy only what you need, or deploy all of them — idle apps cost nothing.
@@ -38,7 +73,23 @@ modal deploy docker/modal-music-gen/app.py
 # Video processing
 modal deploy docker/modal-sadtalker/app.py
 modal deploy docker/modal-propainter/app.py
+
+# Video generation (see the LTX-2 prerequisites note below)
+modal deploy docker/modal-ltx2/app.py
 ```
+
+**Deploy them one at a time.** Modal rate-limits `AppCreate`; launching several
+`modal deploy` calls in parallel makes most of them fail with
+`App create rate limit exceeded`. Image builds happen server-side, so serial
+deploys cost you nothing extra in compute — only wall-clock.
+
+**GPU tier gates some tools.** Most apps request an `A10G`, which works on the free
+tier. Two request A100-class GPUs and fail at deploy time with
+`Please add a payment method to use A100-40GB GPU functions` until a card is on the
+account: `image-edit` (A100) and `ltx2` (A100-80GB). The image still gets built and
+cached before that error, so re-deploying after adding a payment method is fast.
+`ltx2` additionally needs a Modal secret named `huggingface-token` for its gated
+weights — it fails on the missing secret *before* it ever reaches the GPU check.
 
 Each deploy prints an endpoint URL like:
 ```
@@ -56,7 +107,14 @@ MODAL_UPSCALE_ENDPOINT_URL=https://yourname--video-toolkit-upscale-...modal.run
 MODAL_MUSIC_GEN_ENDPOINT_URL=https://yourname--video-toolkit-music-gen-...modal.run
 MODAL_SADTALKER_ENDPOINT_URL=https://yourname--video-toolkit-sadtalker-...modal.run
 MODAL_DEWATERMARK_ENDPOINT_URL=https://yourname--video-toolkit-dewatermark-...modal.run
+MODAL_LTX2_ENDPOINT_URL=https://yourname--video-toolkit-ltx2-...modal.run
 ```
+
+When an endpoint label exceeds Modal's length limit, Modal truncates it and appends a
+hash — `dewatermark` typically becomes `...-dewatermark-de-3e6418.modal.run`. Copy the
+URL Modal actually prints; don't reconstruct it from the pattern. Note that the deploy
+log wraps long URLs across lines, so check for a `(label truncated)` marker and rejoin
+the pieces.
 
 > **Tip:** `/setup` automates this — it runs each deploy, parses the URL, and writes it to `.env` for you.
 

--- a/tools/verify_setup.py
+++ b/tools/verify_setup.py
@@ -146,13 +146,15 @@ def check_modal_apps() -> dict:
             return {"ok": False, "apps": [], "detail": "modal app list failed — run `modal setup`?"}
 
         apps = json.loads(result.stdout)
+        # `modal app list --json` emits lowercase keys ("description", "state"),
+        # unlike the capitalised column headers of its human-readable table.
         toolkit_apps = [
             a for a in apps
-            if a.get("Description", "").startswith("video-toolkit-")
-            and a.get("State") == "deployed"
+            if a.get("description", "").startswith("video-toolkit-")
+            and a.get("state") == "deployed"
         ]
 
-        app_names = [a["Description"] for a in toolkit_apps]
+        app_names = [a["description"] for a in toolkit_apps]
         return {
             "ok": len(toolkit_apps) > 0,
             "apps": app_names,
@@ -172,6 +174,7 @@ def check_modal_env_vars() -> list[dict]:
         "MODAL_MUSIC_GEN_ENDPOINT_URL": "Music (ACE-Step)",
         "MODAL_SADTALKER_ENDPOINT_URL": "Talking Heads (SadTalker)",
         "MODAL_DEWATERMARK_ENDPOINT_URL": "Watermark Removal (ProPainter)",
+        "MODAL_LTX2_ENDPOINT_URL": "Video (LTX-2)",
     }
 
     results = []
@@ -314,7 +317,7 @@ def main():
     modal_configured = sum(1 for t in modal_env if t["ok"])
     results["modal_tools"] = modal_env
     if verbose:
-        print(f"Modal ({modal_configured}/7 tools):")
+        print(f"Modal ({modal_configured}/{len(modal_env)} tools):")
         for t in modal_env:
             print(f"  {'[x]' if t['ok'] else '[ ]'} {t['name']}: {t['detail']}")
 


### PR DESCRIPTION
…ws gotchas

Three unrelated gaps found while running /setup end to end on Windows.

1. MODAL_LTX2_ENDPOINT_URL was read by tools/cloud_gpu.py but appeared in neither .env.example nor verify_setup.py, so LTX-2 could only be configured by someone who had read the source. Added to both, plus the deploy command and env var in docs/modal-setup.md.

2. verify_setup.py always reported "no toolkit apps deployed". `modal app list --json` emits lowercase keys ("description", "state") while the check read the capitalised column headers of the human-readable table, so the filter never matched. Verified against a workspace with 6 deployed apps: now correctly reports "6 deployed". Also made the "N/7 tools" header derive its total from the tool list instead of hardcoding it, since adding LTX-2 would otherwise have desynced the count.

3. Documented three Windows blockers that each present as a toolkit bug:
   - modal deploy aborts mid-build with a cp1252 'charmap' encode error unless PYTHONIOENCODING=utf-8 is set
   - python3 resolves to the zero-byte WindowsApps App Execution Alias, which fails with "Permission denied" — this breaks every documented `python3 tools/...` invocation
   - FFmpeg needs a manual install, with a fallback for when winget's source index is corrupted

   Also documented two Modal behaviours that cost real debugging time: AppCreate
   is rate-limited so deploys must be serial, and A100-class apps (image-edit,
   ltx2) fail at deploy time until a payment method is added. Noted that ltx2
   separately needs a `huggingface-token` secret, and that Modal truncates long
   endpoint labels with a hash so URLs must be copied rather than reconstructed.