### PR TITLE
DOCS: add contributor policy for automated / AI-generated PRs (respond to review, state cost/license/gap)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,13 @@ grep -r "/your-command" README.md CLAUDE.md
 4. Update documentation if needed
 5. Submit a PR with a clear description
 
+### Automated and AI-generated PRs
+
+Automated or AI-generated PRs are welcome only when a human author responds to review and the
+PR states why the toolkit needs the feature — cost, license, and how it differs from the tools
+already here (e.g. a hosted alternative to a self-hosted generator must say when to choose it).
+PRs with no human response within 14 days are closed without further review.
+
 ## Toolkit Tracking Files
 
 | File | Purpose |


### PR DESCRIPTION
Adds a short policy to CONTRIBUTING.md after closing three unresponsive bot-generated PRs today (#47, #50, #52): automated/AI-generated PRs need a human who responds to review and a stated cost/license/gap rationale; 14-day no-response → close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)