### PR TITLE
Add MiniMax music generation tool

### DIFF
--- a/.claude/skills/minimax-music/SKILL.md
+++ b/.claude/skills/minimax-music/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: minimax-music
+description: Generate instrumental or vocal music with MiniMax's hosted music API. Use for MiniMax music generation, global or mainland China endpoints, streamed audio, generated lyrics, or URL output.
+---
+
+# MiniMax Music
+
+Use `tools/minimax_music.py` for hosted text-to-music generation. It supports both API regions and saves the returned audio to a local file.
+
+## Setup
+
+Add your key to `.env`:
+
+```bash
+MINIMAX_API_KEY=your_key_here
+```
+
+The tool sends it as a bearer token and never writes it to output files.
+
+## Models
+
+- `music-3.0` (default)
+- `music-2.6`
+- `music-3.0-free`
+- `music-2.6-free`
+
+Cover models and reference-audio fields are outside this text-to-music tool.
+
+## Common Workflows
+
+Generate an instrumental track:
+
+```bash
+python3 tools/minimax_music.py \
+  --instrumental \
+  --prompt "Warm cinematic ambient score, slow piano, soft strings" \
+  --output public/audio/score.mp3
+```
+
+Generate a vocal song from lyrics:
+
+```bash
+python3 tools/minimax_music.py \
+  --prompt "Bright indie pop, energetic chorus, polished production" \
+  --lyrics "[Verse]\nMorning light across the city\n[Chorus]\nWe begin again" \
+  --output public/audio/song.mp3
+```
+
+Generate lyrics from a prompt:
+
+```bash
+python3 tools/minimax_music.py \
+  --lyrics-optimizer \
+  --prompt "Hopeful acoustic folk song about a new beginning" \
+  --output public/audio/song.mp3
+```
+
+Use the mainland China endpoint and its optional non-streaming watermark:
+
+```bash
+python3 tools/minimax_music.py \
+  --region cn_zh \
+  --aigc-watermark \
+  --instrumental \
+  --prompt "Gentle acoustic background music" \
+  --output public/audio/background.mp3
+```
+
+## Request Controls
+
+- `--region global_en` uses `https://api.minimax.io/v1/music_generation`.
+- `--region cn_zh` uses `https://api.minimaxi.com/v1/music_generation`.
+- `--output-format hex` is the default and supports regular or streamed responses.
+- `--output-format url` downloads the returned link immediately; provider links expire after 24 hours.
+- `--stream` accepts hex output only.
+- `--format` accepts `mp3`, `wav`, or `pcm`.
+- `--sample-rate` accepts `16000`, `24000`, `32000`, or `44100`.
+- `--bitrate` accepts `32000`, `64000`, `128000`, or `256000`.
+- `--json` emits a machine-readable success or error object.
+
+For vocal generation, provide `--lyrics` or use `--lyrics-optimizer`. Instrumental generation requires `--prompt`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ If you're using this repo from Codex, run the migration script once to install t
 python3 scripts/migrate_to_codex.py --force
 ```
 
-That installs 25 entries (11 toolkit skills + 13 command wrappers + 1 overview). The script can also sync the full `CLAUDE.md` content into a generated block at the end of this file — re-run `--force` after editing `CLAUDE.md` to keep the synced block fresh. Manual content above the generated block (i.e. everything you're reading now) is preserved.
+That installs 28 entries (13 toolkit skills + 14 command wrappers + 1 overview). The script can also sync the full `CLAUDE.md` content into a generated block at the end of this file — re-run `--force` after editing `CLAUDE.md` to keep the synced block fresh. Manual content above the generated block (i.e. everything you're reading now) is preserved.
 
 To uninstall:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ This is especially critical for background commands where the working directory 
 
 | Type | Tools | When to Use |
 |------|-------|-------------|
-| **Project tools** | voiceover, music, music_gen, sfx, sync_timing | During video creation workflow |
+| **Project tools** | voiceover, music, music_gen, minimax_music, sfx, sync_timing | During video creation workflow |
 | **Utility tools** | redub, addmusic, notebooklm_brand, locate_watermark | Quick transformations on existing videos |
 | **Cloud GPU** | image_edit, upscale, dewatermark, sadtalker, qwen3_tts, music_gen, flux2 | AI processing via RunPod or Modal (`--cloud runpod\|modal`) |
 | **Publishing** | youtube_upload | Upload a finished render to YouTube (use `/publish` for the guided workflow) |
@@ -287,6 +287,23 @@ python tools/music_gen.py --list-presets
 ```
 
 8 scene presets: `corporate-bg`, `upbeat-tech`, `ambient`, `dramatic`, `tension`, `hopeful`, `cta`, `lofi`. See `.claude/skills/acestep/` for prompt engineering patterns and video production integration guide.
