### PR TITLE
Fix dewatermark --setup crash, dedup migrate scripts, gate undefined names in CI

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -1,0 +1,58 @@
+name: Lint Python
+
+# Catches the crash class of Python bug — a name that is called but never
+# defined — before it reaches a release. This exists because v0.20.0 shipped
+# `scripts/migrate_to_{codex,kiro}.py` with an undefined `write_text`, which
+# made both migrations abort with a NameError on the first real write (#85).
+# `--dry-run` returned before touching that path, so nothing caught it.
+#
+# Deliberately narrow: only rules where a hit is a genuine defect, never a
+# style opinion. The repo has ~800 unused-import / unused-local warnings that
+# are not worth gating on, so they stay out. Add a code here only if a hit
+# means the code is actually broken.
+#
+#   F821  undefined name              -> NameError at runtime
+#   F811  redefinition of unused name -> a later def silently shadows an import
+#   F822  undefined name in __all__
+#   F823  local variable referenced before assignment
+#   E999  syntax error
+#
+# Verified against the tagged v0.20.0 tree: this gate reports 26 errors there,
+# including both `write_text` call sites and the F811 shadowing.
+#
+# Known limit: ruff resolves names per-file, not across modules. If a name is
+# still imported but has been deleted from the module it is imported from, the
+# import counts as a definition and this gate stays green. It catches the
+# v0.20.0 bug because that refactor dropped the import too.
+#
+# Run the same check locally with:
+#   uvx ruff check --select F821,F811,F822,F823 scripts/ tools/
+
+on:
+  pull_request:
+    paths:
+      - '**.py'
+      - '.github/workflows/lint-python.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - '**.py'
+      - '.github/workflows/lint-python.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: undefined names
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Check for undefined names
+        run: uvx ruff check --select F821,F811,F822,F823 --output-format github scripts/ tools/

--- a/scripts/_migrate_common.py
+++ b/scripts/_migrate_common.py
@@ -123,6 +123,14 @@ def find_repo_root(explicit: Path | None) -> Path:
     raise SystemExit("Error: Could not find toolkit root (must contain .claude/ and _internal/toolkit-registry.json)")
 
 def load_mapping(path: Path | None) -> dict[str, Any]:
-    if path is None or not path.exists():
-        return {}
-    return json.loads(path.read_text(encoding="utf-8"))
+    data: dict[str, Any] = {}
+    if path is not None:
+        if not path.exists():
+            raise SystemExit(f"Mapping file not found: {path}")
+        data = json.loads(path.read_text(encoding="utf-8"))
+    return {
+        "skip_commands": set(data.get("skip_commands", [])),
+        "skip_skills": set(data.get("skip_skills", [])),
+        "command_name_overrides": data.get("command_name_overrides", {}),
+        "skill_name_overrides": data.get("skill_name_overrides", {}),
+    }

--- a/scripts/migrate_to_codex.py
+++ b/scripts/migrate_to_codex.py
@@ -61,34 +61,8 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def find_repo_root(explicit: Path | None) -> Path:
-    if explicit is not None:
-        return explicit.resolve()
-
-    current = Path(__file__).resolve().parent
-    for candidate in [current, *current.parents]:
-        if (candidate / "_internal" / "toolkit-registry.json").exists() and (
-            candidate / ".claude"
-        ).exists():
-            return candidate
-
-    raise SystemExit("Could not auto-detect repository root.")
-
-
 def load_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
-
-
-def load_mapping(path: Path) -> dict[str, Any]:
-    if not path.exists():
-        raise SystemExit(f"Mapping file not found: {path}")
-    data = load_json(path)
-    return {
-        "skip_commands": set(data.get("skip_commands", [])),
-        "skip_skills": set(data.get("skip_skills", [])),
-        "command_name_overrides": data.get("command_name_overrides", {}),
-        "skill_name_overrides": data.get("skill_name_overrides", {}),
-    }
 
 
 def load_registry(repo_root: Path) -> dict[str, Any]:

