### PR TITLE
FIX: modal-upscale crash-loop — cap opencv <4.12 so numpy stays 1.x for torch 2.1.2

### DIFF
--- a/docker/modal-upscale/app.py
+++ b/docker/modal-upscale/app.py
@@ -38,11 +38,17 @@ image = (
         "basicsr>=1.4.2",
         extra_options="--no-build-isolation",
     )
+    # opencv 4.12+ hard-requires numpy>=2, which breaks torch 2.1.2's numpy 1.x ABI
+    # ("RuntimeError: Numpy is not available" on `import basicsr`). realesrgan/facexlib/
+    # gfpgan each pull unpinned opencv-python, so cap both variants and restate the
+    # numpy pin here — pip resolves this layer independently of the ones above.
     .pip_install(
+        "numpy>=1.24.0,<2.0",
         "realesrgan>=0.3.0",
         "facexlib>=0.3.0",
         "gfpgan>=1.3.8",
-        "opencv-python-headless>=4.8.0",
+        "opencv-python-headless>=4.8.0,<4.12",
+        "opencv-python<4.12",
         "Pillow>=10.0.0",
         "boto3",
         "requests",


### PR DESCRIPTION
## Problem

`video-toolkit-upscale` on Modal was crash-looping (Modal sent a "function crash-looping" alert). Every container died during startup in `@modal.enter()`:

```
RuntimeError: Numpy is not available
  File "/root/app.py", line 77, in load_default_model
    self._get_upscaler("general", 4, False)
  File "/root/app.py", line 85, in _get_upscaler
    from basicsr.archs.rrdbnet_arch import RRDBNet
```

Because the model preload happens in the container start hook, a dependency error became a boot crash on every attempt.

## Cause

The image resolved **numpy 2.4.4**, but `torch==2.1.2` is compiled against the numpy 1.x C ABI.

The image *did* pin `numpy>=1.24.0,<2.0` — but only in its own layer. pip resolves each `pip_install` layer independently, and **opencv 4.12+ hard-requires `numpy>=2`** on Python 3.9+. Two paths in the final layer dragged it back in:

- `opencv-python-headless>=4.8.0` → resolved to `5.0.0.93`
- `realesrgan`, `facexlib`, and `gfpgan` each depend on unpinned `opencv-python` → `4.13.0.92`

No code changed — the last commit to this file was `4e24215` in March. That build had cached an older resolution; the 2026-08-26 redeploy rebuilt the image against newer opencv releases that had flipped the numpy floor.

## Fix

Cap both opencv variants below 4.12 (`4.11.0.86` is the last release compatible with numpy 1.x) and restate the numpy pin in the same layer so the resolver can't drift again.

## Verification

Deployed and ran a live job against the endpoint — container boots clean, no crash loop:

```
1920x1080 -> 3840x2160    18.3s    $0.0056
```

Build now resolves `numpy-1.26.4`, `opencv-python-4.11.0.86`, `opencv-python-headless-4.11.0.86`.

## Scope

Only this app is affected. `modal-upscale` is the sole app pinned to torch 2.1.2; every other Modal app runs torch 2.4.0+, which handles numpy 2 correctly (as `docker/modal-sadtalker/app.py` already notes). `modal-image-edit` pairs an open-ended numpy pin with opencv but runs torch 2.5.1, so it's safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
