### PR TITLE
Stop /contribute steering brand-shaped changes into template forks

### DIFF
--- a/.claude/commands/contribute.md
+++ b/.claude/commands/contribute.md
@@ -176,6 +176,34 @@ Same as Option 2, but focused on `.claude/skills/{name}/`
 
 ## Option 4: Share a Template
 
+### Step 0: Is it actually a template? (ask this first)
+
+Most "new template" ideas are really a **brand profile**. Ask before anything
+else, and take the answer seriously — this is the single most common wrong turn
+in this command:
+
+```
+What makes your video different from the closest existing template?
+
+  a. Colors, fonts, logo, narrator voice
+  b. Scene pacing / timing values
+  c. Different scenes, different structure, different composition code
+
+If (a) or (b) only -> you want a BRAND PROFILE, not a template.
+```
+
+**If (a) or (b):** stop here and run `/brand` instead. Templates read their
+palette, fonts and voice from a brand (`voice.brand` in `config.json` points at
+`brands/<name>/voice.json`), and timing values like `lead`/`tail`/`xfade` live
+in your project's own `config.json`. Copying a template to change those produces
+a near-identical fork that stops inheriting fixes to the original — worse for
+you than for the toolkit.
+
+A brand profile does not need to be committed to this repo to work. Keep it
+local unless it is genuinely useful to other people.
+
+**Only continue below if (c)** — the composition code itself differs.
+
 ### Step 1: Identify Template
 
 ```
@@ -203,6 +231,17 @@ To turn a project into a shareable template:
    cd templates/my-template
    npm install
    npm run studio
+
+4. Check it is not a near-duplicate — diff every file against the
+   template you started from:
+
+   for f in <new-template>/*; do
+     diff -q "<base-template>/$(basename "$f")" "$f" 2>/dev/null
+   done
+
+   Identical composition code (build.py, gen_captions.py, src/) means this
+   should be a brand profile plus project config, not a template. Go back
+   to Step 0.
 
 Ready to proceed?
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,18 @@ If your integration only works against one paid API or a piece of software we ca
 it in your own repo and open an issue to be listed under **Community add-ons** in the README.
 In-tree integrations need at least one open or self-hostable path.
 
+### Brand profiles and new templates
+
+If your video differs from an existing template only in colors, fonts, logo, narrator voice, or
+timing values, you want a **brand profile**, not a new template. Templates take their palette and
+voice from a brand (`voice.brand` in `config.json` resolves `brands/<name>/voice.json`), and
+timings like `lead`/`tail`/`xfade` belong in your own project's `config.json`. Copying a template
+to change those leaves you with a fork that no longer inherits fixes to the original.
+
+Brand profiles work fine without being committed here, so keep yours local unless other people
+would genuinely use it. A new template in-tree needs to differ in its composition code — new
+scenes, structure, or rendering — not just its look.
+
 ### Automated and AI-generated PRs
 
 Automated or AI-generated PRs are welcome only when a human author responds to review and the


### PR DESCRIPTION
## The problem

`/contribute` Option 4 ("Share a Template") opened with:

```
1. Copy to templates/:
   cp -r projects/my-video templates/my-template
2. Remove project-specific content:
   - Reset config to example values
```

Copy a template, tweak the config, open a PR. Nothing in the command asks whether a template is the right vehicle at all — so a video that differs only in palette, voice or pacing becomes a near-identical fork of an existing template.

That fork then stops inheriting fixes to the original, which is a worse deal for the contributor than for us.

**This has now happened twice** — #43 and #84. In #84 the forked template was byte-identical to its base in `build.py` (262 lines), `gen_captions.py` (116 lines) and `scenes.json`; the entire real difference was a palette and three timing values, both of which the base template already reads from config.

Two contributors making the same mistake is a signal about the command, not about them.

## The fix

A **Step 0** that runs before anything is copied:

> What makes your video different from the closest existing template?
> a. Colors, fonts, logo, narrator voice
> b. Scene pacing / timing values
> c. Different scenes, structure, or composition code
>
> If (a) or (b) only → you want a BRAND PROFILE, not a template.

...routing (a)/(b) to `/brand`, and stating plainly that a brand profile works without being committed to this repo.

Also:
- a duplicate check in the generalize step — diff the new template against its base, and if the composition code is identical, go back to Step 0
- the same guidance in `CONTRIBUTING.md`, for contributors who read that rather than running the command

Both paths are real: `voice.brand` resolves `brands/<name>/voice.json` (#88), and `lead`/`tail`/`xfade` live in the project's own `config.json`.