--- a/scripts/migrate_to_kiro.py
+++ b/scripts/migrate_to_kiro.py
@@ -41,7 +41,6 @@ from _migrate_common import (
     ensure_clean_dir,
     copy_tree,
     remove_dir,
-    yaml_quote,
     contains_generated_block,
     replace_generated_block,
     remove_generated_block,
@@ -92,34 +91,8 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def find_repo_root(explicit: Path | None) -> Path:
-    if explicit is not None:
-        return explicit.resolve()
-    current = Path(__file__).resolve().parent
-    for candidate in [current, *current.parents]:
-        if (candidate / "_internal" / "toolkit-registry.json").exists() and (
-            candidate / ".claude"
-        ).exists():
-            return candidate
-    raise SystemExit("Could not auto-detect repository root.")
-
-
 def load_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
-
-
-def load_mapping(path: Path | None) -> dict[str, Any]:
-    data: dict[str, Any] = {}
-    if path is not None:
-        if not path.exists():
-            raise SystemExit(f"Mapping file not found: {path}")
-        data = load_json(path)
-    return {
-        "skip_commands": set(data.get("skip_commands", [])),
-        "skip_skills": set(data.get("skip_skills", [])),
-        "command_name_overrides": data.get("command_name_overrides", {}),
-        "skill_name_overrides": data.get("skill_name_overrides", {}),
-    }
 
 
 def load_registry(repo_root: Path) -> dict[str, Any]:

--- a/tools/dewatermark.py
+++ b/tools/dewatermark.py
@@ -1529,8 +1529,9 @@ def setup_runpod(gpu_id: str = "AMPERE_24", verbose: bool = True) -> dict:
     }
 
     # Get API key
-    config = get_runpod_config()
-    api_key = config.get("api_key")
+    from dotenv import load_dotenv
+    load_dotenv()
+    api_key = os.getenv("RUNPOD_API_KEY")
 
     if not api_key:
         result["error"] = "RUNPOD_API_KEY not set. Add to .env file first."


### PR DESCRIPTION
Follow-up to #85. That PR fixed the `write_text` crash; this one fixes the rest of the same refactor's fallout, plus a second instance of the same bug class found elsewhere, and adds the CI gate that would have caught all of it.

## `tools/dewatermark.py --setup` was also crashing

`setup_runpod()` calls `get_runpod_config()`, which is defined nowhere in the repo — so the documented `uv run tools/dewatermark.py --setup` aborted with a `NameError` before doing any work, exactly like #85.

`tools/upscale.py` has the same function with the correct three lines, so this adopts that pattern:

```python
from dotenv import load_dotenv
load_dotenv()
api_key = os.getenv("RUNPOD_API_KEY")
```

Verified: `--setup` now completes and finds the existing propainter template/endpoint (created nothing, no cost).

## The migrate cleanup #85 flagged as out of scope

Not a straight "delete the duplicates" — one of them was load-bearing:

- **`_migrate_common.load_mapping` is a broken stub.** It returns raw JSON, so any caller would `KeyError` on `mapping["skip_commands"]`. Nothing hit it only because *both* scripts shadowed it with a local, correct copy. Promoted the real normalizing version (handles `None`, coerces skip lists to sets) into `_migrate_common` and dropped both locals. Deleting the locals without this would have broken both migrations.
- **`find_repo_root`** — local copies are equivalent to the shared one, dropped both. The shared version's error message is more useful.
- **`yaml_quote`** — unused import in `migrate_to_kiro.py`, dropped.

**Behaviour-neutral, and checked rather than assumed:** `migrate_to_codex.py --force` and `migrate_to_kiro.py --force` produce **byte-identical output trees** before and after (`diff -r` over `~/.codex/skills` and `~/.kiro/skills`).

## CI gate

New `Lint Python` workflow runs `ruff check --select F821,F811,F822,F823` over `scripts/` and `tools/`.

Scoped deliberately narrow — only rules where a hit is a genuine defect. The repo has ~800 unused-import / unused-local / f-string warnings; gating on those would mean a mass cleanup and constant noise, so they stay out.

**Verified it actually works:** run against the tagged `v0.20.0` tree it reports **26 errors**, including both `write_text` sites and the `find_repo_root`/`load_mapping` shadowing.

One honest limitation, documented in the workflow: ruff resolves names per-file, so if a name is still imported but deleted from its source module, the import counts as a definition and the gate stays green. It catches the v0.20.0 bug because that refactor dropped the import too.

## Why this slipped through

`--dry-run` returns right after `print_plan()` and writes nothing, so it never exercises the `write_text` path — and there was no Python lint in CI at all.

Suggest a **v0.20.1** patch after this lands: v0.20.0 ships with the Codex and Kiro migrations and `dewatermark --setup` all broken.