### PR TITLE
fix(windows): UTF-8 output so cloud GPU setup doesn't die on cp1252

### DIFF
--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -83,6 +83,37 @@ Check and report. Don't install anything automatically — just tell the user wh
 - **Python deps**: `uv run python -c "import dotenv; import requests"`. If missing: run `uv sync` from the toolkit root (uv installs a compatible Python automatically if needed)
 - **FFmpeg**: `ffmpeg -version`. If missing: "Install with `brew install ffmpeg` (macOS) or see https://ffmpeg.org/ — needed for media conversion"
 
+### Windows only
+
+**Export `PYTHONIOENCODING=utf-8` before running any deploy command in this wizard.** On
+Windows, a piped/captured stdout defaults to the `cp1252` codec. Modal's deploy progress
+output contains box-drawing characters it cannot encode, so `modal deploy` aborts partway
+through the image build with:
+
+```
+'charmap' codec can't encode characters in position 3-42: character maps to <undefined>
+```
+
+The build itself is fine — only the *printing* fails, which makes this look like a broken
+deploy or a network problem rather than an encoding one. Every deploy in Phase 4 fails
+identically without it.
+
+Set it for the shell you run the deploys in:
+
+```bash
+export PYTHONIOENCODING=utf-8   # Git Bash
+$env:PYTHONIOENCODING = 'utf-8' # PowerShell
+```
+
+Offer to make it permanent so the user does not hit this again outside this wizard:
+
+```powershell
+[Environment]::SetEnvironmentVariable('PYTHONIOENCODING','utf-8','User')
+```
+
+See `docs/modal-setup.md` for the rest of the Windows prerequisites (notably the
+Microsoft Store `python3` stub).
+
 ### Output
 
 ```
@@ -277,6 +308,10 @@ Recommend "all" — with Modal's free tier, there's no cost to having them deplo
 For each selected tool, run `uv run modal deploy` and capture the endpoint URL:
 
 ```bash
+# Windows: required, or every deploy below dies with a 'charmap' codec error
+# mid-build. Harmless everywhere else.
+export PYTHONIOENCODING=utf-8
+
 # Deploy each app and capture the URL from output
 uv run modal deploy docker/modal-qwen3-tts/app.py
 uv run modal deploy docker/modal-flux2/app.py

--- a/tools/align_captions.py
+++ b/tools/align_captions.py
@@ -34,6 +34,7 @@ import os
 import re
 import sys
 from pathlib import Path
+from win_encoding import ensure_utf8_output
 
 
 # ─── Caption parsing ────────────────────────────────────────
@@ -265,6 +266,7 @@ def apply_patches(config_text: str, scenes_aligned):
 # ─── Main ───────────────────────────────────────────────────
 
 def main():
+    ensure_utf8_output()  # Windows: piped stdout defaults to cp1252
     ap = argparse.ArgumentParser(
         description="Align caption timestamps to TTS audio via ElevenLabs Scribe.",
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/tools/dewatermark.py
+++ b/tools/dewatermark.py
@@ -58,6 +58,7 @@ from file_transfer import (
     upload_to_storage, download_from_r2, r2_cleanup,
     download_from_url, get_r2_payload_config,
 )
+from win_encoding import ensure_utf8_output
 
 # Default installation path
 PROPAINTER_HOME = Path.home() / ".video-toolkit" / "propainter"
@@ -1608,6 +1609,7 @@ def setup_runpod(gpu_id: str = "AMPERE_24", verbose: bool = True) -> dict:
 
 
 def main():
+    ensure_utf8_output()  # Windows: piped stdout defaults to cp1252
     args = parse_args()
     propainter_path = get_propainter_path(args.propainter_path)
     verbose = not args.json

--- a/tools/qwen3_tts.py
+++ b/tools/qwen3_tts.py
@@ -50,6 +50,7 @@ import argparse
 import base64
 import json
 import os
+import re
 import sys
 import time
 from pathlib import Path
@@ -57,6 +58,23 @@ from pathlib import Path
 import requests
 
 sys.path.insert(0, str(Path(__file__).parent))
+
+from win_encoding import utf8_env
+
+_MODAL_URL_RE = re.compile(r"https://[A-Za-z0-9._-]+\.modal\.run")
+
+
+def _find_modal_url(text: str) -> str | None:
+    """First Modal endpoint URL in `text`, tolerating terminal line-wrapping.
+
+    Modal hard-wraps long URLs to the terminal width, so a URL can arrive split
+    across lines. Collapsing whitespace first is what makes the match reliable;
+    a per-line search silently finds nothing on a wrapped URL.
+    """
+    if not text:
+        return None
+    m = _MODAL_URL_RE.search(re.sub(r"\s+", "", text))
+    return m.group(0) if m else None
 
 # Docker image for RunPod endpoint
 QWEN3_TTS_DOCKER_IMAGE = "ghcr.io/conalmullan/video-toolkit-qwen3-tts:latest"
@@ -756,6 +774,12 @@ def setup_modal(verbose: bool = True) -> dict:
             ["modal", "deploy", str(app_file)],
             capture_output=True,
             text=True,
+            # Modal's progress output is full of box-drawing characters. Without an
+            # explicit codec, Windows decodes the child with cp1252 and the deploy
+            # dies with "'charmap' codec can't encode characters" mid-build.
+            encoding="utf-8",
+            errors="replace",
+            env=utf8_env(),
             timeout=900,  # 15 min for first deploy with model download
         )
 
