### PR TITLE
FIX: drain R2 cleanup on error paths too (upscale, sadtalker, qwen3_tts, dewatermark)

### DIFF
--- a/tools/dewatermark.py
+++ b/tools/dewatermark.py
@@ -55,7 +55,7 @@ import requests
 
 sys.path.insert(0, str(Path(__file__).parent))
 from file_transfer import (
-    upload_to_storage, download_from_r2, delete_from_r2,
+    upload_to_storage, download_from_r2, r2_cleanup,
     download_from_url, get_r2_payload_config,
 )
 
@@ -1142,142 +1142,137 @@ def process_with_cloud(
     progress=None,
 ) -> dict:
     """Process video using cloud GPU endpoint (RunPod or Modal)."""
-    r2_keys_to_cleanup = []
+    with r2_cleanup() as r2_keys_to_cleanup:
+        if verbose:
+            print(f"Cloud provider: {cloud}", file=sys.stderr)
 
-    if verbose:
-        print(f"Cloud provider: {cloud}", file=sys.stderr)
+        # Upload video
+        video_url, video_r2_key = upload_to_storage(input_path, "dewatermark/input")
+        if not video_url:
+            return {"error": "Failed to upload video"}
+        if video_r2_key:
+            r2_keys_to_cleanup.append(video_r2_key)
 
-    # Upload video
-    video_url, video_r2_key = upload_to_storage(input_path, "dewatermark/input")
-    if not video_url:
-        return {"error": "Failed to upload video"}
-    if video_r2_key:
-        r2_keys_to_cleanup.append(video_r2_key)
+        # Upload mask if provided
+        mask_url = None
+        if mask_path:
+            mask_url, mask_r2_key = upload_to_storage(mask_path, "dewatermark/mask")
+            if not mask_url:
+                return {"error": "Failed to upload mask"}
+            if mask_r2_key:
+                r2_keys_to_cleanup.append(mask_r2_key)
 
-    # Upload mask if provided
-    mask_url = None
-    if mask_path:
-        mask_url, mask_r2_key = upload_to_storage(mask_path, "dewatermark/mask")
-        if not mask_url:
-            return {"error": "Failed to upload mask"}
-        if mask_r2_key:
-            r2_keys_to_cleanup.append(mask_r2_key)
+        # Build payload
+        ratio_value = "auto" if resize_ratio == "auto" else float(resize_ratio)
 
