### PR TITLE
CHORE: bookkeeping catch-up for v0.18.0 — registry, roadmap, changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Pre-built video structures in `templates/`:
 - **sprint-review-v2** — Composable scene-based sprint review with modular architecture
 - **product-demo** — Marketing videos with dark tech aesthetic, stats, CTA
 - **concept-explainer-short** — 9:16 vertical TikTok/Reels/Shorts explainers (Python/moviepy, no Remotion)
+- **ai-engineering-review** — Monthly engineering review presented by a designed Qwen3 VoiceDesign narrator; ticket-driven config with caption alignment
 
 See `examples/` for finished projects you can learn from (newest first — scroll down to watch the toolkit evolve in reverse):
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ Pre-built video structures in `templates/`:
 - **sprint-review-v2** — Composable scene-based sprint review with modular architecture
 - **product-demo** — Marketing videos with dark tech aesthetic, stats, CTA
 - **concept-explainer-short** — 9:16 vertical TikTok/Reels/Shorts explainers (Python/moviepy, no Remotion)
-- **ai-engineering-review** — Monthly engineering review presented by a designed Qwen3 VoiceDesign narrator; ticket-driven config with caption alignment
 
 See `examples/` for finished projects you can learn from (newest first — scroll down to watch the toolkit evolve in reverse):
 

--- a/_internal/CHANGELOG.md
+++ b/_internal/CHANGELOG.md
@@ -6,6 +6,73 @@ All notable changes to claude-code-video-toolkit.
 
 ---
 
