### PR TITLE
FIX: delete R2 result objects in flux2, music_gen, image_edit, ltx2

### DIFF
--- a/tools/flux2.py
+++ b/tools/flux2.py
@@ -53,7 +53,7 @@ except ImportError as e:
 load_dotenv()
 
 sys.path.insert(0, str(Path(__file__).parent))
-from file_transfer import download_from_url, get_r2_payload_config
+from file_transfer import delete_from_r2, download_from_url, get_r2_payload_config
 
 
 RUNPOD_GRAPHQL_URL = "https://api.runpod.io/graphql"
@@ -377,7 +377,11 @@ def generate_image(
 
     if "output_url" in result:
         log("Downloading from R2...", "dim")
-        download_from_url(result["output_url"], output_path, verbose=False)
+        if download_from_url(result["output_url"], output_path, verbose=False):
+            # The GPU side leaves the result object in R2. Drop it once the
+            # download succeeded, so the bucket does not grow without bound.
+            if result.get("r2_key"):
+                delete_from_r2(result["r2_key"])
     else:
         decode_and_save(result["image_base64"], output_path)
 
@@ -475,7 +479,11 @@ def edit_image(
 
     if "output_url" in result:
         log("Downloading from R2...", "dim")
-        download_from_url(result["output_url"], output_path, verbose=False)
+        if download_from_url(result["output_url"], output_path, verbose=False):
+            # The GPU side leaves the result object in R2. Drop it once the
+            # download succeeded, so the bucket does not grow without bound.
+            if result.get("r2_key"):
+                delete_from_r2(result["r2_key"])
     else:
         decode_and_save(result["image_base64"], output_path)
 

--- a/tools/image_edit.py
+++ b/tools/image_edit.py
@@ -49,7 +49,7 @@ except ImportError as e:
     sys.exit(1)
 
 sys.path.insert(0, str(Path(__file__).parent))
-from file_transfer import download_from_url, get_r2_payload_config
+from file_transfer import delete_from_r2, download_from_url, get_r2_payload_config
 
 # Background presets
 BACKGROUND_PRESETS = {
@@ -243,7 +243,11 @@ def edit_image(
     # Save result
     if "output_url" in result:
         log("Downloading from R2...", "dim")
-        download_from_url(result["output_url"], output_path, verbose=False)
+        if download_from_url(result["output_url"], output_path, verbose=False):
+            # The GPU side leaves the result object in R2. Drop it once the
+            # download succeeded, so the bucket does not grow without bound.
+            if result.get("r2_key"):
+                delete_from_r2(result["r2_key"])
     else:
         decode_and_save(result["edited_image_base64"], output_path)
 

--- a/tools/ltx2.py
+++ b/tools/ltx2.py
@@ -42,7 +42,7 @@ except ImportError as e:
 load_dotenv()
 
 sys.path.insert(0, str(Path(__file__).parent))
-from file_transfer import download_from_url, get_r2_payload_config
+from file_transfer import delete_from_r2, download_from_url, get_r2_payload_config
 
 # Style LoRA presets. Keep keys in sync with AVAILABLE_LORAS in
 # docker/modal-ltx2/app.py — the server only accepts keys it has baked in.
@@ -190,7 +190,11 @@ def generate_video(
     # Download or decode result
     if "output_url" in result:
         log("Downloading from R2...", "dim")
-        download_from_url(result["output_url"], output_path, verbose=False)
+        if download_from_url(result["output_url"], output_path, verbose=False):
+            # The GPU side leaves the result object in R2. Drop it once the
+            # download succeeded, so the bucket does not grow without bound.
+            if result.get("r2_key"):
+                delete_from_r2(result["r2_key"])
     elif "video_base64" in result:
         with open(output_path, "wb") as f:
             f.write(base64.b64decode(result["video_base64"]))

--- a/tools/music_gen.py
+++ b/tools/music_gen.py
@@ -82,7 +82,7 @@ except ImportError as e:
 load_dotenv()
 
 sys.path.insert(0, str(Path(__file__).parent))
-from file_transfer import download_from_url, get_r2_payload_config
+from file_transfer import delete_from_r2, download_from_url, get_r2_payload_config
 
 # --- Constants ---
 
@@ -652,7 +652,11 @@ def generate_music(
 
     if "output_url" in result:
         log("Downloading from R2...", "dim")
-        download_from_url(result["output_url"], output_path, verbose=False)
+        if download_from_url(result["output_url"], output_path, verbose=False):
+            # The GPU side leaves the result object in R2. Drop it once the
+            # download succeeded, so the bucket does not grow without bound.
+            if result.get("r2_key"):
+                delete_from_r2(result["r2_key"])
     elif "audio_base64" in result:
         with open(output_path, "wb") as f:
             f.write(base64.b64decode(result["audio_base64"]))
@@ -748,7 +752,11 @@ def generate_cover(
     Path(output_path).parent.mkdir(parents=True, exist_ok=True)
 
     if "output_url" in result:
-        download_from_url(result["output_url"], output_path, verbose=False)
+        if download_from_url(result["output_url"], output_path, verbose=False):
+            # The GPU side leaves the result object in R2. Drop it once the
+            # download succeeded, so the bucket does not grow without bound.
+            if result.get("r2_key"):
+                delete_from_r2(result["r2_key"])
     elif "audio_base64" in result:
         with open(output_path, "wb") as f:
             f.write(base64.b64decode(result["audio_base64"]))
@@ -823,7 +831,11 @@ def extract_stem(
     Path(output_path).parent.mkdir(parents=True, exist_ok=True)
 
     if "output_url" in result:
-        download_from_url(result["output_url"], output_path, verbose=False)
+        if download_from_url(result["output_url"], output_path, verbose=False):
+            # The GPU side leaves the result object in R2. Drop it once the
+            # download succeeded, so the bucket does not grow without bound.
+            if result.get("r2_key"):
+                delete_from_r2(result["r2_key"])
     elif "audio_base64" in result:
         with open(output_path, "wb") as f:
             f.write(base64.b64decode(result["audio_base64"]))


### PR DESCRIPTION
## Problem

`flux2`, `music_gen`, `image_edit` and `ltx2` never delete their R2 result
objects. Each download the result through the presigned `output_url` and leave
the underlying object in the bucket permanently, so every generated image, music
clip and video accumulates against the 10GB free tier — silently, with no error
and no log line.

`upscale`, `dewatermark`, `qwen3_tts` and `sadtalker` already clean up. The four
newer tools omitted it:

| Tool | `delete_from_r2` calls (before) |
|------|--------------------------------|
| upscale, dewatermark, sadtalker | 2 each |
| qwen3_tts | 3 |
| **flux2, music_gen, image_edit, ltx2** | **0** |

## How it was found

Listed the bucket after smoke-testing all 8 Modal tools. Four orphans, one per
tool that ran:

```
acestep/results/1ce3324ba50e.mp3      (235KB)
flux2/results/8964afe419fe.png       (1084KB)
image-edit/results/e06f3644e506.png   (942KB)
ltx2/results/b7ca4f50c605.mp4         (687KB)
```

At roughly 1MB per generation this is slow-burning, which is exactly why it went
unnoticed — the tools all report success.

## Fix

Client-side only. The Modal apps already return `r2_key` alongside `output_url`,
so the clients simply weren't using it. Delete after a **successful** download,
following the existing `r2_keys_to_cleanup` pattern in `upscale.py`.

Seven call sites: flux2 2, music_gen 3, image_edit 1, ltx2 1.

## Verification

A `music_gen` run now leaves the bucket empty, where it previously left one
object. Re-verified `upscale` still cleans up correctly (it was already fine).

## Per CONTRIBUTING — automated/AI-generated PRs

Written with Claude Code. **I'm the human author and will respond to review.**
This is a bug fix rather than a new integration — no new dependencies, no new
service, and it brings four tools in line with the cleanup the other four
already do.