-    # Build payload
-    ratio_value = "auto" if resize_ratio == "auto" else float(resize_ratio)
-
-    payload = {
-        "input": {
-            "operation": "dewatermark",
-            "video_url": video_url,
-            "resize_ratio": ratio_value,
+        payload = {
+            "input": {
+                "operation": "dewatermark",
+                "video_url": video_url,
+                "resize_ratio": ratio_value,
+            }
         }
-    }
 
-    if region:
-        payload["input"]["region"] = region
-    if mask_url:
-        payload["input"]["mask_url"] = mask_url
+        if region:
+            payload["input"]["region"] = region
+        if mask_url:
+            payload["input"]["mask_url"] = mask_url
 
-    r2_payload = get_r2_payload_config()
-    if r2_payload:
-        payload["input"]["r2"] = r2_payload
+        r2_payload = get_r2_payload_config()
+        if r2_payload:
+            payload["input"]["r2"] = r2_payload
 
-    # For Modal, the endpoint expects the inner payload directly
-    modal_payload = payload["input"] if cloud == "modal" else payload
+        # For Modal, the endpoint expects the inner payload directly
+        modal_payload = payload["input"] if cloud == "modal" else payload
 
-    # Call cloud GPU endpoint
-    from cloud_gpu import call_cloud_endpoint
+        # Call cloud GPU endpoint
+        from cloud_gpu import call_cloud_endpoint
 
-    result, elapsed = call_cloud_endpoint(
-        provider=cloud,
-        payload=modal_payload,
-        tool_name="dewatermark",
-        timeout=timeout,
-        progress_label="Removing watermark",
-        verbose=verbose,
-        progress=progress,
-    )
+        result, elapsed = call_cloud_endpoint(
+            provider=cloud,
+            payload=modal_payload,
+            tool_name="dewatermark",
+            timeout=timeout,
+            progress_label="Removing watermark",
+            verbose=verbose,
+            progress=progress,
+        )
 
-    if isinstance(result, dict) and result.get("error"):
-        return {"error": result["error"]}
+        if isinstance(result, dict) and result.get("error"):
+            return {"error": result["error"]}
 
-    # Extract output (RunPod wraps in "output", Modal returns directly)
-    output = result.get("output", result) if cloud == "runpod" else result
+        # Extract output (RunPod wraps in "output", Modal returns directly)
+        output = result.get("output", result) if cloud == "runpod" else result
 
-    if isinstance(output, dict) and output.get("error"):
-        return {"error": output["error"]}
+        if isinstance(output, dict) and output.get("error"):
+            return {"error": output["error"]}
 
-    # Download result
-    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
-    downloaded = False
+        # Download result
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        downloaded = False
 
-    output_r2_key = output.get("r2_key") if isinstance(output, dict) else None
-    output_url = output.get("output_url") if isinstance(output, dict) else None
+        output_r2_key = output.get("r2_key") if isinstance(output, dict) else None
+        output_url = output.get("output_url") if isinstance(output, dict) else None
 
-    if output_r2_key:
-        if verbose:
-            print(f"Downloading result from R2...", file=sys.stderr)
-        downloaded = download_from_r2(output_r2_key, output_path)
-        if downloaded:
-            r2_keys_to_cleanup.append(output_r2_key)
-
-    if not downloaded and output_url:
-        downloaded = download_from_url(output_url, output_path, verbose=verbose)
-
-    if not downloaded:
-        # Try base64 fallback (Modal returns base64 when no R2)
-        video_b64 = output.get("video_base64") if isinstance(output, dict) else None
-        if video_b64:
-            import base64
-            with open(output_path, "wb") as f:
-                f.write(base64.b64decode(video_b64))
-            downloaded = True
+        if output_r2_key:
             if verbose:
-                size_mb = Path(output_path).stat().st_size // (1024 * 1024)
-                print(f"  Downloaded: {output_path} ({size_mb}MB)", file=sys.stderr)
+                print(f"Downloading result from R2...", file=sys.stderr)
+            downloaded = download_from_r2(output_r2_key, output_path)
+            if downloaded:
+                r2_keys_to_cleanup.append(output_r2_key)
 
-    if not downloaded:
-        return {"error": f"No output_url, r2_key, or video_base64 in result"}
+        if not downloaded and output_url:
+            downloaded = download_from_url(output_url, output_path, verbose=verbose)
+            # Same object the r2_key names -- register it however we fetched it.
+            if downloaded and output_r2_key:
+                r2_keys_to_cleanup.append(output_r2_key)
 
-    # Restore audio from original (ProPainter strips audio)
-    if preserve_audio:
-        temp_video = output_path + ".noaudio.mp4"
-        shutil.move(output_path, temp_video)
-        if mux_audio_from_original(temp_video, input_path, output_path, verbose=verbose):
-            Path(temp_video).unlink(missing_ok=True)
-        else:
-            shutil.move(temp_video, output_path)
-            if verbose:
-                print(f"  Warning: Could not restore audio, output has no audio", file=sys.stderr)
+        if not downloaded:
+            # Try base64 fallback (Modal returns base64 when no R2)
+            video_b64 = output.get("video_base64") if isinstance(output, dict) else None
+            if video_b64:
+                import base64
+                with open(output_path, "wb") as f:
+                    f.write(base64.b64decode(video_b64))
+                downloaded = True
+                if verbose:
+                    size_mb = Path(output_path).stat().st_size // (1024 * 1024)
+                    print(f"  Downloaded: {output_path} ({size_mb}MB)", file=sys.stderr)
 
-    # Upscale to original resolution if requested
-    actual_ratio = resize_ratio if isinstance(resize_ratio, float) else None
-    if upscale and original_width and original_height and actual_ratio and actual_ratio < 1.0:
-        temp_video = output_path + ".small.mp4"
-        shutil.move(output_path, temp_video)
-        if upscale_video(temp_video, output_path, original_width, original_height, verbose=verbose):
-            Path(temp_video).unlink(missing_ok=True)
-        else:
-            shutil.move(temp_video, output_path)
-            if verbose:
-                print(f"  Warning: Upscale failed, output is at reduced resolution", file=sys.stderr)
+        if not downloaded:
+            return {"error": f"No output_url, r2_key, or video_base64 in result"}
 
-    # Cleanup R2 objects
-    if r2_keys_to_cleanup:
-        if verbose:
-            print(f"Cleaning up {len(r2_keys_to_cleanup)} R2 objects...", file=sys.stderr)
-        for key in r2_keys_to_cleanup:
-            delete_from_r2(key)
+        # Restore audio from original (ProPainter strips audio)
+        if preserve_audio:
+            temp_video = output_path + ".noaudio.mp4"
+            shutil.move(output_path, temp_video)
+            if mux_audio_from_original(temp_video, input_path, output_path, verbose=verbose):
+                Path(temp_video).unlink(missing_ok=True)
+            else:
+                shutil.move(temp_video, output_path)
+                if verbose:
+                    print(f"  Warning: Could not restore audio, output has no audio", file=sys.stderr)
 
-    return {
-        "success": True,
-        "output": output_path,
-        "processing_time_seconds": round(elapsed, 2),
-        "cloud_output": output if not output.get("video_base64") else {
-            k: v for k, v in output.items() if k != "video_base64"
-        },
-    }
+        # Upscale to original resolution if requested
+        actual_ratio = resize_ratio if isinstance(resize_ratio, float) else None
+        if upscale and original_width and original_height and actual_ratio and actual_ratio < 1.0:
+            temp_video = output_path + ".small.mp4"
+            shutil.move(output_path, temp_video)
+            if upscale_video(temp_video, output_path, original_width, original_height, verbose=verbose):
+                Path(temp_video).unlink(missing_ok=True)
+            else:
+                shutil.move(temp_video, output_path)
+                if verbose:
+                    print(f"  Warning: Upscale failed, output is at reduced resolution", file=sys.stderr)
+
+        return {
+            "success": True,
+            "output": output_path,
+            "processing_time_seconds": round(elapsed, 2),
+            "cloud_output": output if not output.get("video_base64") else {
+                k: v for k, v in output.items() if k != "video_base64"
+            },
+        }
 
 
 # =============================================================================

--- a/tools/file_transfer.py
+++ b/tools/file_transfer.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import os
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 
 
@@ -95,6 +96,33 @@ def delete_from_r2(object_key: str) -> bool:
         return True
     except Exception:
         return False
+
+
+@contextmanager
+def r2_cleanup():
+    """Collect R2 keys to delete, and delete them however the block exits.
+
+    Cloud GPU tools upload inputs and download results through R2, then delete
+    those objects. Doing that with a plain list plus a loop at the end of the
+    happy path leaks every object whenever the tool returns an error in
+    between -- a failed upload, an endpoint error, a missing result -- which is
+    exactly when a run is most likely to bail out. Draining in `finally` means
+    success, early return and exception all clean up the same way.
+
+    Usage:
+        with r2_cleanup() as r2_keys_to_cleanup:
+            ...
+            r2_keys_to_cleanup.append(key)
+
+    Deletion is best-effort: delete_from_r2 swallows its own errors, so a key
+    that cannot be removed never masks the result of the block.
+    """
+    keys: list[str] = []
+    try:
+        yield keys
+    finally:
+        for key in keys:
+            delete_from_r2(key)
 
 
 def _upload_to_litterbox(file_path: str, file_name: str) -> str | None:

--- a/tools/qwen3_tts.py
+++ b/tools/qwen3_tts.py
@@ -110,7 +110,7 @@ def resolve_tone(tone: str | None, instruct: str) -> str:
 
 
 from file_transfer import (
-    upload_to_storage, download_from_r2, delete_from_r2,
+    upload_to_storage, download_from_r2, r2_cleanup,
     download_from_url, get_r2_payload_config,
 )
 
@@ -177,223 +177,218 @@ def generate_audio(
       batch call:  {success, outputs: [{output, duration_seconds, ...}, ...]}
     """
     start_time = time.time()
-    r2_keys_to_cleanup = []
+    with r2_cleanup() as r2_keys_to_cleanup:
+        # Normalize inputs
+        is_batch = isinstance(text, list)
+        texts = text if is_batch else [text]
+        out_paths = output_path if is_batch else [output_path]
+        if len(out_paths) != len(texts):
+            return {"success": False, "error": "text and output_path must have matching lengths"}
+        if any(not t for t in texts):
+            return {"success": False, "error": "all texts must be non-empty strings"}
 
-    # Normalize inputs
-    is_batch = isinstance(text, list)
-    texts = text if is_batch else [text]
-    out_paths = output_path if is_batch else [output_path]
-    if len(out_paths) != len(texts):
-        return {"success": False, "error": "text and output_path must have matching lengths"}
-    if any(not t for t in texts):
-        return {"success": False, "error": "all texts must be non-empty strings"}
+        # Get R2 config (used for file transfer regardless of cloud provider)
+        r2_payload = get_r2_payload_config()
 
-    # Get R2 config (used for file transfer regardless of cloud provider)
-    r2_payload = get_r2_payload_config()
+        # Determine mode
+        if design_instruct is not None:
+            if is_batch:
+                return {"success": False, "error": "voice_design mode expects a single seed text, not a batch"}
+            mode = "voice_design"
+        elif ref_audio:
+            mode = "clone"
+        else:
+            mode = "custom_voice"
 
-    # Determine mode
-    if design_instruct is not None:
-        if is_batch:
-            return {"success": False, "error": "voice_design mode expects a single seed text, not a batch"}
-        mode = "voice_design"
-    elif ref_audio:
-        mode = "clone"
-    else:
-        mode = "custom_voice"
-
-    # Upload reference audio for clone mode
-    ref_audio_url = None
-    if mode == "clone":
-        if not Path(ref_audio).exists():
-            return {"success": False, "error": f"Reference audio not found: {ref_audio}"}
-        if not ref_text:
-            return {"success": False, "error": "ref_text is required for voice cloning"}
-
-        ref_audio_url, ref_r2_key = upload_to_storage(ref_audio, "qwen3-tts/input")
-        if not ref_audio_url:
-            return {"success": False, "error": "Failed to upload reference audio"}
-        if ref_r2_key:
-            r2_keys_to_cleanup.append(ref_r2_key)
-
-    if verbose:
-        print(f"Cloud provider: {cloud}", file=sys.stderr)
+        # Upload reference audio for clone mode
+        ref_audio_url = None
         if mode == "clone":
-            print(f"Mode: voice clone ({len(texts)} utterance{'s' if len(texts) > 1 else ''}, shared prompt)", file=sys.stderr)
-        elif mode == "voice_design":
-            print(f"Mode: voice design (instruct={design_instruct[:60]!r}...)", file=sys.stderr)
-        else:
-            print(f"Speaker: {speaker}, Language: {language}, mode: custom_voice", file=sys.stderr)
+            if not Path(ref_audio).exists():
+                return {"success": False, "error": f"Reference audio not found: {ref_audio}"}
+            if not ref_text:
+                return {"success": False, "error": "ref_text is required for voice cloning"}
 
-    # Build payload (same format for both providers)
-    payload = {
-        "input": {
-            "text": texts if is_batch else texts[0],
-            "mode": mode,
-            "language": language,
-            "output_format": output_format,
-        }
-    }
+            ref_audio_url, ref_r2_key = upload_to_storage(ref_audio, "qwen3-tts/input")
+            if not ref_audio_url:
+                return {"success": False, "error": "Failed to upload reference audio"}
+            if ref_r2_key:
+                r2_keys_to_cleanup.append(ref_r2_key)
 
-    if mode == "clone":
-        payload["input"]["ref_audio_url"] = ref_audio_url
-        payload["input"]["ref_text"] = ref_text
-    elif mode == "voice_design":
-        payload["input"]["instruct"] = design_instruct
-    else:
-        payload["input"]["speaker"] = speaker
-        if instruct:
-            payload["input"]["instruct"] = instruct
+        if verbose:
+            print(f"Cloud provider: {cloud}", file=sys.stderr)
+            if mode == "clone":
+                print(f"Mode: voice clone ({len(texts)} utterance{'s' if len(texts) > 1 else ''}, shared prompt)", file=sys.stderr)
+            elif mode == "voice_design":
+                print(f"Mode: voice design (instruct={design_instruct[:60]!r}...)", file=sys.stderr)
+            else:
+                print(f"Speaker: {speaker}, Language: {language}, mode: custom_voice", file=sys.stderr)
 
-    if temperature is not None:
-        payload["input"]["temperature"] = temperature
-    if top_p is not None:
-        payload["input"]["top_p"] = top_p
-
-    if r2_payload:
-        payload["input"]["r2"] = r2_payload
-
-    # Submit job via cloud_gpu abstraction
-    try:
-        from cloud_gpu import call_cloud_endpoint
-    except ImportError:
-        sys.path.insert(0, str(Path(__file__).parent))
-        from cloud_gpu import call_cloud_endpoint
-
-    progress_label = (
-        f"Designing voice" if mode == "voice_design"
-        else (f"Generating {len(texts)} utterances" if is_batch else "Generating speech")
-    )
-    # Batch calls can be longer-running; scale timeout by count
-    effective_timeout = timeout * max(1, len(texts) // 3 + 1)
-
-    output, elapsed = call_cloud_endpoint(
-        provider=cloud,
-        payload=payload,
-        tool_name="qwen3_tts",
-        timeout=effective_timeout,
-        poll_interval=3,
-        progress_label=progress_label,
-        verbose=verbose,
-        progress=progress,
-    )
-
-    if isinstance(output, dict) and output.get("error"):
-        return {"success": False, "error": output["error"]}
-
-    # Parse response — handler returns `outputs: [...]` always; legacy top-level
-    # keys also present when input was single-text. Use `outputs` uniformly.
-    outputs_list = None
-    if isinstance(output, dict):
-        if isinstance(output.get("outputs"), list):
-            outputs_list = output["outputs"]
-        else:
-            # Pre-v0.2 handler or single-shot legacy response — synthesize a
-            # one-item list from top-level keys.
-            legacy_item = {
-                k: output[k] for k in ("audio_url", "r2_key", "audio_base64", "duration_seconds")
-                if k in output
+        # Build payload (same format for both providers)
+        payload = {
+            "input": {
+                "text": texts if is_batch else texts[0],
+                "mode": mode,
+                "language": language,
+                "output_format": output_format,
             }
-            if legacy_item:
-                outputs_list = [legacy_item]
-
-    if not outputs_list or len(outputs_list) != len(texts):
-        return {
-            "success": False,
-            "error": f"Expected {len(texts)} output(s), got {len(outputs_list) if outputs_list else 0}: "
-                     f"{list(output.keys()) if isinstance(output, dict) else output}",
         }
 
-    # Download all outputs
-    downloaded_items = []
-    for i, (item, dest_path) in enumerate(zip(outputs_list, out_paths)):
-        Path(dest_path).parent.mkdir(parents=True, exist_ok=True)
-        downloaded = False
+        if mode == "clone":
+            payload["input"]["ref_audio_url"] = ref_audio_url
+            payload["input"]["ref_text"] = ref_text
+        elif mode == "voice_design":
+            payload["input"]["instruct"] = design_instruct
+        else:
+            payload["input"]["speaker"] = speaker
+            if instruct:
+                payload["input"]["instruct"] = instruct
 
-        r2_key = item.get("r2_key")
-        url = item.get("audio_url")
+        if temperature is not None:
+            payload["input"]["temperature"] = temperature
+        if top_p is not None:
+            payload["input"]["top_p"] = top_p
 
-        if r2_key:
-            if verbose:
-                print(f"Downloading output {i+1}/{len(outputs_list)} from R2...", file=sys.stderr)
-            downloaded = download_from_r2(r2_key, dest_path)
-            if downloaded:
-                r2_keys_to_cleanup.append(r2_key)
+        if r2_payload:
+            payload["input"]["r2"] = r2_payload
+
+        # Submit job via cloud_gpu abstraction
+        try:
+            from cloud_gpu import call_cloud_endpoint
+        except ImportError:
+            sys.path.insert(0, str(Path(__file__).parent))
+            from cloud_gpu import call_cloud_endpoint
+
+        progress_label = (
+            f"Designing voice" if mode == "voice_design"
+            else (f"Generating {len(texts)} utterances" if is_batch else "Generating speech")
+        )
+        # Batch calls can be longer-running; scale timeout by count
+        effective_timeout = timeout * max(1, len(texts) // 3 + 1)
+
+        output, elapsed = call_cloud_endpoint(
+            provider=cloud,
+            payload=payload,
+            tool_name="qwen3_tts",
+            timeout=effective_timeout,
+            poll_interval=3,
+            progress_label=progress_label,
+            verbose=verbose,
+            progress=progress,
+        )
+
+        if isinstance(output, dict) and output.get("error"):
+            return {"success": False, "error": output["error"]}
+
+        # Parse response — handler returns `outputs: [...]` always; legacy top-level
+        # keys also present when input was single-text. Use `outputs` uniformly.
+        outputs_list = None
+        if isinstance(output, dict):
+            if isinstance(output.get("outputs"), list):
+                outputs_list = output["outputs"]
+            else:
+                # Pre-v0.2 handler or single-shot legacy response — synthesize a
+                # one-item list from top-level keys.
+                legacy_item = {
+                    k: output[k] for k in ("audio_url", "r2_key", "audio_base64", "duration_seconds")
+                    if k in output
+                }
+                if legacy_item:
+                    outputs_list = [legacy_item]
+
+        if not outputs_list or len(outputs_list) != len(texts):
+            return {
+                "success": False,
+                "error": f"Expected {len(texts)} output(s), got {len(outputs_list) if outputs_list else 0}: "
+                         f"{list(output.keys()) if isinstance(output, dict) else output}",
+            }
+
+        # Download all outputs
+        downloaded_items = []
+        for i, (item, dest_path) in enumerate(zip(outputs_list, out_paths)):
+            Path(dest_path).parent.mkdir(parents=True, exist_ok=True)
+            downloaded = False
+
+            r2_key = item.get("r2_key")
+            url = item.get("audio_url")
+
+            if r2_key:
                 if verbose:
-                    size_kb = Path(dest_path).stat().st_size // 1024
-                    print(f"  Downloaded: {dest_path} ({size_kb}KB)", file=sys.stderr)
+                    print(f"Downloading output {i+1}/{len(outputs_list)} from R2...", file=sys.stderr)
+                downloaded = download_from_r2(r2_key, dest_path)
+                if downloaded:
+                    r2_keys_to_cleanup.append(r2_key)
+                    if verbose:
+                        size_kb = Path(dest_path).stat().st_size // 1024
+                        print(f"  Downloaded: {dest_path} ({size_kb}KB)", file=sys.stderr)
 
-        if not downloaded and url:
-            downloaded = download_from_url(url, dest_path, verbose=verbose)
+            if not downloaded and url:
+                downloaded = download_from_url(url, dest_path, verbose=verbose)
+                # Same object the r2_key names -- register it however we fetched it.
+                if downloaded and r2_key:
+                    r2_keys_to_cleanup.append(r2_key)
 
-        if not downloaded:
-            audio_base64 = item.get("audio_base64")
-            if audio_base64:
-                Path(dest_path).write_bytes(base64.b64decode(audio_base64))
-                downloaded = True
-                if verbose:
-                    size_kb = Path(dest_path).stat().st_size // 1024
-                    print(f"  Decoded from base64: {dest_path} ({size_kb}KB)", file=sys.stderr)
+            if not downloaded:
+                audio_base64 = item.get("audio_base64")
+                if audio_base64:
+                    Path(dest_path).write_bytes(base64.b64decode(audio_base64))
+                    downloaded = True
+                    if verbose:
+                        size_kb = Path(dest_path).stat().st_size // 1024
+                        print(f"  Decoded from base64: {dest_path} ({size_kb}KB)", file=sys.stderr)
 
-        if not downloaded:
-            # Cleanup before returning
-            for key in r2_keys_to_cleanup:
-                delete_from_r2(key)
-            return {"success": False, "error": f"No audio in output[{i}]: {list(item.keys())}"}
+            if not downloaded:
+                return {"success": False, "error": f"No audio in output[{i}]: {list(item.keys())}"}
 
-        duration = get_audio_duration(dest_path)
-        item_result = {
-            "output": dest_path,
-            "duration_seconds": round(duration, 2) if duration else None,
-            "duration_frames_30fps": int(duration * 30) if duration else None,
-            "script_chars": len(texts[i]),
-        }
+            duration = get_audio_duration(dest_path)
+            item_result = {
+                "output": dest_path,
+                "duration_seconds": round(duration, 2) if duration else None,
+                "duration_frames_30fps": int(duration * 30) if duration else None,
+                "script_chars": len(texts[i]),
+            }
 
-        # Pacing QC (voice_design seed sentences are auditions, not narration)
-        if mode != "voice_design":
-            from pacing import clamp_pace, pace_label
-            if max_wpm:
-                clamp = clamp_pace(dest_path, texts[i], max_wpm, verbose=verbose)
-                if clamp.get("applied"):
-                    new_dur = clamp["duration_seconds"]
-                    item_result["duration_seconds"] = new_dur
-                    item_result["duration_frames_30fps"] = (
-                        int(new_dur * 30) if new_dur else None
+            # Pacing QC (voice_design seed sentences are auditions, not narration)
+            if mode != "voice_design":
+                from pacing import clamp_pace, pace_label
+                if max_wpm:
+                    clamp = clamp_pace(dest_path, texts[i], max_wpm, verbose=verbose)
+                    if clamp.get("applied"):
+                        new_dur = clamp["duration_seconds"]
+                        item_result["duration_seconds"] = new_dur
+                        item_result["duration_frames_30fps"] = (
+                            int(new_dur * 30) if new_dur else None
+                        )
+                        item_result["pace_adjusted"] = {
+                            "original_wpm": clamp["original_wpm"],
+                            "atempo": clamp["atempo"],
+                        }
+                    elif clamp.get("error") and verbose:
+                        print(f"  Pace clamp skipped: {clamp['error']}", file=sys.stderr)
+                wpm, label = pace_label(texts[i], item_result["duration_seconds"])
+                item_result["wpm"] = wpm
+                item_result["pacing"] = label
+                if verbose and label in ("fast", "slow"):
+                    print(
+                        f"  Pacing warning: {Path(dest_path).name} is {wpm:.0f} wpm "
+                        f"({label}; comfortable narration is 140-160). "
+                        "Consider --max-wpm to auto-correct.",
+                        file=sys.stderr,
                     )
-                    item_result["pace_adjusted"] = {
-                        "original_wpm": clamp["original_wpm"],
-                        "atempo": clamp["atempo"],
-                    }
-                elif clamp.get("error") and verbose:
-                    print(f"  Pace clamp skipped: {clamp['error']}", file=sys.stderr)
-            wpm, label = pace_label(texts[i], item_result["duration_seconds"])
-            item_result["wpm"] = wpm
-            item_result["pacing"] = label
-            if verbose and label in ("fast", "slow"):
-                print(
-                    f"  Pacing warning: {Path(dest_path).name} is {wpm:.0f} wpm "
-                    f"({label}; comfortable narration is 140-160). "
-                    "Consider --max-wpm to auto-correct.",
-                    file=sys.stderr,
-                )
 
-        downloaded_items.append(item_result)
+            downloaded_items.append(item_result)
 
-    # Cleanup R2 objects
-    for key in r2_keys_to_cleanup:
-        delete_from_r2(key)
-
-    if is_batch:
-        return {
-            "success": True,
-            "outputs": downloaded_items,
-            "mode": mode,
-        }
-    else:
-        return {
-            "success": True,
-            **downloaded_items[0],
-            "mode": mode,
-        }
+        if is_batch:
+            return {
+                "success": True,
+                "outputs": downloaded_items,
+                "mode": mode,
+            }
+        else:
+            return {
+                "success": True,
+                **downloaded_items[0],
+                "mode": mode,
+            }
 
 
 # =============================================================================

--- a/tools/sadtalker.py
+++ b/tools/sadtalker.py
@@ -41,7 +41,7 @@ import requests
 
 sys.path.insert(0, str(Path(__file__).parent))
 from file_transfer import (
-    upload_to_storage, download_from_r2, delete_from_r2,
+    upload_to_storage, download_from_r2, r2_cleanup,
     download_from_url, get_r2_payload_config,
 )
 
@@ -169,131 +169,129 @@ def process_with_cloud(
     progress=None,
 ) -> dict:
     """Process image+audio using cloud GPU endpoint."""
-    r2_keys_to_cleanup = []
-
-    if verbose:
-        print(f"Cloud provider: {cloud}", file=sys.stderr)
-
-    # Auto-calculate timeout if not specified
-    audio_duration = get_audio_duration(audio_path)
-    if timeout <= 0:
-        if audio_duration:
-            timeout = calculate_timeout(audio_duration)
-            if verbose:
-                print(f"Audio duration: {audio_duration:.1f}s, timeout: {timeout}s", file=sys.stderr)
-        else:
-            timeout = 900  # Default 15 minutes
-            if verbose:
-                print(f"Could not determine audio duration, using default timeout: {timeout}s", file=sys.stderr)
-
-    # Pre-flight estimate
-    if verbose and audio_duration:
-        chunk_duration = 45  # matches CHUNK_DURATION in Modal app
-        num_chunks = max(1, int(audio_duration / chunk_duration) + (1 if audio_duration % chunk_duration > 0 else 0))
-        est_minutes = (audio_duration * PROCESSING_TIME_MULTIPLIER) / 60
-        # A10G cost: ~$0.000362/sec
-        est_cost = (audio_duration * PROCESSING_TIME_MULTIPLIER + PROCESSING_TIME_BUFFER) * 0.000362
-        print(f"Estimate: {num_chunks} chunk{'s' if num_chunks > 1 else ''}, "
-              f"~{est_minutes:.0f} min processing, ~${est_cost:.2f} GPU cost",
-              file=sys.stderr)
-
-    # Upload image
-    image_url, image_r2_key = upload_to_storage(image_path, "sadtalker/input")
-    if not image_url:
-        return {"error": "Failed to upload image"}
-    if image_r2_key:
-        r2_keys_to_cleanup.append(image_r2_key)
-
-    # Upload audio
-    audio_url, audio_r2_key = upload_to_storage(audio_path, "sadtalker/input")
-    if not audio_url:
-        return {"error": "Failed to upload audio"}
-    if audio_r2_key:
-        r2_keys_to_cleanup.append(audio_r2_key)
-
-    # Build payload
-    if verbose:
-        print(f"Submitting job (size={size}, enhancer={enhancer})...", file=sys.stderr)
-
-    payload = {
-        "input": {
-            "image_url": image_url,
-            "audio_url": audio_url,
-            "still_mode": still_mode,
-            "enhancer": enhancer,
-            "preprocess": preprocess,
-            "size": size,
-            "expression_scale": expression_scale,
-            "pose_style": pose_style,
-        }
-    }
-
-    r2_payload = get_r2_payload_config()
-    if r2_payload:
-        payload["input"]["r2"] = r2_payload
-    else:
-        print("Warning: R2 not configured. Video will be returned as base64.", file=sys.stderr)
-
-    # Call cloud GPU endpoint
-    from cloud_gpu import call_cloud_endpoint
-
-    result, elapsed = call_cloud_endpoint(
-        provider=cloud,
-        payload=payload,
-        tool_name="sadtalker",
-        timeout=timeout,
-        progress_label="Generating talking head",
-        verbose=verbose,
-        progress=progress,
-    )
-
-    if isinstance(result, dict) and result.get("error"):
-        return {"error": result["error"]}
-
-    # Download result
-    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
-    downloaded = False
-
-    output_r2_key = result.get("r2_key") if isinstance(result, dict) else None
-    output_url = result.get("video_url") if isinstance(result, dict) else None
-
-    if output_r2_key:
+    with r2_cleanup() as r2_keys_to_cleanup:
         if verbose:
-            print(f"Downloading result from R2...", file=sys.stderr)
-        downloaded = download_from_r2(output_r2_key, output_path)
-        if downloaded:
-            r2_keys_to_cleanup.append(output_r2_key)
+            print(f"Cloud provider: {cloud}", file=sys.stderr)
+
+        # Auto-calculate timeout if not specified
+        audio_duration = get_audio_duration(audio_path)
+        if timeout <= 0:
+            if audio_duration:
+                timeout = calculate_timeout(audio_duration)
+                if verbose:
+                    print(f"Audio duration: {audio_duration:.1f}s, timeout: {timeout}s", file=sys.stderr)
+            else:
+                timeout = 900  # Default 15 minutes
+                if verbose:
+                    print(f"Could not determine audio duration, using default timeout: {timeout}s", file=sys.stderr)
+
+        # Pre-flight estimate
+        if verbose and audio_duration:
+            chunk_duration = 45  # matches CHUNK_DURATION in Modal app
+            num_chunks = max(1, int(audio_duration / chunk_duration) + (1 if audio_duration % chunk_duration > 0 else 0))
+            est_minutes = (audio_duration * PROCESSING_TIME_MULTIPLIER) / 60
+            # A10G cost: ~$0.000362/sec
+            est_cost = (audio_duration * PROCESSING_TIME_MULTIPLIER + PROCESSING_TIME_BUFFER) * 0.000362
+            print(f"Estimate: {num_chunks} chunk{'s' if num_chunks > 1 else ''}, "
+                  f"~{est_minutes:.0f} min processing, ~${est_cost:.2f} GPU cost",
+                  file=sys.stderr)
+
+        # Upload image
+        image_url, image_r2_key = upload_to_storage(image_path, "sadtalker/input")
+        if not image_url:
+            return {"error": "Failed to upload image"}
+        if image_r2_key:
+            r2_keys_to_cleanup.append(image_r2_key)
+
+        # Upload audio
+        audio_url, audio_r2_key = upload_to_storage(audio_path, "sadtalker/input")
+        if not audio_url:
+            return {"error": "Failed to upload audio"}
+        if audio_r2_key:
+            r2_keys_to_cleanup.append(audio_r2_key)
+
+        # Build payload
+        if verbose:
+            print(f"Submitting job (size={size}, enhancer={enhancer})...", file=sys.stderr)
+
+        payload = {
+            "input": {
+                "image_url": image_url,
+                "audio_url": audio_url,
+                "still_mode": still_mode,
+                "enhancer": enhancer,
+                "preprocess": preprocess,
+                "size": size,
+                "expression_scale": expression_scale,
+                "pose_style": pose_style,
+            }
+        }
+
+        r2_payload = get_r2_payload_config()
+        if r2_payload:
+            payload["input"]["r2"] = r2_payload
+        else:
+            print("Warning: R2 not configured. Video will be returned as base64.", file=sys.stderr)
+
+        # Call cloud GPU endpoint
+        from cloud_gpu import call_cloud_endpoint
+
+        result, elapsed = call_cloud_endpoint(
+            provider=cloud,
+            payload=payload,
+            tool_name="sadtalker",
+            timeout=timeout,
+            progress_label="Generating talking head",
+            verbose=verbose,
+            progress=progress,
+        )
+
+        if isinstance(result, dict) and result.get("error"):
+            return {"error": result["error"]}
+
+        # Download result
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        downloaded = False
+
+        output_r2_key = result.get("r2_key") if isinstance(result, dict) else None
+        output_url = result.get("video_url") if isinstance(result, dict) else None
+
+        if output_r2_key:
             if verbose:
-                size_kb = Path(output_path).stat().st_size // 1024
-                print(f"  Downloaded: {output_path} ({size_kb}KB)", file=sys.stderr)
+                print(f"Downloading result from R2...", file=sys.stderr)
+            downloaded = download_from_r2(output_r2_key, output_path)
+            if downloaded:
+                r2_keys_to_cleanup.append(output_r2_key)
+                if verbose:
+                    size_kb = Path(output_path).stat().st_size // 1024
+                    print(f"  Downloaded: {output_path} ({size_kb}KB)", file=sys.stderr)
 
-    if not downloaded and output_url:
-        downloaded = download_from_url(output_url, output_path, verbose=verbose)
+        if not downloaded and output_url:
+            downloaded = download_from_url(output_url, output_path, verbose=verbose)
+            # Same object the r2_key names -- register it however we fetched it.
+            if downloaded and output_r2_key:
+                r2_keys_to_cleanup.append(output_r2_key)
 
-    if not downloaded:
-        # Try base64 fallback
-        video_base64 = result.get("video_base64")
-        if video_base64:
-            Path(output_path).write_bytes(base64.b64decode(video_base64))
-            downloaded = True
-            if verbose:
-                size_kb = Path(output_path).stat().st_size // 1024
-                print(f"  Decoded from base64: {output_path} ({size_kb}KB)", file=sys.stderr)
+        if not downloaded:
+            # Try base64 fallback
+            video_base64 = result.get("video_base64")
+            if video_base64:
+                Path(output_path).write_bytes(base64.b64decode(video_base64))
+                downloaded = True
+                if verbose:
+                    size_kb = Path(output_path).stat().st_size // 1024
+                    print(f"  Decoded from base64: {output_path} ({size_kb}KB)", file=sys.stderr)
 
-    if not downloaded:
-        return {"error": f"No video in result: {list(result.keys()) if isinstance(result, dict) else result}"}
+        if not downloaded:
+            return {"error": f"No video in result: {list(result.keys()) if isinstance(result, dict) else result}"}
 
-    # Cleanup R2 objects
-    for key in r2_keys_to_cleanup:
-        delete_from_r2(key)
-
-    return {
-        "success": True,
-        "output": output_path,
-        "processing_time_seconds": round(elapsed, 2),
-        "duration_seconds": result.get("duration_seconds"),
-        "chunks_processed": result.get("chunks_processed"),
-    }
+        return {
+            "success": True,
+            "output": output_path,
+            "processing_time_seconds": round(elapsed, 2),
+            "duration_seconds": result.get("duration_seconds"),
+            "chunks_processed": result.get("chunks_processed"),
+        }
 
 
 # =============================================================================

--- a/tools/upscale.py
+++ b/tools/upscale.py
@@ -39,7 +39,7 @@ import requests
 
 sys.path.insert(0, str(Path(__file__).parent))
 from file_transfer import (
-    upload_to_storage, download_from_r2, delete_from_r2,
+    upload_to_storage, download_from_r2, r2_cleanup,
     download_from_url, get_r2_payload_config,
 )
 
@@ -62,86 +62,84 @@ def process_with_cloud(
     progress=None,
 ) -> dict:
     """Process image using cloud GPU endpoint."""
-    r2_keys_to_cleanup = []
-
-    if verbose:
-        print(f"Cloud provider: {cloud}", file=sys.stderr)
-
-    # Upload image
-    image_url, image_r2_key = upload_to_storage(input_path, "upscale/input")
-    if not image_url:
-        return {"error": "Failed to upload image"}
-    if image_r2_key:
-        r2_keys_to_cleanup.append(image_r2_key)
-
-    # Build payload
-    if verbose:
-        print(f"Submitting job (scale={scale}, model={model})...", file=sys.stderr)
-
-    payload = {
-        "input": {
-            "operation": "upscale",
-            "image_url": image_url,
-            "scale": scale,
-            "model": model,
-            "face_enhance": face_enhance,
-            "output_format": output_format,
-        }
-    }
-
-    r2_payload = get_r2_payload_config()
-    if r2_payload:
-        payload["input"]["r2"] = r2_payload
-
-    # Call cloud GPU endpoint
-    from cloud_gpu import call_cloud_endpoint
-
-    result, elapsed = call_cloud_endpoint(
-        provider=cloud,
-        payload=payload,
-        tool_name="upscale",
-        timeout=timeout,
-        progress_label="Upscaling image",
-        verbose=verbose,
-        progress=progress,
-    )
-
-    if isinstance(result, dict) and result.get("error"):
-        return {"error": result["error"]}
-
-    # Download result
-    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
-    downloaded = False
-
-    output_r2_key = result.get("r2_key") if isinstance(result, dict) else None
-    output_url = result.get("output_url") if isinstance(result, dict) else None
-
-    if output_r2_key:
+    with r2_cleanup() as r2_keys_to_cleanup:
         if verbose:
-            print(f"Downloading result from R2...", file=sys.stderr)
-        downloaded = download_from_r2(output_r2_key, output_path)
-        if downloaded:
-            r2_keys_to_cleanup.append(output_r2_key)
+            print(f"Cloud provider: {cloud}", file=sys.stderr)
+
+        # Upload image
+        image_url, image_r2_key = upload_to_storage(input_path, "upscale/input")
+        if not image_url:
+            return {"error": "Failed to upload image"}
+        if image_r2_key:
+            r2_keys_to_cleanup.append(image_r2_key)
+
+        # Build payload
+        if verbose:
+            print(f"Submitting job (scale={scale}, model={model})...", file=sys.stderr)
+
+        payload = {
+            "input": {
+                "operation": "upscale",
+                "image_url": image_url,
+                "scale": scale,
+                "model": model,
+                "face_enhance": face_enhance,
+                "output_format": output_format,
+            }
+        }
+
+        r2_payload = get_r2_payload_config()
+        if r2_payload:
+            payload["input"]["r2"] = r2_payload
+
+        # Call cloud GPU endpoint
+        from cloud_gpu import call_cloud_endpoint
+
+        result, elapsed = call_cloud_endpoint(
+            provider=cloud,
+            payload=payload,
+            tool_name="upscale",
+            timeout=timeout,
+            progress_label="Upscaling image",
+            verbose=verbose,
+            progress=progress,
+        )
+
+        if isinstance(result, dict) and result.get("error"):
+            return {"error": result["error"]}
+
+        # Download result
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        downloaded = False
+
+        output_r2_key = result.get("r2_key") if isinstance(result, dict) else None
+        output_url = result.get("output_url") if isinstance(result, dict) else None
+
+        if output_r2_key:
             if verbose:
-                size_kb = Path(output_path).stat().st_size // 1024
-                print(f"  Downloaded: {output_path} ({size_kb}KB)", file=sys.stderr)
+                print(f"Downloading result from R2...", file=sys.stderr)
+            downloaded = download_from_r2(output_r2_key, output_path)
+            if downloaded:
+                r2_keys_to_cleanup.append(output_r2_key)
+                if verbose:
+                    size_kb = Path(output_path).stat().st_size // 1024
+                    print(f"  Downloaded: {output_path} ({size_kb}KB)", file=sys.stderr)
 
-    if not downloaded and output_url:
-        downloaded = download_from_url(output_url, output_path, verbose=verbose)
+        if not downloaded and output_url:
+            downloaded = download_from_url(output_url, output_path, verbose=verbose)
+            # Same object the r2_key names -- register it however we fetched it.
+            if downloaded and output_r2_key:
+                r2_keys_to_cleanup.append(output_r2_key)
 
-    if not downloaded:
-        return {"error": f"No output_url or r2_key in result: {result}"}
+        if not downloaded:
+            return {"error": f"No output_url or r2_key in result: {result}"}
 
-    # Cleanup R2 objects
-    for key in r2_keys_to_cleanup:
-        delete_from_r2(key)
-
-    return {
-        "success": True,
-        "output": output_path,
-        "processing_time_seconds": round(elapsed, 2),
-        "cloud_output": result,
-    }
+        return {
+            "success": True,
+            "output": output_path,
+            "processing_time_seconds": round(elapsed, 2),
+            "cloud_output": result,
+        }
 
 
 # =============================================================================


### PR DESCRIPTION
Follow-up to #72, found while checking whether `sadtalker` had the same leak. It doesn't — it has a different one, and so do the other three tools that supposedly clean up.

## Problem

All four tools collect keys in `r2_keys_to_cleanup` and drain them with a loop at the **end of the happy path**. Every `return {"error": ...}` in between skips cleanup entirely, and with no `try/finally`, so does any exception.

| Tool | Error returns before the drain | Drain at |
|------|-------------------------------|----------|
| `sadtalker.py` | 203, 210, 251, 284 | 287 |
| `upscale.py` | 73, 110, 133 | 136 |
| `dewatermark.py` | 1153, 1162, 1203, 1209, 1241 | 1267 |
| `qwen3_tts.py` | drained at one error path, not the rest | 382 |

Those error paths are exactly the runs most likely to bail out, and each stranded whatever it had already uploaded. Measured on the live bucket: **`sadtalker/input` held 42 objects / 63MB** — image+audio pairs from ~21 runs that errored after upload.

### Second, distinct leak

The output key was registered for cleanup only on the `download_from_r2` branch (`sadtalker.py:265`). When that failed and the presigned-URL fallback at line 271 succeeded, the object was downloaded but never registered — so it stayed forever. That accounts for **`sadtalker/results` at 9 objects / 122MB**. `qwen3_tts.py` had the same asymmetry at 319/326.

## Why #72 didn't cover this

Different bug class. #72 fixed four tools that **never** cleaned up. These four **do** clean up — correctly — but only when nothing goes wrong. Adding a delete call after a successful download, which is what #72 did, wouldn't have caught either leak here.

## Fix

An `r2_cleanup()` context manager in `file_transfer.py` that drains in `finally`, so success, early return and exception all clean up identically:

```python
with r2_cleanup() as r2_keys_to_cleanup:
    ...
    r2_keys_to_cleanup.append(key)
```

Plus registering the output key on both download branches. Deletion stays best-effort — `delete_from_r2` swallows its own errors, so a key that can't be removed never masks the result of the block.

**Most of this diff is re-indentation** from wrapping the function bodies. `git diff -w` shows the actual logic change is a few lines per tool.

## Verification

With the endpoint stubbed to fail *after* upload — the path that leaked:

```
pre-fix   upscale/input  before=0  after=1  -> LEAKED
post-fix  upscale/input  before=0  after=0  -> CLEANED UP
```

The context manager itself is unit-checked on both the success and exception paths. Happy path re-verified end-to-end against Modal (1920x1080 → 3840x2160, `upscale/input` back to 0, results didn't grow), and all four CLIs still load.

## Not included

The 772MB of existing orphans already in the bucket — this only stops new ones. Purging the backlog is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