@@ -768,27 +792,15 @@ def setup_modal(verbose: bool = True) -> dict:
         if verbose:
             print(deploy_result.stdout)
 
-        # Parse endpoint URL from deploy output
-        # Modal prints lines like: Created web endpoint ... => https://workspace--app-name-fn.modal.run
-        endpoint_url = None
-        for line in deploy_result.stdout.splitlines():
-            if "modal.run" in line:
-                # Extract URL from the line
-                import re
-                urls = re.findall(r'https://[^\s"\']+modal\.run[^\s"\']*', line)
-                if urls:
-                    endpoint_url = urls[0]
-                    break
-
-        if not endpoint_url:
-            # Try stderr too (some modal versions output there)
-            for line in deploy_result.stderr.splitlines():
-                if "modal.run" in line:
-                    import re
-                    urls = re.findall(r'https://[^\s"\']+modal\.run[^\s"\']*', line)
-                    if urls:
-                        endpoint_url = urls[0]
-                        break
+        # Parse endpoint URL from deploy output.
+        # Modal prints: Created web endpoint ... => https://workspace--app-name-fn.modal.run
+        # but hard-wraps long URLs to the terminal width, so the URL arrives split
+        # across lines ("...qwen3tts-genera" / "te.modal.run"). Matching per line
+        # therefore finds nothing and the deploy looks like it failed when it did not.
+        # Collapse all whitespace first, then match.
+        endpoint_url = _find_modal_url(deploy_result.stdout) or _find_modal_url(
+            deploy_result.stderr
+        )
 
         if not endpoint_url:
             result["error"] = (

--- a/tools/sync_timing.py
+++ b/tools/sync_timing.py
@@ -40,6 +40,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+from win_encoding import ensure_utf8_output
 
 
 # ─── Audio Duration ──────────────────────────────────────────
@@ -822,6 +823,7 @@ def build_json_output(
 # ─── Main ────────────────────────────────────────────────────
 
 def main():
+    ensure_utf8_output()  # Windows: piped stdout defaults to cp1252
     parser = argparse.ArgumentParser(
         description="Sync scene timing with actual audio durations",
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/tools/voiceover.py
+++ b/tools/voiceover.py
@@ -46,6 +46,7 @@ from config import (
     get_voice_id,
     load_brand_voice_config,
 )
+from win_encoding import ensure_utf8_output
 
 
 def _get_elevenlabs_imports():
@@ -735,6 +736,7 @@ def concat_audio_files(mp3_files: list[Path], output_path: Path) -> dict:
 
 
 def main():
+    ensure_utf8_output()  # Windows: piped stdout defaults to cp1252
     load_dotenv()
     args = parse_args()
 

--- a/tools/win_encoding.py
+++ b/tools/win_encoding.py
@@ -1,0 +1,66 @@
+"""UTF-8 console output on Windows.
+
+Python on Windows picks the *locale* codec (usually cp1252) for `stdout`/`stderr`
+whenever output is redirected rather than attached to a terminal — which is what
+happens whenever a tool is piped, captured by a harness like Claude Code, or read
+with `subprocess.run(..., capture_output=True)`. Printing any character outside
+cp1252 then raises:
+
+    UnicodeEncodeError: 'charmap' codec can't encode character '\\u2713' ...
+
+The traceback points at the `print()`, not at the encoding, so it reads like a bug
+in whatever tool happened to emit an arrow or a check mark.
+
+Two helpers:
+
+* `ensure_utf8_output()` — call once at the top of a tool's `main()`. Re-opens
+  `stdout`/`stderr` as UTF-8. No-op when they are already UTF-8 (macOS, Linux,
+  Windows with `PYTHONUTF8=1`), so it is safe to call unconditionally.
+* `utf8_env()` — environment for `subprocess`, so a *child* process (notably the
+  `modal` CLI, whose progress output is full of box-drawing characters) writes
+  UTF-8 too. Pair it with `encoding="utf-8"` on the `subprocess` call itself.
+
+Python 3.15 makes UTF-8 mode the default (PEP 686), at which point both become
+no-ops rather than wrong.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Mapping
+
+
+def _is_utf8(stream) -> bool:
+    enc = (getattr(stream, "encoding", None) or "").lower().replace("-", "").replace("_", "")
+    return enc in ("utf8", "utf8mb4")
+
+
+def ensure_utf8_output() -> None:
+    """Force `stdout`/`stderr` to UTF-8. Idempotent and never raises."""
+    for name in ("stdout", "stderr"):
+        stream = getattr(sys, name, None)
+        if stream is None or _is_utf8(stream):
+            continue
+        try:
+            # Python 3.7+. errors="replace" keeps a stray glyph from killing a
+            # long-running render that is otherwise fine.
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, OSError, ValueError):
+            # Detached, already-wrapped, or non-reconfigurable stream. Printing
+            # ASCII still works, so degrade quietly rather than break the tool.
+            pass
+
+
+def utf8_env(base: Mapping[str, str] | None = None) -> dict[str, str]:
+    """Environment dict that makes a child process emit UTF-8.
+
+    Pass to `subprocess.run(..., env=utf8_env(), encoding="utf-8")`.
+    """
+    env = dict(os.environ if base is None else base)
+    env["PYTHONIOENCODING"] = "utf-8"
+    env["PYTHONUTF8"] = "1"
+    return env
+
+
+__all__ = ["ensure_utf8_output", "utf8_env"]


### PR DESCRIPTION
## The problem

On Windows, Python picks the **locale codec (cp1252)** for `stdout`/`stderr` whenever output is redirected rather than attached to a terminal. That is the normal case here: under Claude Code, under `subprocess.run(..., capture_output=True)`, and under any pipe. Printing a character outside cp1252 then raises:

```
UnicodeEncodeError: 'charmap' codec can't encode character '✓' ...
```

The traceback points at the `print()`, not at the encoding, so it reads like a bug in whichever tool happened to emit an arrow or a check mark.

This was found by running `/setup` on Windows 11. **All seven `modal deploy` commands failed in a row**, each partway through its image build:

```
'charmap' codec can't encode characters in position 3-42: character maps to <undefined>
```

The builds themselves were fine — only the *printing* failed. But nothing in the error says so, so it presents as a network fault, a Modal outage, or an account problem. The apps had in fact deployed server-side; re-running then produced "subdomain already taken" conflicts, which sent the debugging further off course.

It is not limited to `modal deploy`. Four tools print non-ASCII on their own runtime paths, and two of them are **steps 6 and 7 of the documented workflow**:

| Tool | Character | Where |
|---|---|---|
| `voiceover.py` | `→` | per-scene generation summary |
| `sync_timing.py` | `—` | header and "no updates needed" |
| `dewatermark.py` | `⚠` | Apple Silicon warnings |
| `align_captions.py` | `—` | dry-run notice |

`--help` output is pure ASCII, so the tools look fine until they do real work.

## The fix

**`tools/win_encoding.py`** (new, 66 lines)
- `ensure_utf8_output()` — reconfigures `stdout`/`stderr` to UTF-8 with `errors="replace"`. Idempotent, and swallows the exceptions a detached or already-wrapped stream can raise, so it degrades quietly instead of becoming a new failure mode.
- `utf8_env()` — environment for `subprocess`, so a *child* emits UTF-8 too.

Both are no-ops where UTF-8 already applies (macOS, Linux, `PYTHONUTF8=1`), so they stay correct rather than merely harmless once PEP 686 makes UTF-8 mode the default in 3.15.

**Four tools** call `ensure_utf8_output()` as the first statement in `main()`.

**`tools/qwen3_tts.py --setup`** shells out to `modal deploy`; that child is now decoded as UTF-8 and given `utf8_env()`.

**`.claude/commands/setup.md`** documents the prerequisite. The deploys in Phase 4 run as bash, so no Python-side fix can reach them. `docs/modal-setup.md` already covered this — the setup command did not, which is precisely why the wizard walked into it.

## Second bug, same function

While fixing the subprocess call I hit a related failure in `setup_modal()`. The endpoint-URL parser searched **line by line**:

```python
for line in deploy_result.stdout.splitlines():
    if "modal.run" in line:
        urls = re.findall(r'https://[^\s"\']+modal\.run[^\s"\']*', line)
```

Modal hard-wraps long URLs to the terminal width, so a real deploy emits:

```
└── 🔨 Created Web Function URL for Qwen3TTS.generate =>
    https://user--video-toolkit-qwen3-tts-qwen3tts-genera
    te.modal.run
```

Neither line matches — the first has no `modal.run`, the second has no `https://`. A **successful** deploy therefore reports `could not parse endpoint URL from output`. `_find_modal_url()` collapses whitespace before matching, which handles both wrapped and unwrapped output.

## Verification

Windows 11, Python 3.12.14, piped stdout:

- `sys.stdout.encoding` reports `cp1252`, confirming the trigger
- the unguarded print raises `UnicodeEncodeError`
- the same print succeeds after `ensure_utf8_output()`
- all five patched tools run clean piped with **no** environment override
- `_find_modal_url()` recovers the wrapped URL above; the old line-based parser returns nothing

No behaviour change on macOS or Linux: `ensure_utf8_output()` returns immediately when the stream is already UTF-8.

## Notes for reviewers

- `errors="replace"` is deliberate. A stray glyph should not kill a long render that is otherwise fine.
- The import in `qwen3_tts.py` sits below its existing `sys.path.insert(...)` bootstrap, matching how `file_transfer` is imported in that file.
- Only the four tools that actually emit non-ASCII were touched. A blanket change across all 28 would be larger and mostly inert — happy to widen it if you would rather have the guard everywhere for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