+
+### MiniMax Music Generation
+
+Use the hosted global or mainland China API for instrumental tracks, supplied lyrics, or prompt-generated lyrics. Set `MINIMAX_API_KEY` in `.env` first.
+
+```bash
+# Instrumental music from the global endpoint
+python tools/minimax_music.py --instrumental --prompt "Cinematic ambient score" --output music.mp3
+
+# Vocal music with generated lyrics from the mainland China endpoint
+python tools/minimax_music.py --region cn_zh --lyrics-optimizer --prompt "Hopeful acoustic folk song" --output song.mp3
+
+# Stream hex audio chunks
+python tools/minimax_music.py --stream --instrumental --prompt "Driving electronic pulse" --output pulse.wav --format wav
+```
+
+Supported models: `music-3.0`, `music-2.6`, `music-3.0-free`, and `music-2.6-free`. See `.claude/skills/minimax-music/` for request and output controls.
 
 ### Watermark Removal
 

--- a/_internal/toolkit-registry.json
+++ b/_internal/toolkit-registry.json
@@ -70,6 +70,13 @@
       "created": "2026-03-22",
       "updated": "2026-03-22"
     },
+    "minimax-music": {
+      "path": ".claude/skills/minimax-music/",
+      "description": "Hosted text-to-music generation with global and mainland China endpoints",
+      "status": "beta",
+      "created": "2026-08-12",
+      "updated": "2026-08-12"
+    },
     "ltx2": {
       "path": ".claude/skills/ltx2/",
       "description": "AI video generation — prompting guide, parameters, video production use cases (b-roll, animated slides, portraits)",
@@ -262,6 +269,27 @@
       ],
       "created": "2026-03-22",
       "updated": "2026-04-03"
