### PR TITLE
FIX: flux2 crash-loop — raise transformers floor to 4.51 (Qwen3ForCausalLM)

### DIFF
--- a/docker/modal-flux2/app.py
+++ b/docker/modal-flux2/app.py
@@ -35,7 +35,11 @@ image = (
     .pip_install(
         "torch==2.5.1",
         "torchvision==0.20.1",
-        "transformers>=4.45.0",
+        # Flux2KleinPipeline (diffusers git main) imports Qwen3ForCausalLM,
+        # which landed in transformers 4.51. The old >=4.45 floor let a
+        # cached pre-Qwen3 layer sit under a fresh diffusers, crash-looping
+        # the container at load_pipeline with ModuleNotFoundError.
+        "transformers>=4.51.0",
         "accelerate>=0.30.0",
         "sentencepiece",
         "protobuf",


### PR DESCRIPTION
## Problem

`video-toolkit-flux2` crash-loops on every request. Containers die inside the
`@modal.enter()` hook, so no container ever survives to serve.

```
File "diffusers/pipelines/flux2/pipeline_flux2_klein.py", line 21
  from transformers import Qwen2TokenizerFast, Qwen3ForCausalLM
ModuleNotFoundError: Could not import module 'Qwen3ForCausalLM'
RuntimeError: Failed to import diffusers.pipelines.flux2.pipeline_flux2_klein
```

**The failure mode is worse than the crash itself.** Because it happens in a
startup hook rather than the request handler, nothing propagates back to the
client — `uv run tools/flux2.py --cloud modal` polls indefinitely (observed past
10 minutes) while `modal app list` reports `tasks=0`. It reads as a slow cold
start, not a crash, until Modal sends a crash-loop warning email.

Same class of silent hang as #70.

## Cause

The image installs `diffusers` from git main:

```python
.run_commands("pip install --no-cache-dir git+https://github.com/huggingface/diffusers")
```

diffusers main now ships `Flux2KleinPipeline`, which imports `Qwen3ForCausalLM` —
added in **transformers 4.51**. The image's floor was `transformers>=4.45.0`, so
Modal's layer cache kept a pre-Qwen3 transformers underneath a freshly fetched
diffusers. The two layers drifted apart.

## Fix

Raise the floor to `>=4.51.0`. This states the actual requirement and invalidates
the stale cached layer.

## Verification

Redeployed and generated: **1280x720 in 26.7s total, 5.0s inference**, on
transformers 5.16.1. Endpoint URL unchanged, so no `.env` updates needed.

## Remaining fragility (not fixed here)

`diffusers` is pinned to git main with no commit, so this pairing can drift again
at any time. A pinned diffusers commit, or a transformers ceiling, would make the
image reproducible. Happy to follow up if you have a preference — it seemed
out of scope for a crash fix.

## Per CONTRIBUTING — automated/AI-generated PRs

Written with Claude Code. **I'm the human author and will respond to review.**
This is a bug fix rather than a new integration, so the cost/license/differentiation
questions don't apply: no new dependency is added, and the change is one version
floor in an existing image spec.
