### PR TITLE
FIX: pin diffusers to a commit in modal-flux2 for reproducible builds

### DIFF
--- a/docker/modal-flux2/app.py
+++ b/docker/modal-flux2/app.py
@@ -49,8 +49,16 @@ image = (
         "fastapi[standard]",
         "huggingface_hub>=0.25.0",
     )
-    # Flux2KleinPipeline requires diffusers from git (not PyPI release)
-    .run_commands("pip install --no-cache-dir git+https://github.com/huggingface/diffusers")
+    # Flux2KleinPipeline is not in any tagged diffusers release yet, so this has
+    # to come from git. Pin the commit: an unpinned ref silently re-resolves on
+    # every rebuild, and when the new main needs a dependency the cached layer
+    # below it does not satisfy, the container dies in @modal.enter() -- which
+    # reads as a slow cold start rather than an error (#71, #74).
+    # Bump deliberately, and smoke-test the endpoint after.
+    .run_commands(
+        "pip install --no-cache-dir "
+        "git+https://github.com/huggingface/diffusers@119c339551f68ea523b9f204120b929e56342421"
+    )
     # Bake model weights into the image
     .run_commands(
         'python -c "'


### PR DESCRIPTION
Closes #74. Follow-up to #71, which fixed the symptom; this removes the cause.

## Problem

`Flux2KleinPipeline` isn't in any tagged diffusers release, so the image has to install from git — but the ref was unpinned:

```python
.run_commands("pip install --no-cache-dir git+https://github.com/huggingface/diffusers")
```

That silently re-resolves on every rebuild. When the new main needs something the cached layer beneath it doesn't satisfy, the container dies in `@modal.enter()`, and the failure never reaches the client: the tool polls indefinitely while the app reports `tasks=0`, reading as a slow cold start rather than an error. #71 raised the transformers floor to fix one instance of that; the unpinned ref means it can recur with a different dependency.

## Fix

Pin to `119c339`, with a comment explaining why the ref is a commit rather than a tag, so bumping becomes a deliberate act with a smoke test attached.

## Verification

Deployed and generated: **1024x1024 in 28.8s total, 5.0s inference.**

Worth noting this was the **first full rebuild of flux2 since 2026-03-24** — so it also confirms the March-era pins still resolve to a working set, carrying #71's `transformers>=4.51` floor. That was the open question about #71: its fix was latent until a redeploy, and this is that redeploy.

R2 cleanup re-checked on the same run — `flux2/results` held at 145, confirming #72 behaves on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