+## 2026-08-26 (v0.18.0)
+
+### Added
+- **YouTube publishing** — `tools/youtube_upload.py` + `/publish` command. OAuth login (`--auth`), private-by-default upload, scheduled go-live (`--publish-at`), thumbnails, `--dry-run` validation, 403s classified by API reason. Setup guide in `docs/youtube-upload.md`; google-* deps are opt-in in `tools/requirements.txt`. (#29, #37, #38, #39, #40)
+- **60db TTS provider** — third `voiceover.py --provider 60db` backend plus standalone `tools/sixtydb_tts.py` (synthesize / stream / websocket transports, `--list-voices`). Unified 0-1 voice settings auto-convert to 60db's 0-100 scale; `redub.py --tts-provider 60db`. Brands carry a `sixtydb` block in `voice.json`. (#27)
+- **`_internal/narrative-patterns.md`** — Discovery Story structure for sprint reviews (reorder by narrative arc, turning-point slides, honest bridge framing).
+- **`docs/ltx2.md` Windows gotchas** + LTX-2 Modal config wired into `verify_setup.py`. (#51, #53)
+
+### Changed
+- **Remotion skills sync** now tracks upstream's new per-topic layout via `skills/remotion-best-practices/` (router skill embedding markup/maps/captions/render/saas/studio/docs/upgrade). Workflow fails loudly on the next re-layout and carries the upstream skill version in PR titles. First sync from the new layout: 39 → 137 files. (#56)
+- **Modal image-edit** requests A100-80GB (OOMed on 40GB).
+- `.gitignore` covers `scratch/`, Playwright run artifacts, recursive `assets/voices`; duplicate project copies under `projects/` untracked.
+
+### Fixed
+- Weekly Remotion skills sync had failed every run since 2026-07-13 (upstream directory moved).
+- `verify_setup.py` accepts both `modal` CLI JSON key casings when detecting deployed apps.
+
+### Registry
+- Added missing entries: `ai-engineering-review` template, `digital-samba-ai-engineering` brand, `align_captions` tool, `quick-spot` / `data-viz-chart` / `ds-crt-stinger` / `sky-blue-short` examples. `the-space-between` marked showcase-only (no source directory).
+
+---
+
+## 2026-06-10 (v0.17.0)
+
+### Added
+- **concept-explainer-short template** — 9:16 vertical TikTok/Reels/Shorts explainers. First pure Python/moviepy template: `scenes.json` → `gen_vo.py` (per-scene TTS) → `gen_captions.py` (whisper forced-align) → `build.py` (Ken Burns stills, boomerang clips, karaoke caption pills, ducked music). (#31)
+- **`examples/sky-blue-short`** — 52s showcase of the template with all assets committed.
+- **TTS pacing QC** — `tools/pacing.py`; `voiceover.py` and `qwen3_tts.py` report per-take `wpm` + `pacing` label and accept `--max-wpm` for a pitch-preserving atempo clamp. Fixes cloned voices inheriting a rushed pace from their reference. (#30)
+
+### Docs
+- README restructured to lead with finished videos; "Using with Codex" moved to `docs/codex.md`.
+
+---
+
+## 2026-06-08 (v0.16.0)
+
+### Added
+- **Ideogram 4 text-to-image** — `tools/ideogram4.py` + `ideogram4` skill. Structured JSON captions for legible in-image text and exact brand colours; hosted paid API. FLUX-vs-Ideogram decision rule added to CLAUDE.md. (#28)
+- **ai-engineering-review template** — Lugh-presented monthly review, ticket-driven config.
+- **digital-samba-ai-engineering brand** with a Qwen3 VoiceDesign-designed narrator voice.
+- **Qwen3-TTS v0.2** — VoiceDesign mode (`--design-instruct`), shared-prompt cloning for consistent multi-scene narration, `clone.design` brand schema with self-caching reference; `tools/align_captions.py` (Scribe-based caption timing alignment).
+- **Codex migration flow** for toolkit skills/commands (#16, thanks @kimhoontae-gogo); thin `AGENTS.md`.
+
+### Changed
+- Remotion pinned to exact versions in lab examples; CLAUDE.md clarifies the `<OffthreadVideo>` choice vs upstream `@remotion/media`.
+- Official Remotion skills synced (upstream 277510e). (#17)
+- GitHub Actions bumped to Node 24-compatible versions; docker-build workflow handles multi-commit pushes and skips `modal-*` dirs.
+
+### Fixed
+- Python 3.9 compatibility restored across `tools/` via `from __future__ import annotations`. (#22)
+- `modal-upscale` basicsr build conflict. (#19, thanks @ATECHPCS)
+- Codex migration name read from registry; no-op skip entry dropped. (closes #20)
+
+---
+
+## 2026-04-21 (v0.15.0)
+
+### Added
+- **LTX-2 style LoRA support** with `crt-terminal` preset.
+- **`examples/ds-crt-stinger`** — 6s CRT LoRA + grunged-logo brand stinger.
+- Animated synthwave README banner (`showcase/banner`).
+
+### Changed
+- Official Remotion skills synced (upstream 41a3b06); "Stsrt" → "Start" typo fixed. (#14)
+
+---
+
 ## 2026-04-09 (v0.14.2)
 
 ### Added

--- a/_internal/CHANGELOG.md
+++ b/_internal/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to claude-code-video-toolkit.
 - `verify_setup.py` accepts both `modal` CLI JSON key casings when detecting deployed apps.
 
 ### Registry
-- Added missing entries: `ai-engineering-review` template, `digital-samba-ai-engineering` brand, `align_captions` tool, `quick-spot` / `data-viz-chart` / `ds-crt-stinger` / `sky-blue-short` examples. `the-space-between` marked showcase-only (no source directory).
+- Added missing entries: `align_captions` tool, `quick-spot` / `data-viz-chart` / `ds-crt-stinger` / `sky-blue-short` examples. `the-space-between` marked showcase-only (no source directory).
 
 ---
 
@@ -44,8 +44,6 @@ All notable changes to claude-code-video-toolkit.
 
 ### Added
 - **Ideogram 4 text-to-image** — `tools/ideogram4.py` + `ideogram4` skill. Structured JSON captions for legible in-image text and exact brand colours; hosted paid API. FLUX-vs-Ideogram decision rule added to CLAUDE.md. (#28)
-- **ai-engineering-review template** — Lugh-presented monthly review, ticket-driven config.
-- **digital-samba-ai-engineering brand** with a Qwen3 VoiceDesign-designed narrator voice.
 - **Qwen3-TTS v0.2** — VoiceDesign mode (`--design-instruct`), shared-prompt cloning for consistent multi-scene narration, `clone.design` brand schema with self-caching reference; `tools/align_captions.py` (Scribe-based caption timing alignment).
 - **Codex migration flow** for toolkit skills/commands (#16, thanks @kimhoontae-gogo); thin `AGENTS.md`.
 

--- a/_internal/ROADMAP.md
+++ b/_internal/ROADMAP.md
@@ -19,9 +19,9 @@ An open-source, AI-native video production workspace for Claude Code, featuring:
 
 ## Current Status
 
-**Phase:** 3 - Templates & Brands (nearly complete)
-**Focus:** Additional templates (tutorial, changelog), testing
-**Recent:** Qwen3-TTS integration, sprint-review-v2 template, voice cloning, FilmGrain component
+**Phase:** 3 - Templates & Brands (nearly complete) → moving into Phase 4
+**Focus:** Publishing & distribution, generator coverage (image/video/music), external contributions
+**Recent (v0.15–v0.18):** YouTube publishing (`/publish`), 60db TTS provider, Ideogram 4 T2I, LTX-2 Modal + style LoRAs, concept-explainer-short (9:16) and ai-engineering-review templates, TTS pacing QC, Qwen3 VoiceDesign
 
 ---
 
@@ -131,12 +131,33 @@ An open-source, AI-native video production workspace for Claude Code, featuring:
 - [x] `--runpod` deprecated in upscale.py and dewatermark.py (alias for `--cloud runpod`)
 - [x] `voiceover.py` passes `--cloud` through to Qwen3-TTS
 - [x] `dewatermark.py` migrated to `cloud_gpu.py` (removed ~393 lines of inline RunPod code)
-- [ ] `docs/modal-setup.md` — setup guide for Modal deployment
+- [x] `docs/modal-setup.md` — setup guide for Modal deployment
 - [ ] Add `--setup --cloud modal` to tools (currently manual `modal deploy`)
 
 **Sprint Review v2:**
 - [x] `sprint-review-v2` template — composable scene-based architecture
 - [x] Modular scene components
+
+**Generators & Providers (v0.11–v0.18):**
+- [x] FLUX.2 Klein text-to-image (`tools/flux2.py`, RunPod + Modal)
+- [x] Ideogram 4 text-to-image for in-image text (`tools/ideogram4.py`, hosted API)
+- [x] LTX-2 video generation (`tools/ltx2.py`, `tools/chain_video.py`, style LoRAs incl. crt-terminal)
+- [x] ACE-Step 1.5 music generation (`tools/music_gen.py`, acemusic API + Modal/RunPod)
+- [x] Qwen3-TTS VoiceDesign + shared-prompt cloning (v0.2)
+- [x] 60db TTS provider (`--provider 60db`, `tools/sixtydb_tts.py`)
+- [x] TTS pacing QC (`tools/pacing.py`, `--max-wpm`)
+- [ ] Edge-TTS provider (PR #46, needs rebase over 60db)
+- [ ] Make Qwen3-TTS the default provider (replacing ElevenLabs) — still open
+
+**Publishing:**
+- [x] YouTube upload (`tools/youtube_upload.py`, `/publish`) — OAuth, scheduling, thumbnails
+- [ ] Other destinations (LinkedIn, X, S3/R2 CDN)
+
+**Additional Templates (shipped):**
+- [x] `ai-engineering-review` — Lugh-presented monthly review (ticket-driven)
+- [x] `concept-explainer-short` — 9:16 vertical shorts, first Python/moviepy template
+- [ ] `sync_timing.py` support for ai-engineering-review's `tickets[]` config shape
+- [ ] ai-engineering-review README/CLAUDE.md are still copies of sprint-review's — rewrite
 
 **Additional Components:**
 - [x] `FilmGrain` — SVG noise overlay for cinematic texture
@@ -194,6 +215,10 @@ An open-source, AI-native video production workspace for Claude Code, featuring:
 | qwen-edit | stable | AI image editing prompting patterns |
 | runpod | stable | Cloud GPU setup, Docker images, endpoint management |
 | modal | beta | Alternative cloud GPU provider — faster cold starts, all 6 tools deployed |
+| acestep | stable | ACE-Step 1.5 music generation prompting |
+| ltx2 | beta | LTX-2 video generation prompting, style LoRAs |
+| moviepy | stable | Python composition, deterministic text overlay |
+| ideogram4 | beta | Structured JSON captions for in-image text |
 
 ---
 
@@ -217,14 +242,14 @@ An open-source, AI-native video production workspace for Claude Code, featuring:
 
 | Category | Count | Items |
 |----------|-------|-------|
-| Templates | 3 | sprint-review, sprint-review-v2, product-demo |
-| Brands | 2 | default, digital-samba |
-| Skills | 8 | 6 stable, 2 beta |
-| Tools | 12 | voiceover, music, sfx, redub, addmusic, dewatermark, locate_watermark, notebooklm_brand, image_edit, upscale, sadtalker, qwen3_tts |
-| Commands | 13 | setup, video, brand, template, skills, contribute, record-demo, generate-voiceover, scene-review, design, versions, redub, voice-clone |
+| Templates | 5 | sprint-review, sprint-review-v2, product-demo, concept-explainer-short, ai-engineering-review |
+| Brands | 3 | default, digital-samba, digital-samba-ai-engineering |
+| Skills | 12 | remotion, remotion-official, elevenlabs, ffmpeg, playwright-recording, frontend-design, qwen-edit, runpod, acestep, ltx2, moviepy, ideogram4 |
+| Tools | 22 | voiceover, qwen3_tts, sixtydb_tts, music, music_gen, sfx, redub, addmusic, sync_timing, align_captions, dewatermark, locate_watermark, notebooklm_brand, image_edit, upscale, flux2, ideogram4, ltx2, chain_video, sadtalker, verify_setup, youtube_upload |
+| Commands | 14 | setup, video, brand, template, skills, contribute, record-demo, generate-voiceover, scene-review, design, versions, redub, voice-clone, publish |
 | Components | 11 | AnimatedBackground, SlideTransition, Label, Vignette, FilmGrain, LogoWatermark, SplitScreen, NarratorPiP, Envelope, PointingHand, MazeDecoration |
 | Transitions | 7 | glitch, rgbSplit, zoomBlur, lightLeak, clockWipe, pixelate, checkerboard |
-| Examples | 3 | hello-world, digital-samba-skill-demo, sprint-review-cho-oyu |
+| Examples | 7 | hello-world, quick-spot, data-viz-chart, ds-crt-stinger, sky-blue-short, digital-samba-skill-demo, sprint-review-cho-oyu |
 
 ---
 

--- a/_internal/ROADMAP.md
+++ b/_internal/ROADMAP.md
@@ -21,7 +21,7 @@ An open-source, AI-native video production workspace for Claude Code, featuring:
 
 **Phase:** 3 - Templates & Brands (nearly complete) → moving into Phase 4
 **Focus:** Publishing & distribution, generator coverage (image/video/music), external contributions
-**Recent (v0.15–v0.18):** YouTube publishing (`/publish`), 60db TTS provider, Ideogram 4 T2I, LTX-2 Modal + style LoRAs, concept-explainer-short (9:16) and ai-engineering-review templates, TTS pacing QC, Qwen3 VoiceDesign
+**Recent (v0.15–v0.18):** YouTube publishing (`/publish`), 60db TTS provider, Ideogram 4 T2I, LTX-2 Modal + style LoRAs, concept-explainer-short (9:16) template, TTS pacing QC, Qwen3 VoiceDesign
 
 ---
 
@@ -154,10 +154,8 @@ An open-source, AI-native video production workspace for Claude Code, featuring:
 - [ ] Other destinations (LinkedIn, X, S3/R2 CDN)
 
 **Additional Templates (shipped):**
-- [x] `ai-engineering-review` — Lugh-presented monthly review (ticket-driven)
 - [x] `concept-explainer-short` — 9:16 vertical shorts, first Python/moviepy template
-- [ ] `sync_timing.py` support for ai-engineering-review's `tickets[]` config shape
-- [ ] ai-engineering-review README/CLAUDE.md are still copies of sprint-review's — rewrite
+- [ ] Monthly engineering-review template (ticket-driven, presenter-narrated) — in-tree but not yet ready to publish
 
 **Additional Components:**
 - [x] `FilmGrain` — SVG noise overlay for cinematic texture
@@ -242,8 +240,8 @@ An open-source, AI-native video production workspace for Claude Code, featuring:
 
 | Category | Count | Items |
 |----------|-------|-------|
-| Templates | 5 | sprint-review, sprint-review-v2, product-demo, concept-explainer-short, ai-engineering-review |
-| Brands | 3 | default, digital-samba, digital-samba-ai-engineering |
+| Templates | 4 | sprint-review, sprint-review-v2, product-demo, concept-explainer-short |
+| Brands | 2 | default, digital-samba |
 | Skills | 12 | remotion, remotion-official, elevenlabs, ffmpeg, playwright-recording, frontend-design, qwen-edit, runpod, acestep, ltx2, moviepy, ideogram4 |
 | Tools | 22 | voiceover, qwen3_tts, sixtydb_tts, music, music_gen, sfx, redub, addmusic, sync_timing, align_captions, dewatermark, locate_watermark, notebooklm_brand, image_edit, upscale, flux2, ideogram4, ltx2, chain_video, sadtalker, verify_setup, youtube_upload |
 | Commands | 14 | setup, video, brand, template, skills, contribute, record-demo, generate-voiceover, scene-review, design, versions, redub, voice-clone, publish |

--- a/_internal/toolkit-registry.json
+++ b/_internal/toolkit-registry.json
@@ -964,15 +964,6 @@
       "status": "beta",
       "created": "2026-06-09",
       "updated": "2026-06-09"
-    },
-    "ai-engineering-review": {
-      "path": "templates/ai-engineering-review/",
-      "description": "Lugh-presented monthly AI Engineering review — ticket-driven (tickets[] + lugh intro/outro) rather than scene-driven, designed Qwen3 VoiceDesign narrator, caption alignment via align_captions.py",
-      "stack": "remotion",
-      "status": "beta",
-      "brand": "digital-samba-ai-engineering",
-      "created": "2026-05-07",
-      "updated": "2026-05-07"
     }
   },
   "transitions": {
@@ -1146,12 +1137,6 @@
       "description": "Digital Samba - European video conferencing platform",
       "created": "2025-12-09",
       "updated": "2025-12-09"
-    },
-    "digital-samba-ai-engineering": {
-      "path": "brands/digital-samba-ai-engineering/",
-      "description": "Digital Samba AI Engineering team — Lugh presenter, runic metallurgy aesthetic; voice.json carries a Qwen3 VoiceDesign brief with a cached designed reference (assets/voice-design-ref.wav)",
-      "created": "2026-05-07",
-      "updated": "2026-05-07"
     }
   },
   "examples": {

--- a/_internal/toolkit-registry.json
+++ b/_internal/toolkit-registry.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-video-toolkit",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "AI-native video production workspace for Claude Code",
   "repository": "https://github.com/digitalsamba/claude-code-video-toolkit",
   "skills": {
@@ -563,6 +563,19 @@
       "created": "2026-02-24",
       "updated": "2026-02-24"
     },
+    "align_captions": {
+      "path": "tools/align_captions.py",
+      "description": "Align hand-estimated cap() caption timings in sprint-config.ts to actual TTS audio — transcribes each scene with ElevenLabs Scribe, fuzzy-matches phrases to word timestamps, patches fromSec/durSec in --apply mode",
+      "usage": "python3 tools/align_captions.py --config src/config/sprint-config.ts --scene-dir public/audio/scenes [--apply --tail-pad 0.3]",
+      "status": "beta",
+      "category": "project",
+      "requires": "ElevenLabs API key (Scribe)",
+      "envVars": [
+        "ELEVENLABS_API_KEY"
+      ],
+      "created": "2026-05-07",
+      "updated": "2026-05-07"
+    },
     "flux2": {
       "path": "tools/flux2.py",
       "description": "AI image generation and editing using FLUX.2 Klein 4B - text-to-image, image editing, and scene presets",
@@ -951,6 +964,15 @@
       "status": "beta",
       "created": "2026-06-09",
       "updated": "2026-06-09"
+    },
+    "ai-engineering-review": {
+      "path": "templates/ai-engineering-review/",
+      "description": "Lugh-presented monthly AI Engineering review — ticket-driven (tickets[] + lugh intro/outro) rather than scene-driven, designed Qwen3 VoiceDesign narrator, caption alignment via align_captions.py",
+      "stack": "remotion",
+      "status": "beta",
+      "brand": "digital-samba-ai-engineering",
+      "created": "2026-05-07",
+      "updated": "2026-05-07"
     }
   },
   "transitions": {
@@ -1124,6 +1146,12 @@
       "description": "Digital Samba - European video conferencing platform",
       "created": "2025-12-09",
       "updated": "2025-12-09"
+    },
+    "digital-samba-ai-engineering": {
+      "path": "brands/digital-samba-ai-engineering/",
+      "description": "Digital Samba AI Engineering team — Lugh presenter, runic metallurgy aesthetic; voice.json carries a Qwen3 VoiceDesign brief with a cached designed reference (assets/voice-design-ref.wav)",
+      "created": "2026-05-07",
+      "updated": "2026-05-07"
     }
   },
   "examples": {
@@ -1149,12 +1177,46 @@
       "contributor": "Digital Samba"
     },
     "the-space-between": {
-      "path": "examples/the-space-between/",
-      "description": "AI-generated video essay — flux2 avatar, Qwen3-TTS voice, SadTalker animation",
+      "path": null,
+      "description": "AI-generated video essay — flux2 avatar, Qwen3-TTS voice, SadTalker animation (finished video only — no source directory in examples/)",
       "template": "custom",
       "complexity": "advanced",
       "demo": "https://demos.digitalsamba.com/video/the-space-between.mp4",
-      "created": "2026-03-15"
+      "created": "2026-03-15",
+      "showcaseOnly": true
+    },
+    "quick-spot": {
+      "path": "examples/quick-spot/",
+      "description": "15s ad-style moviepy spot — audio-anchored timeline, PIL text, zero external assets",
+      "template": null,
+      "stack": "python-moviepy",
+      "complexity": "beginner",
+      "created": "2026-04-08"
+    },
+    "data-viz-chart": {
+      "path": "examples/data-viz-chart/",
+      "description": "Animated time-series chart (matplotlib for data, moviepy for deterministic title/attribution)",
+      "template": null,
+      "stack": "python-moviepy",
+      "complexity": "beginner",
+      "created": "2026-04-08"
+    },
+    "ds-crt-stinger": {
+      "path": "examples/ds-crt-stinger/",
+      "description": "6s brand stinger — LTX-2 crt-terminal LoRA footage + post-processed grunged logo",
+      "template": null,
+      "stack": "ltx2+python-moviepy",
+      "complexity": "intermediate",
+      "created": "2026-04-21"
+    },
+    "sky-blue-short": {
+      "path": "examples/sky-blue-short/",
+      "description": "52s vertical 9:16 'Why is the sky blue?' — concept-explainer-short showcase; all assets committed, re-renders with build.py",
+      "template": "concept-explainer-short",
+      "stack": "python-moviepy",
+      "complexity": "intermediate",
+      "demo": "https://demos.digitalsamba.com/video/short-blue-sky.mp4",
+      "created": "2026-06-10"
     }
   },
   "config": {


### PR DESCRIPTION
## Summary
- **Registry** (`_internal/toolkit-registry.json`): adds entries that had drifted since April — `align_captions` tool, `quick-spot` / `data-viz-chart` / `ds-crt-stinger` / `sky-blue-short` examples. `the-space-between` marked `showcaseOnly` (finished video, no source dir). Version bumped to **0.18.0**.
- **ROADMAP**: current-status line and metrics table refreshed (4 templates, 2 brands, 12 skills, 22 tools, 14 commands, 7 examples); `docs/modal-setup.md` ticked; new "Generators & Providers", "Publishing", "Additional Templates (shipped)" sections (the in-tree monthly-review template stays unlisted until it is ready).
- **CHANGELOG**: fills in v0.15.0, v0.16.0, v0.17.0 and the pending v0.18.0 (it had stopped at v0.14.2).


No code changes. After merge, tag `v0.18.0` to cut the release (release body auto-generates from commit subjects since v0.17.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)