### PR TITLE
Add Kiro CLI support (migrate_to_kiro.py)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ examples/*/chart_anim.mp4
 playwright/output/*.mp4
 playwright/recordings/*.mp4
 .ai_dev/
+
+# Kiro CLI generated skills/steering (scripts/migrate_to_kiro.py)
+.kiro/

--- a/README.md
+++ b/README.md
@@ -362,6 +362,16 @@ python3 scripts/migrate_to_codex.py --force
 
 See [docs/codex.md](docs/codex.md) for what it installs, how the `AGENTS.md` block is managed, and how to remove it. Contributed by [@kimhoontae-gogo](https://github.com/kimhoontae-gogo) in [#16](https://github.com/digitalsamba/claude-code-video-toolkit/pull/16).
 
+## Using with Kiro CLI
+
+A sibling migration script installs the toolkit for [Kiro CLI](https://kiro.dev/). Kiro shares Claude Code's `SKILL.md` format and `$ARGUMENTS` slash-command convention, so the skills copy verbatim and `/video`, `/setup`, etc. work as slash commands:
+
+```bash
+python3 scripts/migrate_to_kiro.py --force
+```
+
+Skills install to the workspace `.kiro/skills/` (gitignored) and toolkit instructions are generated into `.kiro/steering/` from `CLAUDE.md`. See [docs/kiro.md](docs/kiro.md) for details, options, and removal.
+
 ## Contributing
 
 Contributions welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/docs/kiro.md
+++ b/docs/kiro.md
@@ -1,0 +1,48 @@
+# Using with Kiro CLI
+
+This toolkit is built around Claude Code assets in `.claude/` and `CLAUDE.md`, but it also ships a migration script for [Kiro CLI](https://kiro.dev/) — the sibling of `scripts/migrate_to_codex.py`.
+
+```bash
+python3 scripts/migrate_to_kiro.py --force
+```
+
+This does three things:
+
+1. **Copies the toolkit skills into `.kiro/skills/`** — Kiro uses the same `SKILL.md` frontmatter format as Claude Code, so the domain-knowledge skills (remotion, ltx2, ideogram4, acestep, …) copy verbatim. The set is discovered dynamically from `_internal/toolkit-registry.json`, so newly added skills are picked up on the next run.
+2. **Generates a wrapper skill per slash command** — Kiro invokes skills as `/name` slash commands with the same `$ARGUMENTS` placeholder Claude Code uses, so `/video`, `/setup`, `/scene-review`, etc. work identically. Each wrapper points at the original `.claude/commands/*.md` file as the source of truth, so upstream command updates flow through without re-running the script.
+3. **Generates `.kiro/steering/video-toolkit.md` from `CLAUDE.md`** — Kiro steering files are always-loaded context, the equivalent of `CLAUDE.md` in Claude Code. The content lives inside a managed marker block; manual content outside the block is preserved.
+
+By default everything installs into the repository workspace (`.kiro/`, gitignored), so the toolkit context only loads when running Kiro from this repo. Use `--global-skills` to install the skills to `~/.kiro/skills` instead — steering always stays workspace-scoped.
+
+## Usage
+
+```bash
+cd claude-code-video-toolkit
+kiro-cli chat
+```
+
+Then `/video`, `/setup`, `/brand`, etc. are available as slash commands, and Kiro loads the toolkit instructions automatically (it reads both `AGENTS.md` and `.kiro/steering/` by default).
+
+## Keeping it fresh
+
+- After `CLAUDE.md` changes: re-run `python3 scripts/migrate_to_kiro.py --force` to refresh the steering file.
+- After new skills/commands are added upstream: re-run with `--force` — the set is rediscovered from the registry.
+- Command workflow edits need no re-run at all (wrappers read the originals at invocation time).
+
+## Options
+
+| Flag | Effect |
+|------|--------|
+| `--force` | Overwrite previously installed skills and refresh the steering block |
+| `--dry-run` | Print the plan without writing anything |
+| `--global-skills` | Install skills to `~/.kiro/skills` instead of workspace `.kiro/skills` |
+| `--reset` | Remove installed toolkit skills and the generated steering block |
+| `--map-file` | Override `kiro/migration_map.json` (skip/rename skills and commands) |
+
+## Removing
+
+```bash
+python3 scripts/migrate_to_kiro.py --reset
+```
+
+`--reset` removes the toolkit skills previously installed under `.kiro/skills` (or `~/.kiro/skills` with `--global-skills`) and removes the generated block from the steering file. It does not delete other skills and it does not remove manual steering content.

--- a/kiro/migration_map.json
+++ b/kiro/migration_map.json
@@ -1,0 +1,6 @@
+{
+  "skip_commands": [],
+  "skip_skills": [],
+  "command_name_overrides": {},
+  "skill_name_overrides": {}
+}

--- a/scripts/migrate_to_kiro.py
+++ b/scripts/migrate_to_kiro.py
@@ -1,0 +1,506 @@
+#!/usr/bin/env python3
+"""Install Kiro CLI-compatible skills and steering from claude-code-video-toolkit.
+
+Kiro CLI sibling of scripts/migrate_to_codex.py:
+
+1. Copies each toolkit skill from `.claude/skills/` into `.kiro/skills/`
+   (Kiro uses the same SKILL.md frontmatter format, so skills copy verbatim).
+2. Generates a thin wrapper skill per Claude Code slash command in
+   `.claude/commands/` — Kiro invokes skills as `/name` slash commands with
+   the same `$ARGUMENTS` placeholder, and each wrapper points back at the
+   original command file as the source of truth.
+3. Generates `.kiro/steering/video-toolkit.md` from `CLAUDE.md` inside a
+   managed marker block (Kiro steering files are always-loaded context,
+   the equivalent of CLAUDE.md in Claude Code).
+
+By default everything is installed into the repository workspace (`.kiro/`),
+so the toolkit context only loads when running Kiro from this repo. Use
+`--global-skills` to install the skills to `~/.kiro/skills` instead
+(steering always stays workspace-scoped to avoid leaking into unrelated
+sessions).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+GENERATED_STEERING_BEGIN = "<!-- BEGIN GENERATED: claude-to-kiro -->"
+GENERATED_STEERING_END = "<!-- END GENERATED: claude-to-kiro -->"
+STEERING_FILE_NAME = "video-toolkit.md"
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    name: str
+    description: str
+    path: Path
+
+
+@dataclass(frozen=True)
+class SkillSpec:
+    name: str
+    description: str
+    path: Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Install Kiro CLI-compatible skills from claude-code-video-toolkit."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Toolkit repository root. Auto-detected by default.",
+    )
+    parser.add_argument(
+        "--map-file",
+        type=Path,
+        default=None,
+        help="Optional migration map override file.",
+    )
+    parser.add_argument(
+        "--global-skills",
+        action="store_true",
+        help="Install skills to ~/.kiro/skills instead of the workspace .kiro/skills.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing generated/copied skills if they already exist.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print planned actions without writing files.",
+    )
+    parser.add_argument(
+        "--reset",
+        action="store_true",
+        help="Remove previously installed toolkit skills and the generated steering file.",
+    )
+    return parser.parse_args()
+
+
+def find_repo_root(explicit: Path | None) -> Path:
+    if explicit is not None:
+        return explicit.resolve()
+    current = Path(__file__).resolve().parent
+    for candidate in [current, *current.parents]:
+        if (candidate / "_internal" / "toolkit-registry.json").exists() and (
+            candidate / ".claude"
+        ).exists():
+            return candidate
+    raise SystemExit("Could not auto-detect repository root.")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_mapping(path: Path | None) -> dict[str, Any]:
+    data: dict[str, Any] = {}
+    if path is not None:
+        if not path.exists():
+            raise SystemExit(f"Mapping file not found: {path}")
+        data = load_json(path)
+    return {
+        "skip_commands": set(data.get("skip_commands", [])),
+        "skip_skills": set(data.get("skip_skills", [])),
+        "command_name_overrides": data.get("command_name_overrides", {}),
+        "skill_name_overrides": data.get("skill_name_overrides", {}),
+    }
+
+
+def load_registry(repo_root: Path) -> dict[str, Any]:
+    return load_json(repo_root / "_internal" / "toolkit-registry.json")
+
+
+def load_command_specs(
+    repo_root: Path, registry: dict[str, Any], mapping: dict[str, Any]
+) -> list[CommandSpec]:
+    commands: list[CommandSpec] = []
+    entries = registry.get("commands", {})
+    for original_name, entry in sorted(entries.items()):
+        if original_name in mapping["skip_commands"]:
+            continue
+        command_name = mapping["command_name_overrides"].get(original_name, original_name)
+        relative_path = entry.get("path")
+        if not relative_path:
+            continue
+        command_path = repo_root / relative_path
+        commands.append(
+            CommandSpec(
+                name=command_name,
+                description=entry.get("description", f"Kiro wrapper for /{original_name}"),
+                path=command_path,
+            )
+        )
+    return commands
+
+
+def parse_skill_frontmatter(skill_md: Path) -> tuple[str, str]:
+    text = skill_md.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    if len(lines) < 3 or lines[0].strip() != "---":
+        raise SystemExit(f"Skill frontmatter missing in {skill_md}")
+    name = ""
+    description = ""
+    for line in lines[1:]:
+        stripped = line.strip()
+        if stripped == "---":
+            break
+        if stripped.startswith("name:"):
+            name = stripped.split(":", 1)[1].strip()
+        if stripped.startswith("description:"):
+            description = stripped.split(":", 1)[1].strip()
+    if not name or not description:
+        raise SystemExit(f"Skill name/description missing in {skill_md}")
+    return name, description
+
+
+def load_skill_specs(repo_root: Path, mapping: dict[str, Any]) -> list[SkillSpec]:
+    # Only `.claude/skills/` is scanned. Platform-specific skills under top-level
+    # `skills/` (e.g. OpenClaw) are intentionally not migrated to Kiro.
+    results: list[SkillSpec] = []
+    for skill_md in sorted((repo_root / ".claude" / "skills").glob("*/SKILL.md")):
+        source_name, description = parse_skill_frontmatter(skill_md)
+        if source_name in mapping["skip_skills"]:
+            continue
+        skill_name = mapping["skill_name_overrides"].get(source_name, source_name)
+        results.append(
+            SkillSpec(
+                name=skill_name,
+                description=description,
+                path=skill_md.parent,
+            )
+        )
+    return results
+
+
+def ensure_clean_dir(path: Path, force: bool, dry_run: bool) -> None:
+    if path.exists():
+        if not force:
+            raise SystemExit(
+                f"Destination already exists: {path}. Re-run with --force to overwrite."
+            )
+        if dry_run:
+            return
+        if path.is_dir():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+
+
+def write_text(path: Path, content: str, dry_run: bool) -> None:
+    if dry_run:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def copy_tree(src: Path, dest: Path, force: bool, dry_run: bool) -> None:
+    ensure_clean_dir(dest, force=force, dry_run=dry_run)
+    if dry_run:
+        return
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(src, dest)
+
+
+def yaml_quote(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
+def remove_dir(path: Path, dry_run: bool) -> bool:
+    if not path.exists():
+        return False
+    if dry_run:
+        return True
+    if path.is_dir():
+        shutil.rmtree(path)
+    else:
+        path.unlink()
+    return True
+
+
+def build_steering_block(repo_root: Path) -> str:
+    claude_md = (repo_root / "CLAUDE.md").read_text(encoding="utf-8").strip()
+    return (
+        f"{GENERATED_STEERING_BEGIN}\n"
+        "## Kiro Migration Note\n\n"
+        "This file is generated by `scripts/migrate_to_kiro.py` from `CLAUDE.md`.\n"
+        "Re-run `python3 scripts/migrate_to_kiro.py --force` after updating `CLAUDE.md`.\n\n"
+        f"{claude_md}\n"
+        f"{GENERATED_STEERING_END}"
+    )
+
+
+def contains_generated_block(text: str) -> bool:
+    return GENERATED_STEERING_BEGIN in text and GENERATED_STEERING_END in text
+
+
+def replace_generated_block(text: str, new_block: str) -> str:
+    start = text.index(GENERATED_STEERING_BEGIN)
+    end = text.index(GENERATED_STEERING_END) + len(GENERATED_STEERING_END)
+    before = text[:start].rstrip()
+    after = text[end:].lstrip()
+
+    parts: list[str] = []
+    if before:
+        parts.append(before)
+    parts.append(new_block)
+    if after:
+        parts.append(after)
+    return "\n\n".join(parts).rstrip() + "\n"
+
+
+def remove_generated_block(text: str) -> str:
+    start = text.index(GENERATED_STEERING_BEGIN)
+    end = text.index(GENERATED_STEERING_END) + len(GENERATED_STEERING_END)
+    before = text[:start].rstrip()
+    after = text[end:].lstrip()
+    if before and after:
+        return f"{before}\n\n{after}\n"
+    if before:
+        return f"{before}\n"
+    if after:
+        return f"{after}\n"
+    return ""
+
+
+def sync_steering_file(repo_root: Path, force: bool, dry_run: bool) -> None:
+    steering_path = repo_root / ".kiro" / "steering" / STEERING_FILE_NAME
+    new_block = build_steering_block(repo_root)
+    existing = steering_path.read_text(encoding="utf-8") if steering_path.exists() else ""
+
+    if steering_path.exists() and contains_generated_block(existing):
+        new_content = replace_generated_block(existing, new_block)
+        if existing == new_content:
+            print("steering_status=up_to_date")
+            return
+    elif steering_path.exists():
+        if not force:
+            raise SystemExit(
+                f"{steering_path} exists and has no generated Kiro block. "
+                "Re-run with --force to append a CLAUDE.md-derived block."
+            )
+        base = existing.rstrip()
+        new_content = f"{base}\n\n{new_block}\n" if base else f"{new_block}\n"
+    else:
+        new_content = f"{new_block}\n"
+
+    print(f"steering_sync={steering_path}")
+    if dry_run:
+        return
+    steering_path.parent.mkdir(parents=True, exist_ok=True)
+    steering_path.write_text(new_content, encoding="utf-8")
+
+
+def command_wrapper_content(
+    repo_root: Path,
+    command: CommandSpec,
+    installed_skill_names: list[str],
+    toolkit_name: str,
+) -> str:
+    related = ", ".join(f"`{name}`" for name in installed_skill_names) or "(none)"
+    source_rel = command.path.relative_to(repo_root).as_posix()
+
+    return f"""---
+name: {yaml_quote(command.name)}
+description: {yaml_quote(f"Kiro wrapper for Claude Code `/{command.name}` in `{toolkit_name}`. Use when the user wants: {command.description}")}
+---
+
+# /{command.name} for Kiro CLI
+
+This skill is the Kiro CLI entrypoint equivalent of the Claude Code slash command `/{command.name}`.
+
+## User Request
+
+$ARGUMENTS
+
+## Source of Truth
+
+Before acting, read the original workflow document:
+
+`{source_rel}`
+
+Also use these files when relevant:
+
+1. `CLAUDE.md`
+2. `_internal/toolkit-registry.json`
+3. `docs/README.md`
+
+## Operating Rules
+
+1. Treat `{source_rel}` as the authoritative workflow.
+2. Do not rewrite or replace the original Claude resources just to satisfy Kiro.
+3. Reuse installed toolkit skills when they help the task.
+4. Where the original workflow says to restart Claude Code, restart Kiro CLI instead.
+
+## Related Toolkit Skills
+
+{related}
+"""
+
+
+def install_copied_skills(
+    repo_root: Path,
+    dest_root: Path,
+    skills: list[SkillSpec],
+    force: bool,
+    dry_run: bool,
+) -> list[Path]:
+    installed: list[Path] = []
+    for skill in skills:
+        target = dest_root / skill.name
+        copy_tree(skill.path, target, force=force, dry_run=dry_run)
+        installed.append(target)
+    return installed
+
+
+def install_command_wrappers(
+    repo_root: Path,
+    dest_root: Path,
+    commands: list[CommandSpec],
+    installed_skill_names: list[str],
+    toolkit_name: str,
+    force: bool,
+    dry_run: bool,
+) -> list[Path]:
+    installed: list[Path] = []
+    for command in commands:
+        target = dest_root / command.name
+        ensure_clean_dir(target, force=force, dry_run=dry_run)
+        write_text(
+            target / "SKILL.md",
+            command_wrapper_content(repo_root, command, installed_skill_names, toolkit_name),
+            dry_run=dry_run,
+        )
+        installed.append(target)
+    return installed
+
+
+def print_plan(
+    repo_root: Path,
+    dest_root: Path,
+    skills: list[SkillSpec],
+    commands: list[CommandSpec],
+) -> None:
+    print(f"repo_root={repo_root}")
+    print(f"dest={dest_root}")
+    print(
+        f"steering={repo_root / '.kiro' / 'steering' / STEERING_FILE_NAME}"
+        " <- generated from CLAUDE.md"
+    )
+    print(f"copy_skills={len(skills)}")
+    for skill in skills:
+        print(f"  skill:{skill.name} <- {skill.path.relative_to(repo_root)}")
+    print(f"generate_command_wrappers={len(commands)}")
+    for command in commands:
+        print(f"  command:{command.name} <- {command.path.relative_to(repo_root)}")
+
+
+def reset_installed(
+    repo_root: Path,
+    dest_root: Path,
+    skills: list[SkillSpec],
+    commands: list[CommandSpec],
+    dry_run: bool,
+) -> int:
+    removable_names = {skill.name for skill in skills}
+    removable_names.update(command.name for command in commands)
+
+    print(f"reset_dest={dest_root}")
+    removed_any = False
+    for name in sorted(removable_names):
+        target = dest_root / name
+        removed = remove_dir(target, dry_run=dry_run)
+        status = "would_remove" if dry_run else "removed"
+        if removed:
+            removed_any = True
+            print(f"  {status}:{name}")
+        else:
+            print(f"  missing:{name}")
+
+    if not removed_any:
+        print("nothing_to_remove")
+
+    steering_path = repo_root / ".kiro" / "steering" / STEERING_FILE_NAME
+    if steering_path.exists():
+        existing = steering_path.read_text(encoding="utf-8")
+        if contains_generated_block(existing):
+            new_content = remove_generated_block(existing)
+            print(f"steering_reset={steering_path}")
+            if not dry_run:
+                if new_content:
+                    steering_path.write_text(new_content, encoding="utf-8")
+                else:
+                    steering_path.unlink()
+        else:
+            print("steering_status=no_generated_block")
+    else:
+        print("steering_status=missing")
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = find_repo_root(args.repo_root)
+    default_map = repo_root / "kiro" / "migration_map.json"
+    map_file = args.map_file or (default_map if default_map.exists() else None)
+    mapping = load_mapping(map_file)
+    registry = load_registry(repo_root)
+    toolkit_name = registry.get("name") or repo_root.name
+    commands = load_command_specs(repo_root, registry, mapping)
+    skills = load_skill_specs(repo_root, mapping)
+    if args.global_skills:
+        dest_root = (Path.home() / ".kiro" / "skills").expanduser().resolve()
+    else:
+        dest_root = repo_root / ".kiro" / "skills"
+
+    if args.force and args.reset:
+        raise SystemExit("--force and --reset cannot be used together.")
+
+    if args.reset:
+        return reset_installed(
+            repo_root=repo_root,
+            dest_root=dest_root,
+            skills=skills,
+            commands=commands,
+            dry_run=args.dry_run,
+        )
+
+    print_plan(repo_root, dest_root, skills, commands)
+    if args.dry_run:
+        return 0
+
+    sync_steering_file(repo_root=repo_root, force=args.force, dry_run=False)
+    dest_root.mkdir(parents=True, exist_ok=True)
+    install_copied_skills(
+        repo_root=repo_root,
+        dest_root=dest_root,
+        skills=skills,
+        force=args.force,
+        dry_run=False,
+    )
+    install_command_wrappers(
+        repo_root=repo_root,
+        dest_root=dest_root,
+        commands=commands,
+        installed_skill_names=[skill.name for skill in skills],
+        toolkit_name=toolkit_name,
+        force=args.force,
+        dry_run=False,
+    )
+    print("done")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

A sibling of `scripts/migrate_to_codex.py` (#16) that installs the toolkit for [Kiro CLI](https://kiro.dev/):

```bash
python3 scripts/migrate_to_kiro.py --force
```

Kiro turned out to be an easier target than Codex because it shares two Claude Code conventions directly:

- **Same `SKILL.md` frontmatter format** — the 12 domain skills copy verbatim into `.kiro/skills/`
- **Same `$ARGUMENTS` slash-command convention** — each `.claude/commands/*.md` gets a thin wrapper skill invoked as the identical `/video`, `/setup`, `/scene-review`, … slash command. Wrappers point at the original command file as source of truth, so command edits flow through without re-running the script.

Since Kiro's always-loaded context is `.kiro/steering/`, the script also generates `.kiro/steering/video-toolkit.md` from `CLAUDE.md` inside a managed marker block (same pattern as the Codex `AGENTS.md` block; manual content outside the block is preserved).

## Design choices

- **Workspace install by default** (`.kiro/`, added to `.gitignore`) so the toolkit context only loads when running Kiro from this repo; `--global-skills` targets `~/.kiro/skills` instead
- Dynamic discovery from `_internal/toolkit-registry.json`, mirroring the Codex script
- `--dry-run`, `--force`, `--reset` semantics match the Codex script; `kiro/migration_map.json` mirrors `codex/migration_map.json`

## Tested

- All 26 installed skills (12 copied + 14 command wrappers) validate against Kiro's skill naming/frontmatter rules
- A live `kiro-cli chat` session from the repo root sees all 26 skills and invokes them as slash commands
- `--force` re-run is idempotent; `--reset` removes everything it installed and nothing else
- Verified on macOS and Amazon Linux 2

## Files

- `scripts/migrate_to_kiro.py` — the migration script
- `kiro/migration_map.json` — skip/rename overrides (parity with `codex/`)
- `docs/kiro.md` — usage, options, removal
- `README.md` — 'Using with Kiro CLI' section
- `.gitignore` — ignore generated `.kiro/`