### PR TITLE
FEAT: /versions --bump-toolkit + grouped Dependabot for Remotion (#23 part 3)

### DIFF
--- a/.claude/commands/versions.md
+++ b/.claude/commands/versions.md
@@ -179,6 +179,59 @@ Restart Claude Code to load new skills and commands.
 
 ---
 
+## Bump Toolkit Flow (`/versions --bump-toolkit [version]`)
+
+Maintainer mode: move every pinned Remotion project to one version, with the render-baseline
+A/B as the gate. Only run on a clean tree on a branch.
+
+### Step 1: Pick the target
+
+```bash
+uv run scripts/check_versions.py --json      # → remotion.latest, current pins
+```
+
+Default to `remotion.latest` unless the user named a version. Confirm:
+
+```
+Bump Remotion 4.0.425 → 4.0.518 across 10 projects (templates, examples, showcase, tests)?
+Runs: rewrite pins → refresh lockfiles → smoke-render frame 0 → render-baseline A/B.
+```
+
+### Step 2: Run the bump
+
+```bash
+git checkout -b deps/remotion-4.0.518
+uv run scripts/bump_remotion.py 4.0.518 --smoke --summary /tmp/bump-summary.md
+```
+
+The script rewrites `remotion` / `@remotion/*` pins (exact), refreshes each lockfile, smoke-renders
+frame 0 of each Remotion project's first composition, runs `scripts/render-baseline.mjs ab`, and
+prints a markdown summary. Non-zero exit = something failed; read the table before going on.
+For a cautious first pass use `--only templates/sprint-review-v2` (the test-bed template).
+
+### Step 3: Review and open the PR
+
+```bash
+git diff --stat
+git add -A && git commit -m "DEPS: bump Remotion 4.0.425 → 4.0.518 across templates, examples, showcase, tests"
+gh pr create --title "DEPS: bump Remotion 4.0.425 → 4.0.518" --body-file /tmp/bump-summary.md
+```
+
+CI (`render-baseline.yml`) re-runs the A/B on Linux and comments the per-frame table. Any
+differing frame fails the check by design — open the artifacts, look at the diff images, and
+either accept (comment why on the PR) or hold the bump.
+
+### Step 4: After merge
+
+- Note the new pin in `_internal/CHANGELOG.md`.
+- If frames differed and were accepted, record what changed and why in the PR — that is the
+  calibration data for eventually relaxing the `--threshold`.
+
+Dependabot (`.github/dependabot.yml`) opens the same kind of PR monthly for the `remotion`
+group; it goes through the identical CI gate, so reviewing it is Step 3 without Step 2.
+
+---
+
 ## Automatic Checks
 
 Consider running version check automatically:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+# Dependabot — grouped Remotion bumps only.
+#
+# The toolkit pins exact Remotion versions in every template/example/showcase and
+# in the render-baseline harness. One grouped PR a month moves them all together;
+# .github/workflows/render-baseline.yml renders before/after on the same runner and
+# fails the check if any frame differs, so a human looks before merging.
+#
+# Python deps are managed with uv (pyproject.toml + uv.lock) and are deliberately
+# not automated here — run `uv run scripts/check_versions.py` to see what's behind.
+
+version: 2
+updates:
+  - package-ecosystem: npm
+    directories:
+      - /templates/sprint-review
+      - /templates/sprint-review-v2
+      - /templates/product-demo
+      - /templates/ai-engineering-review
+      - /examples/hello-world
+      - /examples/digital-samba-skill-demo/remotion
+      - /examples/sprint-review-cho-oyu/remotion
+      - /showcase/transitions
+      - /showcase/banner
+      - /tests/render-baseline
+    schedule:
+      interval: monthly
+    versioning-strategy: increase   # keep exact pins exact
+    groups:
+      remotion:
+        patterns:
+          - "remotion"
+          - "@remotion/*"
+    # Only Remotion; React/TypeScript stay on caret ranges and aren't render-sensitive.
+    allow:
+      - dependency-name: "remotion"
+      - dependency-name: "@remotion/*"
+    labels:
+      - dependencies
+      - remotion-bump
+    commit-message:
+      prefix: "DEPS"
+    open-pull-requests-limit: 1

--- a/scripts/bump_remotion.py
+++ b/scripts/bump_remotion.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""
+Bump the toolkit's pinned Remotion version — the mechanical half of
+`/versions --bump-toolkit`.
+
+For every package.json under templates/, examples/, showcase/, tests/ that
+pins `remotion` / `@remotion/*`:
+  1. rewrite the pins to <version> (exact, never a caret)
+  2. refresh the lockfile (`npm install --package-lock-only`)
+  3. optionally smoke-render frame 0 of the project's first composition
+     (`--smoke`; requires a full `npm install`, so it is slower and only runs
+     for Remotion projects with an entry point)
+Then, unless --no-baseline, run the render-baseline A/B (before = current
+pin, after = <version>) via scripts/render-baseline.mjs and include its
+report in the summary.
+
+Writes a markdown summary to stdout (or --summary <file>) that the skill
+pastes into the bump PR body.
+
+Usage:
+    uv run scripts/bump_remotion.py 4.0.518                # pins + lockfiles + baseline A/B
+    uv run scripts/bump_remotion.py 4.0.518 --smoke        # also smoke-render each project
+    uv run scripts/bump_remotion.py 4.0.518 --only templates/sprint-review-v2
+    uv run scripts/bump_remotion.py 4.0.518 --dry-run      # report what would change
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+SCAN_DIRS = ("templates", "examples", "showcase", "tests")
+REMOTION_RE = re.compile(r"^(remotion|@remotion/.+)$")
+
+
+def repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for p in (here.parent, *here.parents):
+        if (p / "_internal" / "toolkit-registry.json").exists():
+            return p
+    return Path.cwd()
+
+
+def find_projects(root: Path, only: list[str]) -> list[Path]:
+    out = []
+    for d in SCAN_DIRS:
+        base = root / d
+        if not base.exists():
+            continue
+        for pj in base.rglob("package.json"):
+            if "node_modules" in pj.parts:
+                continue
+            if only and not any(str(pj.parent.relative_to(root)).startswith(o.rstrip("/")) for o in only):
+                continue
+            out.append(pj)
+    return sorted(out)
+
+
+def current_pins(pj: Path) -> dict[str, str]:
+    data = json.loads(pj.read_text())
+    pins = {}
+    for section in ("dependencies", "devDependencies"):
+        for name, ver in (data.get(section) or {}).items():
+            if REMOTION_RE.match(name):
+                pins[name] = ver
+    return pins
+
+
+def rewrite_pins(pj: Path, version: str) -> int:
+    """Rewrite in place with a regex so formatting/key order is preserved."""
+    text = pj.read_text()
+    new, n = re.subn(
+        r'("(?:remotion|@remotion/[^"]+)"\s*:\s*")[^"]+(")',
+        lambda m: f"{m.group(1)}{version}{m.group(2)}",
+        text,
+    )
+    if n:
+        pj.write_text(new)
+    return n
+
+
+def npm(args: list[str], cwd: Path, timeout: int = 600) -> tuple[bool, str]:
+    cmd = ["npm", *args, "--no-audit", "--no-fund", "--loglevel=error"]
+    try:
+        r = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, timeout=timeout,
+                           shell=(sys.platform == "win32"))
+        return r.returncode == 0, (r.stderr or r.stdout).strip()[-800:]
+    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+        return False, str(e)
+
+
+def first_composition(project: Path) -> tuple[str, str] | None:
+    entry = project / "src" / "index.ts"
+    root_tsx = project / "src" / "Root.tsx"
+    if not entry.exists() or not root_tsx.exists():
+        return None
+    m = re.search(r'id\s*=\s*["\']([^"\']+)["\']', root_tsx.read_text())
+    return ("src/index.ts", m.group(1)) if m else None
+
+
+def smoke_render(project: Path) -> tuple[str, str]:
+    """Render frame 0 of the first composition at tiny scale. Returns (status, detail)."""
+    comp = first_composition(project)
+    if not comp:
+        return "skipped", "no Remotion entry point"
+    ok, msg = npm(["install"], project)
+    if not ok:
+        return "FAILED", f"npm install: {msg}"
+    out = project / "out" / "smoke-frame0.png"
+    out.parent.mkdir(exist_ok=True)
+    cmd = ["npx", "remotion", "still", comp[0], comp[1], str(out),
+           "--frame=0", "--scale=0.1", "--image-format=png", "--gl=swangle", "--log=error"]
+    try:
+        r = subprocess.run(cmd, cwd=project, capture_output=True, text=True, timeout=900,
+                           shell=(sys.platform == "win32"))
+    except subprocess.TimeoutExpired:
+        return "FAILED", "render timed out"
+    if r.returncode != 0:
+        return "FAILED", (r.stderr or r.stdout).strip()[-800:]
+    out.unlink(missing_ok=True)
+    return "ok", f"{comp[1]} frame 0 rendered"
+
+
+def run_baseline(root: Path, version: str) -> tuple[bool | None, str]:
+    script = root / "scripts" / "render-baseline.mjs"
+    project = root / "tests" / "render-baseline"
+    if not script.exists() or not project.exists():
+        return None, "render-baseline harness not present"
+    if not (project / "node_modules").exists():
+        ok, msg = npm(["install"], project)
+        if not ok:
+            return False, f"npm install for harness failed: {msg}"
+    r = subprocess.run(["node", str(script), "ab", version], cwd=root, capture_output=True, text=True,
+                       shell=(sys.platform == "win32"))
+    report = project / "out" / "diff-before-vs-after" / "report.md"
+    text = report.read_text() if report.exists() else (r.stderr or r.stdout)[-1500:]
+    return r.returncode == 0, text
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("version", help="Target Remotion version, e.g. 4.0.518")
+    ap.add_argument("--only", action="append", default=[], help="Limit to project dirs starting with this path (repeatable)")
+    ap.add_argument("--smoke", action="store_true", help="Full npm install + render frame 0 per Remotion project")
+    ap.add_argument("--no-baseline", action="store_true", help="Skip the render-baseline A/B")
+    ap.add_argument("--dry-run", action="store_true", help="Report what would change without touching files")
+    ap.add_argument("--summary", help="Write the markdown summary to this file as well as stdout")
+    args = ap.parse_args()
+
+    if not re.match(r"^\d+\.\d+\.\d+$", args.version):
+        print(f"error: version must be exact (got {args.version!r}); the toolkit never pins ranges", file=sys.stderr)
+        return 2
+    if not shutil.which("npm"):
+        print("error: npm not found", file=sys.stderr)
+        return 2
+
+    root = repo_root()
+    projects = find_projects(root, args.only)
+    rows = []
+    before_versions = set()
+    failed = False
+
+    # The baseline harness manages its own pin during the A/B; exclude it from the walk
+    # unless the user targeted it explicitly, and bump it last (below).
+    harness = root / "tests" / "render-baseline" / "package.json"
+
+    for pj in projects:
+        pins = current_pins(pj)
+        if not pins:
+            continue
+        rel = str(pj.parent.relative_to(root))
+        old = sorted(set(pins.values()))
+        before_versions.update(old)
+        row = {"project": rel, "from": ", ".join(old), "to": args.version, "lock": "—", "smoke": "—"}
+        if args.dry_run:
+            row["lock"] = "would refresh"
+            rows.append(row)
+            continue
+        if pj == harness and not args.no_baseline:
+            row["lock"] = "after A/B"
+            rows.append(row)
+            continue
+        rewrite_pins(pj, args.version)
+        ok, msg = npm(["install", "--package-lock-only", "--ignore-scripts"], pj.parent)
+        row["lock"] = "refreshed" if ok else f"FAILED: {msg}"
+        failed |= not ok
+        if args.smoke and ok:
+            status, detail = smoke_render(pj.parent)
+            row["smoke"] = f"{status} — {detail}"
+            failed |= status == "FAILED"
+        rows.append(row)
+
+    baseline_ok, baseline_text = (None, "skipped")
+    if not args.dry_run and not args.no_baseline:
+        baseline_ok, baseline_text = run_baseline(root, args.version)
+        # `ab` restores the harness pin; now move it forward like everything else.
+        if harness.exists():
+            rewrite_pins(harness, args.version)
+            ok, msg = npm(["install", "--package-lock-only", "--ignore-scripts"], harness.parent)
+            for r in rows:
+                if r["project"] == "tests/render-baseline":
+                    r["lock"] = "refreshed" if ok else f"FAILED: {msg}"
+            failed |= not ok
+        failed |= baseline_ok is False
+
+    # ─── summary ────────────────────────────────────────────
+    frm = ", ".join(sorted(before_versions)) or "?"
+    L = [f"## Remotion bump {frm} → {args.version}" + (" (dry run)" if args.dry_run else ""), ""]
+    L += ["| Project | From | Lockfile | Smoke render |", "|---|---|---|---|"]
+    L += [f"| `{r['project']}` | {r['from']} | {r['lock']} | {r['smoke']} |" for r in rows]
+    L += [""]
+    if baseline_ok is None:
+        L += [f"**Render baseline:** {baseline_text}"]
+    else:
+        L += ["**Render baseline (tests/render-baseline, A/B on this machine):**", "", baseline_text.strip()]
+    L += ["", "Next: review, `git diff --stat`, then open the PR — CI re-runs the A/B on Linux and comments the table."]
+    summary = "\n".join(L) + "\n"
+    print(summary)
+    if args.summary:
+        Path(args.summary).write_text(summary)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Part 3 of #23. Builds on #63 (staleness) and #64 (render baseline) but merges independently.

- **`scripts/bump_remotion.py <version>`** — rewrites every `remotion` / `@remotion/*` pin under `templates/`, `examples/`, `showcase/`, `tests/` to an exact version, refreshes each lockfile (`npm install --package-lock-only`), optionally smoke-renders frame 0 of each Remotion project's first composition (`--smoke`, catches API breaks — templates have no assets so no visual diff), runs the render-baseline A/B, and prints a markdown summary for the PR body. `--only <dir>` for a cautious single-template pass, `--dry-run`, `--summary <file>`. Non-zero exit on any failure.
- **`/versions --bump-toolkit`** documented in `versions.md`: pick target → run script on a branch → open PR → CI A/B gates → changelog note.
- **`.github/dependabot.yml`** — one grouped monthly PR for the `remotion` group across the ten pinned directories, exact pins preserved (`versioning-strategy: increase`), React/TS excluded. Same CI gate as a manual bump.