### PR TITLE
refactor: extract shared migration module (#58)

### DIFF
--- a/docs/kiro.md
+++ b/docs/kiro.md
@@ -26,7 +26,7 @@ Prefer a repo-local install anyway? Use `--workspace-skills` — just remember i
 kiro-cli chat   # from anywhere
 ```
 
-Then `/video`, `/setup`, `/brand`, etc. are available as slash commands (tab completion works: `/vid<Tab>`). When running from the toolkit root, Kiro also auto-loads the generated steering and `AGENTS.md` for full always-on context.
+Then `/video`, `/setup`, `/brand`, etc. are available as slash commands (tab completion works: `/vid<Tab>`). When running from the toolkit root, Kiro also auto-loads the generated steering for full always-on context.
 
 ## Keeping it fresh
 

--- a/scripts/_migrate_common.py
+++ b/scripts/_migrate_common.py
@@ -1,0 +1,132 @@
+﻿import json
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class CommandSpec:
+    name: str
+    path: Path
+    description: str
+
+
+@dataclass
+class SkillSpec:
+    name: str
+    path: Path
+    description: str
+
+
+def find_repo_root(explicit: Path | None) -> Path:
+    if explicit:
+        return explicit.resolve(strict=True)
+    current = Path.cwd()
+    while current != current.parent:
+        if (current / "CLAUDE.md").exists():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find repository root (no CLAUDE.md found).")
+
+
+
+
+def parse_skill_frontmatter(skill_md: Path) -> tuple[str, str]:
+    content = skill_md.read_text(encoding="utf-8")
+    lines = content.splitlines()
+    if not lines or lines[0] != "---":
+        return skill_md.parent.name, ""
+
+    name = skill_md.parent.name
+    description = ""
+    for line in lines[1:]:
+        if line == "---":
+            break
+        if line.startswith("name:"):
+            name = line[5:].strip().strip("\"'")
+        elif line.startswith("description:"):
+            description = line[12:].strip().strip("\"'")
+    return name, description
+
+
+def ensure_clean_dir(path: Path, force: bool, dry_run: bool) -> None:
+    if path.exists():
+        if not force:
+            raise SystemExit(f"{path} already exists. Use --force to overwrite.")
+        if not dry_run:
+            shutil.rmtree(path)
+    if not dry_run:
+        path.mkdir(parents=True, exist_ok=True)
+
+
+def copy_tree(src: Path, dest: Path, force: bool, dry_run: bool) -> None:
+    ensure_clean_dir(dest, force=force, dry_run=dry_run)
+    if not dry_run:
+        shutil.copytree(src, dest, dirs_exist_ok=True)
+
+
+def remove_dir(path: Path, dry_run: bool) -> bool:
+    if path.exists() and path.is_dir():
+        if not dry_run:
+            shutil.rmtree(path)
+        return True
+    return False
+
+
+def yaml_quote(value: str) -> str:
+    if not value:
+        return '""'
+    escaped = value.replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def contains_generated_block(text: str, begin_marker: str, end_marker: str) -> bool:
+    return begin_marker in text and end_marker in text
+
+
+def replace_generated_block(text: str, new_block: str, begin_marker: str, end_marker: str) -> str:
+    start = text.index(begin_marker)
+    end = text.index(end_marker) + len(end_marker)
+    before = text[:start].rstrip()
+    after = text[end:].lstrip()
+
+    parts: list[str] = []
+    if before:
+        parts.append(before)
+    parts.append(new_block)
+    if after:
+        parts.append(after)
+    return "\n\n".join(parts) + "\n"
+
+
+def remove_generated_block(text: str, begin_marker: str, end_marker: str) -> str:
+    start = text.index(begin_marker)
+    end = text.index(end_marker) + len(end_marker)
+    before = text[:start].rstrip()
+    after = text[end:].lstrip()
+    if before and after:
+        return f"{before}\n\n{after}\n"
+    if before:
+        return f"{before}\n"
+    if after:
+        return f"{after}\n"
+    return ""
+
+def find_repo_root(explicit: Path | None) -> Path:
+    if explicit is not None:
+        return explicit.resolve()
+
+    current = Path(__file__).resolve().parent
+    for candidate in [current, *current.parents]:
+        if (candidate / "_internal" / "toolkit-registry.json").exists() and (
+            candidate / ".claude"
+        ).exists():
+            return candidate
+
+    raise SystemExit("Error: Could not find toolkit root (must contain .claude/ and _internal/toolkit-registry.json)")
+
+def load_mapping(path: Path | None) -> dict[str, Any]:
+    if path is None or not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))

--- a/scripts/migrate_to_codex.py
+++ b/scripts/migrate_to_codex.py
@@ -3,28 +3,27 @@ from __future__ import annotations
 
 import argparse
 import json
-import shutil
 import sys
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from _migrate_common import (
+    CommandSpec,
+    SkillSpec,
+    find_repo_root,
+    load_mapping,
+    parse_skill_frontmatter,
+    ensure_clean_dir,
+    copy_tree,
+    remove_dir,
+    yaml_quote,
+    contains_generated_block,
+    replace_generated_block,
+    remove_generated_block,
+)
+
 GENERATED_AGENTS_BEGIN = "<!-- BEGIN GENERATED: claude-to-codex -->"
 GENERATED_AGENTS_END = "<!-- END GENERATED: claude-to-codex -->"
-
-
-@dataclass(frozen=True)
-class CommandSpec:
-    name: str
-    description: str
-    path: Path
-
-
-@dataclass(frozen=True)
-class SkillSpec:
-    name: str
-    description: str
-    path: Path
 
 
 def parse_args() -> argparse.Namespace:
@@ -122,28 +121,6 @@ def load_command_specs(
     return commands
 
 
-def parse_skill_frontmatter(skill_md: Path) -> tuple[str, str]:
-    text = skill_md.read_text(encoding="utf-8")
-    lines = text.splitlines()
-    if len(lines) < 3 or lines[0].strip() != "---":
-        raise SystemExit(f"Skill frontmatter missing in {skill_md}")
-
-    name = ""
-    description = ""
-    for line in lines[1:]:
-        stripped = line.strip()
-        if stripped == "---":
-            break
-        if stripped.startswith("name:"):
-            name = stripped.split(":", 1)[1].strip()
-        if stripped.startswith("description:"):
-            description = stripped.split(":", 1)[1].strip()
-
-    if not name or not description:
-        raise SystemExit(f"Skill name/description missing in {skill_md}")
-    return name, description
-
-
 def load_skill_specs(
     repo_root: Path, mapping: dict[str, Any]
 ) -> list[SkillSpec]:
@@ -166,41 +143,11 @@ def load_skill_specs(
     return results
 
 
-def ensure_clean_dir(path: Path, force: bool, dry_run: bool) -> None:
-    if path.exists():
-        if not force:
-            raise SystemExit(
-                f"Destination already exists: {path}. Re-run with --force to overwrite."
-            )
-        if dry_run:
-            return
-        if path.is_dir():
-            shutil.rmtree(path)
-        else:
-            path.unlink()
-
-
-def write_text(path: Path, content: str, dry_run: bool) -> None:
-    if dry_run:
-        return
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(content, encoding="utf-8")
-
-
-def copy_tree(src: Path, dest: Path, force: bool, dry_run: bool) -> None:
-    ensure_clean_dir(dest, force=force, dry_run=dry_run)
     if dry_run:
         return
     shutil.copytree(src, dest)
 
 
-def yaml_quote(value: str) -> str:
-    return json.dumps(value, ensure_ascii=False)
-
-
-def remove_dir(path: Path, dry_run: bool) -> bool:
-    if not path.exists():
-        return False
     if dry_run:
         return True
     if path.is_dir():
@@ -222,46 +169,13 @@ def build_agents_block(repo_root: Path) -> str:
     )
 
 
-def contains_generated_agents_block(text: str) -> bool:
-    return GENERATED_AGENTS_BEGIN in text and GENERATED_AGENTS_END in text
-
-
-def replace_generated_agents_block(text: str, new_block: str) -> str:
-    start = text.index(GENERATED_AGENTS_BEGIN)
-    end = text.index(GENERATED_AGENTS_END) + len(GENERATED_AGENTS_END)
-    before = text[:start].rstrip()
-    after = text[end:].lstrip()
-
-    parts: list[str] = []
-    if before:
-        parts.append(before)
-    parts.append(new_block)
-    if after:
-        parts.append(after)
-    return "\n\n".join(parts).rstrip() + "\n"
-
-
-def remove_generated_agents_block(text: str) -> str:
-    start = text.index(GENERATED_AGENTS_BEGIN)
-    end = text.index(GENERATED_AGENTS_END) + len(GENERATED_AGENTS_END)
-    before = text[:start].rstrip()
-    after = text[end:].lstrip()
-    if before and after:
-        return f"{before}\n\n{after}\n"
-    if before:
-        return f"{before}\n"
-    if after:
-        return f"{after}\n"
-    return ""
-
-
 def sync_agents_file(repo_root: Path, force: bool, dry_run: bool) -> None:
     agents_path = repo_root / "AGENTS.md"
     new_block = build_agents_block(repo_root)
     existing = agents_path.read_text(encoding="utf-8") if agents_path.exists() else ""
 
-    if agents_path.exists() and contains_generated_agents_block(existing):
-        new_content = replace_generated_agents_block(existing, new_block)
+    if agents_path.exists() and contains_generated_block(existing, GENERATED_AGENTS_BEGIN, GENERATED_AGENTS_END):
+        new_content = replace_generated_block(existing, new_block, GENERATED_AGENTS_BEGIN, GENERATED_AGENTS_END)
         if existing == new_content:
             print("agents_status=up_to_date")
             return
@@ -471,8 +385,8 @@ def reset_installed_skills(
     agents_path = repo_root / "AGENTS.md"
     if agents_path.exists():
         existing = agents_path.read_text(encoding="utf-8")
-        if contains_generated_agents_block(existing):
-            new_content = remove_generated_agents_block(existing)
+        if contains_generated_block(existing, GENERATED_AGENTS_BEGIN, GENERATED_AGENTS_END):
+            new_content = remove_generated_block(existing, GENERATED_AGENTS_BEGIN, GENERATED_AGENTS_END)
             print(f"agents_reset={agents_path}")
             if not dry_run:
                 agents_path.write_text(new_content, encoding="utf-8")

--- a/scripts/migrate_to_kiro.py
+++ b/scripts/migrate_to_kiro.py
@@ -27,29 +27,28 @@ from __future__ import annotations
 
 import argparse
 import json
-import shutil
 import sys
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+from _migrate_common import (
+    CommandSpec,
+    SkillSpec,
+    find_repo_root,
+    load_mapping,
+    parse_skill_frontmatter,
+    ensure_clean_dir,
+    copy_tree,
+    remove_dir,
+    yaml_quote,
+    contains_generated_block,
+    replace_generated_block,
+    remove_generated_block,
+)
 
 GENERATED_STEERING_BEGIN = "<!-- BEGIN GENERATED: claude-to-kiro -->"
 GENERATED_STEERING_END = "<!-- END GENERATED: claude-to-kiro -->"
 STEERING_FILE_NAME = "video-toolkit.md"
-
-
-@dataclass(frozen=True)
-class CommandSpec:
-    name: str
-    description: str
-    path: Path
-
-
-@dataclass(frozen=True)
-class SkillSpec:
-    name: str
-    description: str
-    path: Path
 
 
 def parse_args() -> argparse.Namespace:
@@ -149,26 +148,6 @@ def load_command_specs(
     return commands
 
 
-def parse_skill_frontmatter(skill_md: Path) -> tuple[str, str]:
-    text = skill_md.read_text(encoding="utf-8")
-    lines = text.splitlines()
-    if len(lines) < 3 or lines[0].strip() != "---":
-        raise SystemExit(f"Skill frontmatter missing in {skill_md}")
-    name = ""
-    description = ""
-    for line in lines[1:]:
-        stripped = line.strip()
-        if stripped == "---":
-            break
-        if stripped.startswith("name:"):
-            name = stripped.split(":", 1)[1].strip()
-        if stripped.startswith("description:"):
-            description = stripped.split(":", 1)[1].strip()
-    if not name or not description:
-        raise SystemExit(f"Skill name/description missing in {skill_md}")
-    return name, description
-
-
 def load_skill_specs(repo_root: Path, mapping: dict[str, Any]) -> list[SkillSpec]:
     # Only `.claude/skills/` is scanned. Platform-specific skills under top-level
     # `skills/` (e.g. OpenClaw) are intentionally not migrated to Kiro.
@@ -188,38 +167,12 @@ def load_skill_specs(repo_root: Path, mapping: dict[str, Any]) -> list[SkillSpec
     return results
 
 
-def ensure_clean_dir(path: Path, force: bool, dry_run: bool) -> None:
-    if path.exists():
-        if not force:
-            raise SystemExit(
-                f"Destination already exists: {path}. Re-run with --force to overwrite."
-            )
-        if dry_run:
-            return
-        if path.is_dir():
-            shutil.rmtree(path)
-        else:
-            path.unlink()
-
-
-def write_text(path: Path, content: str, dry_run: bool) -> None:
-    if dry_run:
-        return
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(content, encoding="utf-8")
-
-
-def copy_tree(src: Path, dest: Path, force: bool, dry_run: bool) -> None:
-    ensure_clean_dir(dest, force=force, dry_run=dry_run)
     if dry_run:
         return
     dest.parent.mkdir(parents=True, exist_ok=True)
     shutil.copytree(src, dest)
 
 
-def remove_dir(path: Path, dry_run: bool) -> bool:
-    if not path.exists():
-        return False
     if dry_run:
         return True
     if path.is_dir():
@@ -241,46 +194,13 @@ def build_steering_block(repo_root: Path) -> str:
     )
 
 
-def contains_generated_block(text: str) -> bool:
-    return GENERATED_STEERING_BEGIN in text and GENERATED_STEERING_END in text
-
-
-def replace_generated_block(text: str, new_block: str) -> str:
-    start = text.index(GENERATED_STEERING_BEGIN)
-    end = text.index(GENERATED_STEERING_END) + len(GENERATED_STEERING_END)
-    before = text[:start].rstrip()
-    after = text[end:].lstrip()
-
-    parts: list[str] = []
-    if before:
-        parts.append(before)
-    parts.append(new_block)
-    if after:
-        parts.append(after)
-    return "\n\n".join(parts).rstrip() + "\n"
-
-
-def remove_generated_block(text: str) -> str:
-    start = text.index(GENERATED_STEERING_BEGIN)
-    end = text.index(GENERATED_STEERING_END) + len(GENERATED_STEERING_END)
-    before = text[:start].rstrip()
-    after = text[end:].lstrip()
-    if before and after:
-        return f"{before}\n\n{after}\n"
-    if before:
-        return f"{before}\n"
-    if after:
-        return f"{after}\n"
-    return ""
-
-
 def sync_steering_file(repo_root: Path, force: bool, dry_run: bool) -> None:
     steering_path = repo_root / ".kiro" / "steering" / STEERING_FILE_NAME
     new_block = build_steering_block(repo_root)
     existing = steering_path.read_text(encoding="utf-8") if steering_path.exists() else ""
 
-    if steering_path.exists() and contains_generated_block(existing):
-        new_content = replace_generated_block(existing, new_block)
+    if steering_path.exists() and contains_generated_block(existing, GENERATED_STEERING_BEGIN, GENERATED_STEERING_END):
+        new_content = replace_generated_block(existing, new_block, GENERATED_STEERING_BEGIN, GENERATED_STEERING_END)
         if existing == new_content:
             print("steering_status=up_to_date")
             return
@@ -441,8 +361,8 @@ def reset_installed(
     steering_path = repo_root / ".kiro" / "steering" / STEERING_FILE_NAME
     if steering_path.exists():
         existing = steering_path.read_text(encoding="utf-8")
-        if contains_generated_block(existing):
-            new_content = remove_generated_block(existing)
+        if contains_generated_block(existing, GENERATED_STEERING_BEGIN, GENERATED_STEERING_END):
+            new_content = remove_generated_block(existing, GENERATED_STEERING_BEGIN, GENERATED_STEERING_END)
             print(f"steering_reset={steering_path}")
             if not dry_run:
                 if new_content:


### PR DESCRIPTION
Resolves #58. Extracted shared logic from \scripts/migrate_to_codex.py\ and \scripts/migrate_to_kiro.py\ into \scripts/_migrate_common.py\. Also updated \docs/kiro.md\ to soften the claim about \AGENTS.md\ auto-loading.