### PR TITLE
DOCS: Community add-ons section + single-vendor integration guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,12 @@ grep -r "/your-command" README.md CLAUDE.md
 4. Update documentation if needed
 5. Submit a PR with a clear description
 
+### Integrations that depend on a single paid service or local software
+
+If your integration only works against one paid API or a piece of software we can't bundle, keep
+it in your own repo and open an issue to be listed under **Community add-ons** in the README.
+In-tree integrations need at least one open or self-hostable path.
+
 ### Automated and AI-generated PRs
 
 Automated or AI-generated PRs are welcome only when a human author responds to review and the

--- a/README.md
+++ b/README.md
@@ -374,6 +374,19 @@ uv run scripts/migrate_to_kiro.py --force
 
 See [docs/kiro.md](docs/kiro.md) for what it installs, how it achieves Claude Code-parity, and how to remove it.
 
+## Community add-ons
+
+Projects built on or around the toolkit that live in their own repos — typically because they need
+software or a service we can't bundle. We haven't reviewed them; check each project's README.
+
+| Add-on | What it does | Needs |
+|--------|--------------|-------|
+| [VOICEPEAK for voiceover.py](https://github.com/fialuxe/claude-code-video-toolkit-expand-ja-voicepeak/) | Offline Japanese TTS provider (patches `voiceover.py`) | VOICEPEAK (paid, local) |
+
+To be listed, open an issue with a link and a one-line description. The toolkit itself only takes
+integrations that have at least one open or self-hostable path — see
+[CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## Contributing
 
 Contributions welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.


### PR DESCRIPTION
Adds a **Community add-ons** table to the README for integrations that live in their own repos (paid service / local software we can't bundle), with VOICEPEAK (#42) as the first entry, and a matching CONTRIBUTING.md paragraph pointing single-vendor integrations there. Resolves the ask in #42; gives #44 and #48 a path.

Closes #42.