+    },
+    "minimax_music": {
+      "path": "tools/minimax_music.py",
+      "description": "Generate instrumental or vocal music with the MiniMax hosted API",
+      "usage": "python tools/minimax_music.py --instrumental --prompt 'Cinematic ambient score' --output music.mp3",
+      "status": "beta",
+      "options": {
+        "model": "music-3.0, music-2.6, music-3.0-free, or music-2.6-free",
+        "region": "global_en or cn_zh",
+        "stream": "Stream hex audio chunks",
+        "output-format": "hex or url",
+        "format": "mp3, wav, or pcm",
+        "lyrics-optimizer": "Generate lyrics from the prompt",
+        "instrumental": "Generate music without vocals",
+        "aigc-watermark": "Enable the cn_zh non-streaming AIGC watermark"
+      },
+      "envVars": [
+        "MINIMAX_API_KEY"
+      ],
+      "created": "2026-08-12",
+      "updated": "2026-08-12"
     },
     "sfx": {
       "path": "tools/sfx.py",

--- a/tests/test_minimax_music.py
+++ b/tests/test_minimax_music.py
@@ -1,0 +1,193 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).parents[1] / "tools" / "minimax_music.py"
+SPEC = importlib.util.spec_from_file_location("minimax_music", MODULE_PATH)
+minimax_music = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(minimax_music)
+
+
+class FakeResponse:
+    def __init__(self, *, payload=None, content=b"", lines=None, status_code=200):
+        self.payload = payload
+        self.content = content
+        self.lines = lines or []
+        self.status_code = status_code
+
+    def json(self):
+        return self.payload
+
+    def iter_lines(self, decode_unicode=False):
+        return iter(self.lines)
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise minimax_music.requests.HTTPError(f"HTTP {self.status_code}")
+
+
+class FakeSession:
+    def __init__(self, post_response, get_response=None):
+        self.post_response = post_response
+        self.get_response = get_response
+        self.posts = []
+        self.gets = []
+
+    def post(self, url, **kwargs):
+        self.posts.append((url, kwargs))
+        return self.post_response
+
+    def get(self, url, **kwargs):
+        self.gets.append((url, kwargs))
+        return self.get_response
+
+
+def base_args(**overrides):
+    values = {
+        "model": "music-3.0",
+        "prompt": "Cinematic ambient score",
+        "lyrics": None,
+        "stream": False,
+        "output_format": "hex",
+        "sample_rate": 44100,
+        "bitrate": 256000,
+        "audio_format": "mp3",
+        "lyrics_optimizer": False,
+        "is_instrumental": True,
+        "region": "global_en",
+        "aigc_watermark": None,
+    }
+    values.update(overrides)
+    return values
+
+
+class BuildPayloadTests(unittest.TestCase):
+    def test_builds_documented_global_payload(self):
+        payload = minimax_music.build_payload(**base_args())
+        self.assertEqual("music-3.0", payload["model"])
+        self.assertEqual("Cinematic ambient score", payload["prompt"])
+        self.assertEqual(
+            {"sample_rate": 44100, "bitrate": 256000, "format": "mp3"},
+            payload["audio_setting"],
+        )
+        self.assertTrue(payload["is_instrumental"])
+        self.assertNotIn("aigc_watermark", payload)
+
+    def test_supports_all_generation_models(self):
+        for model in minimax_music.MODELS:
+            with self.subTest(model=model):
+                payload = minimax_music.build_payload(**base_args(model=model))
+                self.assertEqual(model, payload["model"])
+
+    def test_adds_watermark_only_for_mainland_china(self):
+        payload = minimax_music.build_payload(
+            **base_args(region="cn_zh", aigc_watermark=True)
+        )
+        self.assertTrue(payload["aigc_watermark"])
+        with self.assertRaisesRegex(ValueError, "only available for the cn_zh"):
+            minimax_music.build_payload(**base_args(aigc_watermark=True))
+
+    def test_rejects_url_streaming(self):
+        with self.assertRaisesRegex(ValueError, "only supports hex"):
+            minimax_music.build_payload(**base_args(stream=True, output_format="url"))
+
+    def test_validates_prompt_and_lyrics_requirements(self):
+        with self.assertRaisesRegex(ValueError, "requires a prompt"):
+            minimax_music.build_payload(**base_args(prompt=None))
+        with self.assertRaisesRegex(ValueError, "requires lyrics"):
+            minimax_music.build_payload(
+                **base_args(prompt="A pop song", lyrics=None, is_instrumental=False)
+            )
+
+
+class GenerateMusicTests(unittest.TestCase):
+    def test_decodes_hex_response_and_uses_global_endpoint(self):
+        response = FakeResponse(
+            payload={
+                "data": {"audio": "494433", "status": 2},
+                "base_resp": {"status_code": 0, "status_msg": "success"},
+            }
+        )
+        session = FakeSession(response)
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "track.mp3"
+            result = minimax_music.generate_music(
+                api_key="test-key", output=output, session=session, **base_args()
+            )
+            self.assertEqual(b"ID3", output.read_bytes())
+        self.assertEqual(minimax_music.ENDPOINTS["global_en"], session.posts[0][0])
+        self.assertEqual("Bearer test-key", session.posts[0][1]["headers"]["Authorization"])
+        self.assertEqual(2, result["status"])
+
+    def test_downloads_url_response_from_mainland_china_endpoint(self):
+        response = FakeResponse(
+            payload={
+                "data": {"audio": "https://files.example/track.wav", "status": 2},
+                "base_resp": {"status_code": 0},
+            }
+        )
+        session = FakeSession(response, FakeResponse(content=b"RIFFaudio"))
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "track.wav"
+            minimax_music.generate_music(
+                api_key="test-key",
+                output=output,
+                session=session,
+                **base_args(region="cn_zh", output_format="url", audio_format="wav"),
+            )
+            self.assertEqual(b"RIFFaudio", output.read_bytes())
+        self.assertEqual(minimax_music.ENDPOINTS["cn_zh"], session.posts[0][0])
+        self.assertEqual("https://files.example/track.wav", session.gets[0][0])
+
+    def test_collects_streaming_hex_chunks(self):
+        events = [
+            {"data": {"audio": "4944", "status": 1}, "base_resp": {"status_code": 0}},
+            {"data": {"audio": "33", "status": 2}, "base_resp": {"status_code": 0}},
+        ]
+        response = FakeResponse(lines=[f"data: {json.dumps(event)}" for event in events])
+        session = FakeSession(response)
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "track.mp3"
+            result = minimax_music.generate_music(
+                api_key="test-key",
+                output=output,
+                session=session,
+                **base_args(stream=True),
+            )
+            self.assertEqual(b"ID3", output.read_bytes())
+        self.assertTrue(result["stream"])
+        self.assertTrue(session.posts[0][1]["stream"])
+
+    def test_reports_api_error(self):
+        response = FakeResponse(
+            payload={"base_resp": {"status_code": 1001, "status_msg": "invalid key"}}
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(minimax_music.MiniMaxMusicError, "invalid key"):
+                minimax_music.generate_music(
+                    api_key="test-key",
+                    output=Path(directory) / "track.mp3",
+                    session=FakeSession(response),
+                    **base_args(),
+                )
+
+    def test_rejects_incomplete_response(self):
+        response = FakeResponse(
+            payload={"data": {"audio": "494433", "status": 1}, "base_resp": {"status_code": 0}}
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(minimax_music.MiniMaxMusicError, "did not complete"):
+                minimax_music.generate_music(
+                    api_key="test-key",
+                    output=Path(directory) / "track.mp3",
+                    session=FakeSession(response),
+                    **base_args(),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/minimax_music.py
+++ b/tools/minimax_music.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Generate music with MiniMax's global or mainland China API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import requests
+from dotenv import load_dotenv
+
+
+ENDPOINTS = {
+    "global_en": "https://api.minimax.io/v1/music_generation",
+    "cn_zh": "https://api.minimaxi.com/v1/music_generation",
+}
+MODELS = ("music-3.0", "music-2.6", "music-3.0-free", "music-2.6-free")
+OUTPUT_FORMATS = ("url", "hex")
+AUDIO_FORMATS = ("mp3", "wav", "pcm")
+SAMPLE_RATES = (16000, 24000, 32000, 44100)
+BITRATES = (32000, 64000, 128000, 256000)
+
+
+class MiniMaxMusicError(RuntimeError):
+    """Raised when a MiniMax request or response is invalid."""
+
+
+def build_payload(
+    *,
+    model: str,
+    prompt: str | None,
+    lyrics: str | None,
+    stream: bool,
+    output_format: str,
+    sample_rate: int,
+    bitrate: int,
+    audio_format: str,
+    lyrics_optimizer: bool,
+    is_instrumental: bool,
+    region: str,
+    aigc_watermark: bool | None = None,
+) -> dict[str, Any]:
+    """Validate inputs and build the documented music-generation payload."""
+    if model not in MODELS:
+        raise ValueError(f"Unsupported model: {model}")
+    if region not in ENDPOINTS:
+        raise ValueError(f"Unsupported region: {region}")
+    if output_format not in OUTPUT_FORMATS:
+        raise ValueError(f"Unsupported output format: {output_format}")
+    if audio_format not in AUDIO_FORMATS:
+        raise ValueError(f"Unsupported audio format: {audio_format}")
+    if sample_rate not in SAMPLE_RATES:
+        raise ValueError(f"Unsupported sample rate: {sample_rate}")
+    if bitrate not in BITRATES:
+        raise ValueError(f"Unsupported bitrate: {bitrate}")
+    if stream and output_format != "hex":
+        raise ValueError("Streaming output only supports hex")
+    if aigc_watermark is not None and region != "cn_zh":
+        raise ValueError("aigc_watermark is only available for the cn_zh region")
+    if stream and aigc_watermark:
+        raise ValueError("aigc_watermark is only available for non-streaming requests")
+
+    prompt = prompt.strip() if prompt else None
+    lyrics = lyrics.strip() if lyrics else None
+    if prompt and len(prompt) > 2000:
+        raise ValueError("Prompt must be no more than 2000 characters")
+    if lyrics and len(lyrics) > 3500:
+        raise ValueError("Lyrics must be no more than 3500 characters")
+    if is_instrumental and not prompt:
+        raise ValueError("Instrumental generation requires a prompt")
+    if not is_instrumental and not lyrics and not lyrics_optimizer:
+        raise ValueError("Vocal generation requires lyrics or --lyrics-optimizer")
+    if lyrics_optimizer and not lyrics and not prompt:
+        raise ValueError("Lyrics optimization without lyrics requires a prompt")
+
+    payload: dict[str, Any] = {
+        "model": model,
+        "stream": stream,
+        "output_format": output_format,
+        "audio_setting": {
+            "sample_rate": sample_rate,
+            "bitrate": bitrate,
+            "format": audio_format,
+        },
+        "lyrics_optimizer": lyrics_optimizer,
+        "is_instrumental": is_instrumental,
+    }
+    if prompt:
+        payload["prompt"] = prompt
+    if lyrics:
+        payload["lyrics"] = lyrics
+    if aigc_watermark is not None:
+        payload["aigc_watermark"] = aigc_watermark
+    return payload
+
+
+def _check_event(event: dict[str, Any]) -> tuple[int | None, str | None]:
+    base_resp = event.get("base_resp") or {}
+    status_code = base_resp.get("status_code")
+    if status_code not in (None, 0):
+        message = base_resp.get("status_msg") or "unknown API error"
+        raise MiniMaxMusicError(f"MiniMax API error {status_code}: {message}")
+
+    data = event.get("data") or {}
+    return data.get("status"), data.get("audio")
+
+
+def _parse_json_response(response: requests.Response) -> tuple[str, dict[str, Any]]:
+    try:
+        event = response.json()
+    except ValueError as exc:
+        raise MiniMaxMusicError("MiniMax returned invalid JSON") from exc
+    if not isinstance(event, dict):
+        raise MiniMaxMusicError("MiniMax returned an invalid response object")
+    status, audio = _check_event(event)
+    if status != 2:
+        raise MiniMaxMusicError(f"Music generation did not complete (status={status!r})")
+    if not isinstance(audio, str) or not audio:
+        raise MiniMaxMusicError("Completed response did not include audio")
+    return audio, event
+
+
+def _parse_stream_response(response: requests.Response) -> tuple[bytes, dict[str, Any]]:
+    chunks: list[bytes] = []
+    last_event: dict[str, Any] = {}
+    completed = False
+
+    for raw_line in response.iter_lines(decode_unicode=True):
+        if isinstance(raw_line, bytes):
+            raw_line = raw_line.decode("utf-8")
+        line = raw_line.strip()
+        if not line or line.startswith(":"):
+            continue
+        if line.startswith("data:"):
+            line = line[5:].strip()
+        if line == "[DONE]":
+            break
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise MiniMaxMusicError("MiniMax returned an invalid streaming event") from exc
+        if not isinstance(event, dict):
+            raise MiniMaxMusicError("MiniMax returned an invalid streaming event object")
+        status, audio = _check_event(event)
+        if audio:
+            try:
+                chunks.append(bytes.fromhex(audio))
+            except ValueError as exc:
+                raise MiniMaxMusicError("MiniMax returned invalid hex audio") from exc
+        if status == 2:
+            completed = True
+        last_event = event
+
+    if not completed:
+        raise MiniMaxMusicError("Music generation stream ended before completion")
+    if not chunks:
+        raise MiniMaxMusicError("Completed stream did not include audio")
+    return b"".join(chunks), last_event
+
+
+def generate_music(
+    *,
+    api_key: str,
+    output: str | Path,
+    region: str = "global_en",
+    timeout: float = 600,
+    session: requests.Session | None = None,
+    **payload_args: Any,
+) -> dict[str, Any]:
+    """Call MiniMax, save the returned audio, and return machine-readable metadata."""
+    if not api_key:
+        raise ValueError("A MiniMax API key is required")
+    payload = build_payload(region=region, **payload_args)
+    client = session or requests.Session()
+    try:
+        response = client.post(
+            ENDPOINTS[region],
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json=payload,
+            stream=payload["stream"],
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        if payload["stream"]:
+            audio_bytes, raw_response = _parse_stream_response(response)
+        else:
+            audio, raw_response = _parse_json_response(response)
+            if payload["output_format"] == "hex":
+                try:
+                    audio_bytes = bytes.fromhex(audio)
+                except ValueError as exc:
+                    raise MiniMaxMusicError("MiniMax returned invalid hex audio") from exc
+            else:
+                if not audio.startswith("https://"):
+                    raise MiniMaxMusicError("MiniMax returned an invalid audio URL")
+                download = client.get(audio, timeout=timeout)
+                download.raise_for_status()
+                audio_bytes = download.content
+    except requests.RequestException as exc:
+        raise MiniMaxMusicError(f"MiniMax request failed: {exc}") from exc
+
+    output_path = Path(output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_bytes(audio_bytes)
+    return {
+        "success": True,
+        "output": str(output_path),
+        "bytes": len(audio_bytes),
+        "region": region,
+        "model": payload["model"],
+        "audio_format": payload["audio_setting"]["format"],
+        "output_format": payload["output_format"],
+        "stream": payload["stream"],
+        "status": (raw_response.get("data") or {}).get("status"),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate music with MiniMax")
+    parser.add_argument("--prompt", help="Style, mood, and scenario description")
+    parser.add_argument("--lyrics", help="Song lyrics, including optional section tags")
+    parser.add_argument("--model", choices=MODELS, default="music-3.0")
+    parser.add_argument("--region", choices=tuple(ENDPOINTS), default="global_en")
+    parser.add_argument("--stream", action="store_true", help="Stream hex audio chunks")
+    parser.add_argument("--output-format", choices=OUTPUT_FORMATS, default="hex")
+    parser.add_argument("--format", dest="audio_format", choices=AUDIO_FORMATS, default="mp3")
+    parser.add_argument("--sample-rate", type=int, choices=SAMPLE_RATES, default=44100)
+    parser.add_argument("--bitrate", type=int, choices=BITRATES, default=256000)
+    parser.add_argument("--lyrics-optimizer", action="store_true")
+    parser.add_argument("--instrumental", action="store_true")
+    parser.add_argument(
+        "--aigc-watermark",
+        action="store_true",
+        default=None,
+        help="Add the mainland China AIGC watermark (cn_zh, non-streaming only)",
+    )
+    parser.add_argument("--output", "-o", required=True, help="Output audio path")
+    parser.add_argument("--timeout", type=float, default=600)
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON")
+    return parser.parse_args()
+
+
+def main() -> int:
+    load_dotenv()
+    args = parse_args()
+    api_key = os.getenv("MINIMAX_API_KEY", "")
+    try:
+        result = generate_music(
+            api_key=api_key,
+            output=args.output,
+            region=args.region,
+            timeout=args.timeout,
+            model=args.model,
+            prompt=args.prompt,
+            lyrics=args.lyrics,
+            stream=args.stream,
+            output_format=args.output_format,
+            sample_rate=args.sample_rate,
+            bitrate=args.bitrate,
+            audio_format=args.audio_format,
+            lyrics_optimizer=args.lyrics_optimizer,
+            is_instrumental=args.instrumental,
+            aigc_watermark=args.aigc_watermark,
+        )
+    except (MiniMaxMusicError, ValueError) as exc:
+        if args.json:
+            print(json.dumps({"success": False, "error": str(exc)}))
+        else:
+            print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, indent=2) if args.json else f"Music saved to: {result['output']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Reason: The toolkit lacks MiniMax text-to-music support for the global and mainland China endpoints, generation models, request controls, output formats, and response parsing.

## Summary

- add a dedicated hosted music CLI for instrumental, supplied-lyrics, and generated-lyrics workflows
- support both regional endpoints, four generation models, hex and URL output, streaming, audio settings, and the China-only watermark field
- validate and parse API errors, in-progress and completed states, hex audio, streamed chunks, and expiring audio URLs
- register and document the tool and its skill

## Checks

- `python -m unittest discover -s tests -p 'test_minimax_music.py' -v`
- `python tools/minimax_music.py --help`
- `python -m json.tool _internal/toolkit-registry.json`
- `python scripts/migrate_to_codex.py --repo-root . --dry-run`
- `git diff --check`
