### PR TITLE
concept-explainer-short: let voice.brand drive the narrator

### DIFF
--- a/templates/concept-explainer-short/README.md
+++ b/templates/concept-explainer-short/README.md
@@ -92,7 +92,8 @@ Alternate cards and motion so the viewer gets a pattern interrupt every
   "provider": "qwen3", "cloud": "modal", "maxWpm": 165,
   "refAudio": "ref/my-voice.m4a",
   "refText": "Exact transcript of the reference recording.",
-  "speaker": "Ryan", "tone": ""
+  "speaker": "Ryan", "tone": "",
+  "brand": ""
 }
 ```
 
@@ -103,6 +104,10 @@ Alternate cards and motion so the viewer gets a pattern interrupt every
 - `maxWpm` is the pacing safety net: rushed takes are slowed in place with
   pitch-preserving atempo. gen_vo.py prints per-scene wpm either way.
 - `provider: "elevenlabs"` also works (uses your configured voice).
+- **Brand voice**: set `"brand": "my-brand"` to take the voice from
+  `brands/my-brand/voice.json` (voiceId and settings) instead of the ambient
+  config. Works with any provider, and pairs with a brand's palette so one
+  brand drives both look and narrator.
 
 ## Captions
 

--- a/templates/concept-explainer-short/config.json
+++ b/templates/concept-explainer-short/config.json
@@ -30,7 +30,8 @@
     "refAudio": "",
     "refText": "",
     "speaker": "Ryan",
-    "tone": ""
+    "tone": "",
+    "brand": ""
   },
   "music": {
     "file": "audio/music.mp3",

--- a/templates/concept-explainer-short/gen_vo.py
+++ b/templates/concept-explainer-short/gen_vo.py
@@ -70,6 +70,8 @@ def main() -> None:
     ]
     if voice.get("maxWpm"):
         cmd += ["--max-wpm", str(voice["maxWpm"])]
+    if voice.get("brand"):
+        cmd += ["--brand", voice["brand"]]
     if voice.get("provider", "qwen3") == "qwen3":
         cmd += ["--cloud", voice.get("cloud", "modal")]
         ref_audio = voice.get("refAudio", "")


### PR DESCRIPTION
`templates/concept-explainer-short/gen_vo.py` assembles its `voiceover.py` call from `config.json → voice`, but never passed `--brand`. So a brand profile could drive the template's palette while the narrator came from ambient config — brand voices were unreachable from this template.

Two lines:

```python
if voice.get("brand"):
    cmd += ["--brand", voice["brand"]]
```

Plus the key in `config.json` and a README note, so it is discoverable rather than folklore.

**Backwards compatible** — empty or absent `brand` adds no flag, so existing configs build the identical command.

**Verified, not assumed:**
- `--provider elevenlabs --brand digital-samba` resolves `brands/digital-samba/voice.json`
- `--brand no-such-brand` is rejected with `Brand 'no-such-brand' not found or has no voice.json`, which confirms resolution actually runs rather than the flag being silently ignored

### Credit

These two lines come from #84, which introduced them inside a full fork of this template. The fork copies `build.py` (262 lines) and `gen_captions.py` (116 lines) byte-identically, so the duplication would drift on the first fix to either — but this part of it is a real gap in the base template and is worth having on its own. Thanks @adriancuevas92-ops.