### PR TITLE
fix(scripts): restore write_text helper dropped by the _migrate_common refactor

### DIFF
--- a/scripts/_migrate_common.py
+++ b/scripts/_migrate_common.py
@@ -39,6 +39,13 @@ def parse_skill_frontmatter(skill_md: Path) -> tuple[str, str]:
     return name, description
 
 
+def write_text(path: Path, content: str, dry_run: bool) -> None:
+    if dry_run:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
 def ensure_clean_dir(path: Path, force: bool, dry_run: bool) -> None:
     if path.exists():
         if not force:

--- a/scripts/migrate_to_codex.py
+++ b/scripts/migrate_to_codex.py
@@ -13,6 +13,7 @@ from _migrate_common import (
     find_repo_root,
     load_mapping,
     parse_skill_frontmatter,
+    write_text,
     ensure_clean_dir,
     copy_tree,
     remove_dir,
@@ -141,20 +142,6 @@ def load_skill_specs(
             )
         )
     return results
-
-
-    if dry_run:
-        return
-    shutil.copytree(src, dest)
-
-
-    if dry_run:
-        return True
-    if path.is_dir():
-        shutil.rmtree(path)
-    else:
-        path.unlink()
-    return True
 
 
 def build_agents_block(repo_root: Path) -> str:

--- a/scripts/migrate_to_kiro.py
+++ b/scripts/migrate_to_kiro.py
@@ -37,6 +37,7 @@ from _migrate_common import (
     find_repo_root,
     load_mapping,
     parse_skill_frontmatter,
+    write_text,
     ensure_clean_dir,
     copy_tree,
     remove_dir,
@@ -165,21 +166,6 @@ def load_skill_specs(repo_root: Path, mapping: dict[str, Any]) -> list[SkillSpec
             )
         )
     return results
-
-
-    if dry_run:
-        return
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(src, dest)
-
-
-    if dry_run:
-        return True
-    if path.is_dir():
-        shutil.rmtree(path)
-    else:
-        path.unlink()
-    return True
 
 
 def build_steering_block(repo_root: Path) -> str:


### PR DESCRIPTION
## Problem

`scripts/migrate_to_codex.py` and `scripts/migrate_to_kiro.py` both abort with a `NameError` the moment they do any real work. `--dry-run` still passes, because `main()` returns right after `print_plan(...)`, which is probably why this went unnoticed — but an actual migration never installs a single skill:

```console
$ python scripts/migrate_to_codex.py --force
...
agents_sync=/…/AGENTS.md
Traceback (most recent call last):
  File "scripts/migrate_to_codex.py", line 459, in <module>
    sys.exit(main())
  File "scripts/migrate_to_codex.py", line 436, in main
    install_command_wrappers(
  File "scripts/migrate_to_codex.py", line 332, in install_command_wrappers
    write_text(
NameError: name 'write_text' is not defined
```

```console
$ python scripts/migrate_to_kiro.py --force
...
  File "scripts/migrate_to_kiro.py", line 307, in install_command_wrappers
    write_text(
NameError: name 'write_text' is not defined
```

## Cause

The `_migrate_common` extraction in 18de2b8 moved `ensure_clean_dir` / `copy_tree` / `remove_dir` into `scripts/_migrate_common.py`, but `write_text` was deleted from both scripts **without** being moved there and **without** being added to either import list. It is still called in two places per script — `install_overview_skill()` and `install_command_wrappers()` — and both sit on the main (non-dry-run) install path.

The same commit also stripped the `def copy_tree(...)` / `def remove_dir(...)` headers while leaving their bodies in place, so eleven statements referencing undefined names (`shutil`, `src`, `dest`, `path`, `dry_run`) are stranded after `return results` at the end of `load_skill_specs()` in each script.

`pyflakes scripts/` on `main`:

```
scripts/migrate_to_codex.py:148:5: undefined name 'shutil'
scripts/migrate_to_codex.py:154:9: undefined name 'shutil'
scripts/migrate_to_codex.py:296:5: undefined name 'write_text'
scripts/migrate_to_codex.py:332:9: undefined name 'write_text'
scripts/migrate_to_kiro.py:173:5: undefined name 'shutil'
scripts/migrate_to_kiro.py:179:9: undefined name 'shutil'
scripts/migrate_to_kiro.py:307:9: undefined name 'write_text'
…
```

## Fix

- Restore `write_text()` in `scripts/_migrate_common.py`, byte-identical to the pre-refactor implementation (`18de2b8^:scripts/migrate_to_codex.py:183`), and add it to the `_migrate_common` import list in both scripts.
- Delete the two orphaned function bodies.

28 lines net, no behaviour change beyond making the scripts run.

## Verification

On a clean checkout of `main`, with `HOME` pointed at a scratch directory:

| | before | after |
|---|---|---|
| `migrate_to_codex.py --force` | `NameError: name 'write_text' is not defined` | `done` — 27 skills under `~/.codex/skills` |
| `migrate_to_kiro.py --force` | `NameError: name 'write_text' is not defined` | `done` — 27 skills under `~/.kiro/skills` |
| `pyflakes scripts/` | 7 undefined names | 0 undefined names |

The generated `~/.codex/skills/video-toolkit/SKILL.md` frontmatter and the per-command wrappers look correct.

Out of scope, but noticed while reading: the same refactor left `find_repo_root` / `load_mapping` defined **and** imported in both scripts (`pyflakes` reports `redefinition of unused …`), and `yaml_quote` is imported but unused in `migrate_to_kiro.py`. Happy to fold that cleanup in if you'd like, but I kept this PR to just the crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
